### PR TITLE
Set target library versions for Wizard embeds

### DIFF
--- a/content/contracts-cairo/wizard.mdx
+++ b/content/contracts-cairo/wizard.mdx
@@ -9,4 +9,4 @@ contract and learn about the components offered in OpenZeppelin Contracts for Ca
 We strongly recommend checking the [Components](components) section to understand how to extend from our library.
 </Callout>
 
-<OZWizard lang="cairo" />
+<OZWizard lang="cairo" version="3.0.0-alpha.2" />

--- a/content/contracts/5.x/accounts.mdx
+++ b/content/contracts/5.x/accounts.mdx
@@ -10,7 +10,7 @@ User operations are validated using an [`AbstractSigner`](/contracts/5.x/api/uti
 
 To setup an account, you can either start configuring it using our Wizard and selecting a predefined validation scheme, or bring your own logic and start by inheriting [`Account`](/contracts/5.x/api/account#Account) from scratch.
 
-<OZWizard tab="Account" />
+<OZWizard tab="Account" version="5.4.0" />
 
 <Callout>
 Accounts don’t support [ERC-721](erc721) and [ERC-1155](erc1155) tokens natively since these require the receiving address to implement an acceptance check. It is recommended to inherit [ERC721Holder](/contracts/5.x/api/token/ERC721#ERC721Holder), [ERC1155Holder](/contracts/5.x/api/token/ERC1155#ERC1155Holder) to include these checks in your account.

--- a/content/contracts/5.x/wizard.mdx
+++ b/content/contracts/5.x/wizard.mdx
@@ -9,4 +9,4 @@ contract and learn about the components offered in OpenZeppelin Contracts.
 Place the resulting contract in your `contracts` or `src` directory in order to compile it with a tool like Hardhat or Foundry. Consider reading our guide on [Developing Smart Contracts](learn::developing-smart-contracts) for more guidance!
 </Callout>
 
-<OZWizard />
+<OZWizard version="5.4.0" />

--- a/content/stellar-contracts/0.2.0/get-started.mdx
+++ b/content/stellar-contracts/0.2.0/get-started.mdx
@@ -4,4 +4,4 @@ title: Get Started
 
 Not sure where to start? Use the interactive generator below to bootstrap your contract and find about the components offered in OpenZeppelin Smart Contracts Suite for Stellar. You can also access the code generator from [here](https://wizard.openzeppelin.com/stellar).
 
-<OZWizard lang="stellar"/>
+<OZWizard lang="stellar" version="0.2.0"/>

--- a/content/stellar-contracts/0.3.0/get-started.mdx
+++ b/content/stellar-contracts/0.3.0/get-started.mdx
@@ -4,4 +4,4 @@ title: Get Started
 
 Not sure where to start? Use the interactive generator below to bootstrap your contract and find about the components offered in OpenZeppelin Smart Contracts Suite for Stellar. You can also access the code generator from [here](https://wizard.openzeppelin.com/stellar).
 
-<OZWizard lang="stellar"/>
+<OZWizard lang="stellar" version="0.3.0"/>

--- a/content/stellar-contracts/get-started.mdx
+++ b/content/stellar-contracts/get-started.mdx
@@ -4,4 +4,4 @@ title: Get Started
 
 Not sure where to start? Use the interactive generator below to bootstrap your contract and find about the components offered in OpenZeppelin Smart Contracts Suite for Stellar. You can also access the code generator from [here](https://wizard.openzeppelin.com/stellar).
 
-<OZWizard lang="stellar"/>
+<OZWizard lang="stellar" version="0.4.1"/>

--- a/src/components/oz-wizard.tsx
+++ b/src/components/oz-wizard.tsx
@@ -14,6 +14,7 @@ declare global {
 				style?: React.CSSProperties;
 				"data-tab"?: string;
 				"data-lang"?: string;
+				"version"?: string;
 			};
 		}
 	}
@@ -22,12 +23,13 @@ declare global {
 interface OZWizardProps {
 	tab?: string;
 	lang?: string;
+	version?: string;
 }
 
 // Global flag to prevent multiple script loads
 let wizardScriptLoaded = false;
 
-function OZWizardComponent({ tab, lang }: OZWizardProps) {
+function OZWizardComponent({ tab, lang, version }: OZWizardProps) {
 	const wizardRef = useRef<HTMLElement>(null);
 
 	useEffect(() => {
@@ -57,6 +59,7 @@ function OZWizardComponent({ tab, lang }: OZWizardProps) {
 			ref={wizardRef}
 			data-tab={tab}
 			data-lang={lang}
+			version={version}
 			style={{
 				display: "block",
 				minHeight: "40rem",


### PR DESCRIPTION
Wizard supports a `version` parameter for doc site embeddings to specify the target version of the Contracts library that the docs are referring to.  This version gets compared to the semantic versions supported by Wizard for the requested language, allowing Wizard to display a specific version (if supported) or to show an error that the version is out of range.

For example, if the user is viewing stellar 0.3.0 docs but Wizard supports only ^0.4.1, it will show an error:
```
Version 0.3.0 is not supported by the Wizard.
Select a version that is compatible with the version range: ^0.4.1.
```

This PR adds the `version` parameter for all embeddings, except for the main Wizard doc page.