### PR TITLE
Fix links in Contracts and Community Contracts

### DIFF
--- a/content/community-contracts/account-modules.mdx
+++ b/content/community-contracts/account-modules.mdx
@@ -10,7 +10,7 @@ ERC-7579 defines a standardized interface for modular smart accounts. This stand
 
 ### Accounts
 
-OpenZeppelin offers an implementation of an [`AccountERC7579`](/community-contracts/api/account#AccountERC7579) contract that allows installing modules compliant with this standard. There’s also an [`AccountERC7579Hooked`](/community-contracts/api/account#AccountERC7579Hooked) variant that supports installation of hooks. Like [most accounts](accounts#handling_initialization), an instance should define an initializer function where the first module that controls the account will be set:
+OpenZeppelin offers an implementation of an [`AccountERC7579`](/community-contracts/api/account#AccountERC7579) contract that allows installing modules compliant with this standard. There’s also an [`AccountERC7579Hooked`](/community-contracts/api/account#AccountERC7579Hooked) variant that supports installation of hooks. Like [most accounts](/contracts/5.x/accounts#handling-initialization), an instance should define an initializer function where the first module that controls the account will be set:
 
 <include cwd lang='solidity'>./examples/account/MyAccountERC7579.sol</include>
 
@@ -97,7 +97,7 @@ Social recovery is not a single solution but a design space with multiple config
 * Cancellation windows
 * Confirmation requirements
 
-To support _different guardian types_, we can leverage ERC-7913 as discussed in the [multisig](multisig#beyond_standard_signature_verification) section. For ERC-7579 modules, this is implemented through the [`ERC7579Multisig`](/community-contracts/api/account#ERC7579Multisig) validator.
+To support _different guardian types_, we can leverage ERC-7913 as discussed in the [multisig](/contracts/5.x/multisig#beyond-standard-signature-verification) section. For ERC-7579 modules, this is implemented through the [`ERC7579Multisig`](/community-contracts/api/account#ERC7579Multisig) validator.
 
 Combined with an [`ERC7579Executor`](/community-contracts/api/account#ERC7579Executor), it provides a basic foundation that can be extended with more sophisticated features:
 

--- a/content/community-contracts/crosschain.mdx
+++ b/content/community-contracts/crosschain.mdx
@@ -162,4 +162,4 @@ function receiveMessage(
 
 ```
 
-The bridge is designed to be configurable. As an `Ownable` contract, it allows the owner to manage the list of trusted gateways and adjust the confirmation threshold. The `_gateways` list and threshold are initially set during contract deployment using the [`+_addGateway+`](/community-contracts/api/crosschain#ERC7786OpenBridge-_addGateway-address-) and [`+_setThreshold+`](/community-contracts/api/crosschain#ERC7786OpenBridge-_setThreshold-uint8-) functions. The owner can update these settings as needed to adapt to changing requirements or add new gateways.
+The bridge is designed to be configurable. As an `Ownable` contract, it allows the owner to manage the list of trusted gateways and adjust the confirmation threshold. The `_gateways` list and threshold are initially set during contract deployment using the [`_addGateway`](/community-contracts/api/crosschain#ERC7786OpenBridge-_addGateway-address-) and [`_setThreshold`](/community-contracts/api/crosschain#ERC7786OpenBridge-_setThreshold-uint8-) functions. The owner can update these settings as needed to adapt to changing requirements or add new gateways.

--- a/content/community-contracts/paymasters.mdx
+++ b/content/community-contracts/paymasters.mdx
@@ -19,7 +19,7 @@ Learn more about [signers](/contracts/5.x/accounts#selecting-a-signer) to explor
 <include cwd lang='solidity'>./examples/account/paymaster/PaymasterECDSASigner.sol</include>
 
 <Callout>
-Use [`ERC4337Utils`](https://docs.openzeppelin.com/contracts/5.x/api/account#ERC4337Utils) to facilitate the access to paymaster-related fields of the userOp (e.g. `paymasterData`, `paymasterVerificationGasLimit`)
+Use [`ERC4337Utils`](/contracts/5.x/api/account#ERC4337Utils) to facilitate the access to paymaster-related fields of the userOp (e.g. `paymasterData`, `paymasterVerificationGasLimit`)
 </Callout>
 
 To implement signature-based sponsorship, you’ll first need to deploy the paymaster contract. This contract will hold the ETH used to pay for user operations and verify signatures from your authorized signer. After deployment, you must fund the paymaster with ETH to cover gas costs for the operations it will sponsor:
@@ -214,7 +214,7 @@ The price of the ERC-20 must be scaled by [`_tokenPriceDenominator`](/community-
 Here’s how an implementation of `_fetchOracleDetails` would look like using this approach:
 
 <Callout>
-Use [`ERC4337Utils.combineValidationData`](https://docs.openzeppelin.com/contracts/5.x/api/account#ERC4337Utils-combineValidationData-uint256-uint256-) to merge two `validationData` values.
+Use [`ERC4337Utils.combineValidationData`](/contracts/5.x/api/account#ERC4337Utils-combineValidationData-uint256-uint256-) to merge two `validationData` values.
 </Callout>
 
 ```solidity

--- a/content/community-contracts/paymasters.mdx
+++ b/content/community-contracts/paymasters.mdx
@@ -13,7 +13,7 @@ To enable sponsorship, users sign their user operations including a special fiel
 The [`PaymasterSigner`](/community-contracts/api/account#PaymasterSigner) implements signature-based sponsorship via authorization signatures, allowing designated paymaster signers to authorize and sponsor specific user operations without requiring users to hold native ETH.
 
 <Callout>
-Learn more about [signers](accounts#selecting_a_signer) to explore different approaches to user operation sponsorship via signatures.
+Learn more about [signers](/contracts/5.x/accounts#selecting-a-signer) to explore different approaches to user operation sponsorship via signatures.
 </Callout>
 
 <include cwd lang='solidity'>./examples/account/paymaster/PaymasterECDSASigner.sol</include>

--- a/content/community-contracts/utilities.mdx
+++ b/content/community-contracts/utilities.mdx
@@ -10,9 +10,9 @@ Multiple libraries and general purpose utilities included in the community versi
 
 _For prior knowledge on how to validate signatures on-chain, check out the [OpenZeppelin Contracts documentation](https://docs.openzeppelin.com/contracts/5.x/utilities#checking_signatures_on_chain)_
 
-As opposed to validating plain-text messages, it is possible to let your users sign structured data (i.e. typed values) in a way that is still readable on their wallets. This is possible by implementing [`EIP712`](https://docs.openzeppelin.com/contracts/api/utils#EIP712), a standard way to encode structured data into a typed data hash.
+As opposed to validating plain-text messages, it is possible to let your users sign structured data (i.e. typed values) in a way that is still readable on their wallets. This is possible by implementing [`EIP712`](/contracts/5.x/api/utils/cryptography#EIP712), a standard way to encode structured data into a typed data hash.
 
-To start validating signed typed structures, just validate the [typed data hash](https://docs.openzeppelin.com/contracts/api/utils#EIP712-_hashTypedDataV4-bytes32-):
+To start validating signed typed structures, just validate the [typed data hash](/contracts/5.x/api/utils/cryptography#EIP712-_hashTypedDataV4-bytes32-):
 
 <include cwd lang='solidity'>./examples/utils/cryptography/MyContractDomain.sol</include>
 
@@ -27,7 +27,7 @@ Accounts (i.e. Smart Contract Wallets or Smart Accounts) are particularly likely
 
 On one hand, making sure that the Account signature is only valid for an specific smart contract (i.e. an application) is difficult since it requires to validate a signature whose domain is the application but also the Account itself. For these reason, the community developed [ERC-7739](https://eips.ethereum.org/EIPS/eip-7739); a defensive rehashing mechanism that binds a signature to a single domain using a nested EIP-712 approach (i.e. an EIP-712 typed structure wrapping another).
 
-In case your smart contract validates signatures, using [`ERC7739`](https://docs.openzeppelin.com/contracts/api/utils/cryptography#ERC7739) signer will implement the [`IERC1271`](https://docs.openzeppelin.com/contracts/api/interfaces#IERC1271) interface for validating smart contract signatures following the approach suggested by ERC-7739:
+In case your smart contract validates signatures, using [`ERC7739`](/contracts/5.x/api/utils/cryptography#ERC7739) signer will implement the [`IERC1271`](https://docs.openzeppelin.com/contracts/api/interfaces#IERC1271) interface for validating smart contract signatures following the approach suggested by ERC-7739:
 
 <include cwd lang='solidity'>./examples/utils/cryptography/ERC7739SignerECDSA.sol</include>
 

--- a/content/community-contracts/utilities.mdx
+++ b/content/community-contracts/utilities.mdx
@@ -8,7 +8,7 @@ Multiple libraries and general purpose utilities included in the community versi
 
 ### Validating Typed Data Signatures
 
-_For prior knowledge on how to validate signatures on-chain, check out the [OpenZeppelin Contracts documentation](https://docs.openzeppelin.com/contracts/5.x/utilities#checking_signatures_on_chain)_
+_For prior knowledge on how to validate signatures on-chain, check out the [OpenZeppelin Contracts documentation](/contracts/5.x/utilities#checking_signatures_on_chain)_
 
 As opposed to validating plain-text messages, it is possible to let your users sign structured data (i.e. typed values) in a way that is still readable on their wallets. This is possible by implementing [`EIP712`](/contracts/5.x/api/utils/cryptography#EIP712), a standard way to encode structured data into a typed data hash.
 
@@ -27,7 +27,7 @@ Accounts (i.e. Smart Contract Wallets or Smart Accounts) are particularly likely
 
 On one hand, making sure that the Account signature is only valid for an specific smart contract (i.e. an application) is difficult since it requires to validate a signature whose domain is the application but also the Account itself. For these reason, the community developed [ERC-7739](https://eips.ethereum.org/EIPS/eip-7739); a defensive rehashing mechanism that binds a signature to a single domain using a nested EIP-712 approach (i.e. an EIP-712 typed structure wrapping another).
 
-In case your smart contract validates signatures, using [`ERC7739`](/contracts/5.x/api/utils/cryptography#ERC7739) signer will implement the [`IERC1271`](https://docs.openzeppelin.com/contracts/api/interfaces#IERC1271) interface for validating smart contract signatures following the approach suggested by ERC-7739:
+In case your smart contract validates signatures, using [`ERC7739`](/contracts/5.x/api/utils/cryptography#ERC7739) signer will implement the [`IERC1271`](/contracts/5.x/api/interfaces#IERC1271) interface for validating smart contract signatures following the approach suggested by ERC-7739:
 
 <include cwd lang='solidity'>./examples/utils/cryptography/ERC7739SignerECDSA.sol</include>
 
@@ -50,7 +50,7 @@ function _verify(bytes memory signer, bytes32 hash, bytes memory signature) inte
 The verification process works as follows:
 
 * If `signer.length < 20`: verification fails
-* If `signer.length == 20`: verification is done using [SignatureChecker](https://docs.openzeppelin.com/contracts/5.x/api/utils#SignatureChecker)
+* If `signer.length == 20`: verification is done using [SignatureChecker](/contracts/5.x/api/utils#SignatureChecker)
 * Otherwise: verification is done using an ERC-7913 verifier.
 
 This allows for backward compatibility with EOAs and ERC-1271 contracts while supporting new types of keys.

--- a/content/contracts/3.x/upgradeable.mdx
+++ b/content/contracts/3.x/upgradeable.mdx
@@ -2,11 +2,11 @@
 title: Using with Upgrades
 ---
 
-If your contract is going to be deployed with upgradeability, such as using the [OpenZeppelin Upgrades Plugins](upgrades-plugins::index), you will need to use the Upgrade Safe variant of OpenZeppelin Contracts.
+If your contract is going to be deployed with upgradeability, such as using the [OpenZeppelin Upgrades Plugins](/upgrades-plugins), you will need to use the Upgrade Safe variant of OpenZeppelin Contracts.
 
 This variant is available as a separate package called `@openzeppelin/contracts-upgradeable`, which is hosted in the repository [OpenZeppelin/openzeppelin-contracts-upgradeable](https://github.com/OpenZeppelin/openzeppelin-contracts-upgradeable).
 
-It follows all of the rules for [Writing Upgradeable Contracts](upgrades-plugins::writing-upgradeable): constructors are replaced by initializer functions, state variables are initialized in initializer functions, and we additionally check for storage incompatibilities across minor versions.
+It follows all of the rules for [Writing Upgradeable Contracts](/upgrades-plugins/writing-upgradeable): constructors are replaced by initializer functions, state variables are initialized in initializer functions, and we additionally check for storage incompatibilities across minor versions.
 
 ## Overview
 
@@ -41,7 +41,7 @@ Constructors are replaced by internal initializer functions following the naming
 Use with multiple inheritance requires special attention. See the section below titled [Multiple Inheritance](#multiple-inheritance).
 </Callout>
 
-Once this contract is set up and compiled, you can deploy it using the [Upgrades Plugins](upgrades-plugins::index). The following snippet shows an example deployment script using Hardhat.
+Once this contract is set up and compiled, you can deploy it using the [Upgrades Plugins](/upgrades-plugins). The following snippet shows an example deployment script using Hardhat.
 
 ```js
 const  ethers, upgrades  = require("hardhat");
@@ -70,4 +70,4 @@ The function `__ContractName_init_unchained` found in every contract is the init
 
 You may notice that every contract includes a state variable named `__gap`. This is empty reserved space in storage that is put in place in Upgrade Safe contracts. It allows us to freely add new state variables in the future without compromising the storage compatibility with existing deployments.
 
-It isn’t safe to simply add a state variable because it "shifts down" all of the state variables below in the inheritance chain. This makes the storage layouts incompatible, as explained in [Writing Upgradeable Contracts](upgrades-plugins::writing-upgradeable#modifying-your-contracts). The size of the `__gap` array is calculated so that the amount of storage used by a contract always adds up to the same number (in this case 50 storage slots).
+It isn’t safe to simply add a state variable because it "shifts down" all of the state variables below in the inheritance chain. This makes the storage layouts incompatible, as explained in [Writing Upgradeable Contracts](/upgrades-plugins/writing-upgradeable#modifying-your-contracts). The size of the `__gap` array is calculated so that the amount of storage used by a contract always adds up to the same number (in this case 50 storage slots).

--- a/content/contracts/4.x/upgradeable.mdx
+++ b/content/contracts/4.x/upgradeable.mdx
@@ -2,14 +2,14 @@
 title: Using with Upgrades
 ---
 
-If your contract is going to be deployed with upgradeability, such as using the [OpenZeppelin Upgrades Plugins](upgrades-plugins::index), you will need to use the Upgradeable variant of OpenZeppelin Contracts.
+If your contract is going to be deployed with upgradeability, such as using the [OpenZeppelin Upgrades Plugins](/upgrades-plugins), you will need to use the Upgradeable variant of OpenZeppelin Contracts.
 
 This variant is available as a separate package called `@openzeppelin/contracts-upgradeable`, which is hosted in the repository [OpenZeppelin/openzeppelin-contracts-upgradeable](https://github.com/OpenZeppelin/openzeppelin-contracts-upgradeable).
 
-It follows all of the rules for [Writing Upgradeable Contracts](upgrades-plugins::writing-upgradeable): constructors are replaced by initializer functions, state variables are initialized in initializer functions, and we additionally check for storage incompatibilities across minor versions.
+It follows all of the rules for [Writing Upgradeable Contracts](/upgrades-plugins/writing-upgradeable): constructors are replaced by initializer functions, state variables are initialized in initializer functions, and we additionally check for storage incompatibilities across minor versions.
 
 <Callout>
-OpenZeppelin provides a full suite of tools for deploying and securing upgradeable smart contracts. [Check out the full list of resources](openzeppelin::upgrades).
+OpenZeppelin provides a full suite of tools for deploying and securing upgradeable smart contracts. [Check out the full list of resources](/upgrades).
 </Callout>
 
 ## Overview
@@ -45,7 +45,7 @@ Constructors are replaced by internal initializer functions following the naming
 Use with multiple inheritance requires special attention. See the section below titled [Multiple Inheritance](#multiple-inheritance).
 </Callout>
 
-Once this contract is set up and compiled, you can deploy it using the [Upgrades Plugins](upgrades-plugins::index). The following snippet shows an example deployment script using Hardhat.
+Once this contract is set up and compiled, you can deploy it using the [Upgrades Plugins](/upgrades-plugins). The following snippet shows an example deployment script using Hardhat.
 
 ```js
 const  ethers, upgrades  = require("hardhat");
@@ -74,4 +74,4 @@ The function `__ContractName_init_unchained` found in every contract is the init
 
 You may notice that every contract includes a state variable named `__gap`. This is empty reserved space in storage that is put in place in Upgradeable contracts. It allows us to freely add new state variables in the future without compromising the storage compatibility with existing deployments.
 
-It isn’t safe to simply add a state variable because it "shifts down" all of the state variables below in the inheritance chain. This makes the storage layouts incompatible, as explained in [Writing Upgradeable Contracts](upgrades-plugins::writing-upgradeable#modifying-your-contracts). The size of the `__gap` array is calculated so that the amount of storage used by a contract always adds up to the same number (in this case 50 storage slots).
+It isn’t safe to simply add a state variable because it "shifts down" all of the state variables below in the inheritance chain. This makes the storage layouts incompatible, as explained in [Writing Upgradeable Contracts](/upgrades-plugins/writing-upgradeable#modifying-your-contracts). The size of the `__gap` array is calculated so that the amount of storage used by a contract always adds up to the same number (in this case 50 storage slots).

--- a/content/contracts/5.x/api/proxy.mdx
+++ b/content/contracts/5.x/api/proxy.mdx
@@ -3,7 +3,7 @@ title: "Proxy"
 description: "Smart contract proxy utilities and implementations"
 ---
 
-This is a low-level set of contracts implementing different proxy patterns with and without upgradeability. For an in-depth overview of this pattern check out the [Proxy Upgrade Pattern](upgrades-plugins::proxies.adoc) page.
+This is a low-level set of contracts implementing different proxy patterns with and without upgradeability. For an in-depth overview of this pattern check out the [Proxy Upgrade Pattern](https://docs.openzeppelin.com/upgrades-plugins/proxies) page.
 
 Most of the proxies below are built on an abstract base contract.
 
@@ -20,7 +20,7 @@ There are two alternative ways to add upgradeability to an ERC-1967 proxy. Their
 * [`UUPSUpgradeable`](#UUPSUpgradeable): An upgradeability mechanism to be included in the implementation contract.
 
 **🔥 CAUTION**\
-Using upgradeable proxies correctly and securely is a difficult task that requires deep knowledge of the proxy pattern, Solidity, and the EVM. Unless you want a lot of low level control, we recommend using the [OpenZeppelin Upgrades Plugins](upgrades-plugins::index.adoc) for Hardhat and Foundry.
+Using upgradeable proxies correctly and securely is a difficult task that requires deep knowledge of the proxy pattern, Solidity, and the EVM. Unless you want a lot of low level control, we recommend using the [OpenZeppelin Upgrades Plugins](https://docs.openzeppelin.com/upgrades-plugins) for Hardhat and Foundry.
 
 A different family of proxies are beacon proxies. This pattern, popularized by Dharma, allows multiple proxies to be upgraded to a different implementation in a single transaction.
 

--- a/content/contracts/5.x/api/proxy.mdx
+++ b/content/contracts/5.x/api/proxy.mdx
@@ -3,7 +3,7 @@ title: "Proxy"
 description: "Smart contract proxy utilities and implementations"
 ---
 
-This is a low-level set of contracts implementing different proxy patterns with and without upgradeability. For an in-depth overview of this pattern check out the [Proxy Upgrade Pattern](https://docs.openzeppelin.com/upgrades-plugins/proxies) page.
+This is a low-level set of contracts implementing different proxy patterns with and without upgradeability. For an in-depth overview of this pattern check out the [Proxy Upgrade Pattern](upgrades-plugins::proxies.adoc) page.
 
 Most of the proxies below are built on an abstract base contract.
 
@@ -20,7 +20,7 @@ There are two alternative ways to add upgradeability to an ERC-1967 proxy. Their
 * [`UUPSUpgradeable`](#UUPSUpgradeable): An upgradeability mechanism to be included in the implementation contract.
 
 **🔥 CAUTION**\
-Using upgradeable proxies correctly and securely is a difficult task that requires deep knowledge of the proxy pattern, Solidity, and the EVM. Unless you want a lot of low level control, we recommend using the [OpenZeppelin Upgrades Plugins](https://docs.openzeppelin.com/upgrades-plugins) for Hardhat and Foundry.
+Using upgradeable proxies correctly and securely is a difficult task that requires deep knowledge of the proxy pattern, Solidity, and the EVM. Unless you want a lot of low level control, we recommend using the [OpenZeppelin Upgrades Plugins](upgrades-plugins::index.adoc) for Hardhat and Foundry.
 
 A different family of proxies are beacon proxies. This pattern, popularized by Dharma, allows multiple proxies to be upgraded to a different implementation in a single transaction.
 

--- a/content/contracts/5.x/backwards-compatibility.mdx
+++ b/content/contracts/5.x/backwards-compatibility.mdx
@@ -44,7 +44,7 @@ An important aspect that major releases may break is "upgrade compatibility", in
 
 Minor and patch updates always preserve storage layout compatibility. This means that a live contract can be upgraded from one minor to another without corrupting the storage layout. In some cases it may be necessary to initialize new state variables when upgrading, although we expect this to be infrequent.
 
-We recommend using [OpenZeppelin Upgrades Plugins or CLI](upgrades-plugins::index) to ensure storage layout safety of upgrades.
+We recommend using [OpenZeppelin Upgrades Plugins or CLI](/upgrades-plugins) to ensure storage layout safety of upgrades.
 
 ## Solidity Version
 

--- a/content/contracts/5.x/index.mdx
+++ b/content/contracts/5.x/index.mdx
@@ -45,7 +45,7 @@ Once installed, you can use the contracts in the library by importing them:
 <include cwd lang='solidity'>./examples/MyNFT.sol</include>
 
 <Callout>
-If you’re new to smart contract development, head to [Developing Smart Contracts](learn::developing-smart-contracts) to learn about creating a new project and compiling your contracts.
+If you’re new to smart contract development, head to [Developing Smart Contracts](/contracts/5.x/learn/developing-smart-contracts) to learn about creating a new project and compiling your contracts.
 </Callout>
 
 To keep your system secure, you should ***always*** use the installed code as-is, and neither copy-paste it from online sources, nor modify it yourself. The library is designed so that only the contracts and functions you use are deployed, so you don’t need to worry about it needlessly increasing gas costs.
@@ -60,11 +60,11 @@ The [Security Center](https://contracts.openzeppelin.com/security) contains more
 
 The guides in the sidebar will teach about different concepts, and how to use the related contracts that OpenZeppelin Contracts provides:
 
-* [Access Control](access-control): decide who can perform each of the actions on your system.
-* [Tokens](tokens): create tradable assets or collectibles, like the well known [ERC20](erc20) and [ERC721](erc721) standards.
-* [Utilities](utilities): generic useful tools, including non-overflowing math, signature verification, and trustless paying systems.
+* [Access Control](/contracts/5.x/access-control): decide who can perform each of the actions on your system.
+* [Tokens](/contracts/5.x/tokens): create tradable assets or collectibles, like the well known [ERC20](/contracts/5.x/api/token/ERC20) and [ERC721](/contracts/5.x/api/token/ERC721) standards.
+* [Utilities](/contracts/5.x/utilities): generic useful tools, including non-overflowing math, signature verification, and trustless paying systems.
 
-The [full API](contracts/v5.x/api/token/ERC20) is also thoroughly documented, and serves as a great reference when developing your smart contract application. You can also ask for help or follow Contracts' development in the [community forum](https://forum.openzeppelin.com).
+The [full API](/contracts/5.x/api/token/ERC20) is also thoroughly documented, and serves as a great reference when developing your smart contract application. You can also ask for help or follow Contracts' development in the [community forum](https://forum.openzeppelin.com).
 
 The following articles provide great background reading, though please note, some of the referenced tools have changed as the tooling in the ecosystem continues to rapidly evolve.
 

--- a/content/contracts/5.x/learn/developing-smart-contracts.mdx
+++ b/content/contracts/5.x/learn/developing-smart-contracts.mdx
@@ -178,13 +178,13 @@ However, this is not the only way to split your code into modules. You can also 
 
 ## Using OpenZeppelin Contracts
 
-Reusable modules and libraries are the cornerstone of great software. [**OpenZeppelin Contracts**](contracts::index) contains lots of useful building blocks for smart contracts to build on. And you can rest easy when building on them: they’ve been the subject of multiple audits, with their security and correctness battle-tested.
+Reusable modules and libraries are the cornerstone of great software. [**OpenZeppelin Contracts**](/contracts) contains lots of useful building blocks for smart contracts to build on. And you can rest easy when building on them: they’ve been the subject of multiple audits, with their security and correctness battle-tested.
 
 ### About inheritance
 
 Many of the contracts in the library are not standalone, that is, you’re not expected to deploy them as-is. Instead, you will use them as a starting point to build your own contracts by adding features to them. Solidity provides _multiple inheritance_ as a mechanism to achieve this: take a look at the [Solidity documentation](https://solidity.readthedocs.io/en/latest/contracts.html#inheritance) for more details.
 
-For example, the [`Ownable`](contracts:api:access#Ownable) contract marks the deployer account as the contract’s owner, and provides a modifier called `onlyOwner`. When applied to a function, `onlyOwner` will cause all function calls that do not originate from the owner account to revert. Functions to [transfer](contracts:api:access#Ownable-transferOwnership-address-) and [renounce](contracts:api:access#Ownable-renounceOwnership--) ownership are also available.
+For example, the [`Ownable`](/contracts/5.x/api/access#Ownable) contract marks the deployer account as the contract’s owner, and provides a modifier called `onlyOwner`. When applied to a function, `onlyOwner` will cause all function calls that do not originate from the owner account to revert. Functions to [transfer](contracts:api:access#Ownable-transferOwnership-address-) and [renounce](contracts:api:access#Ownable-renounceOwnership--) ownership are also available.
 
 When used this way, inheritance becomes a powerful mechanism that allows for modularization, without forcing you to deploy and manage multiple contracts.
 
@@ -227,7 +227,7 @@ contract Box is Ownable
 }
 ```
 
-The [OpenZeppelin Contracts documentation](contracts::index) is a great place to learn about developing secure smart contract systems. It features both guides and a detailed API reference: see for example the [Access Control](contracts::access-control) guide to know more about the `Ownable` contract used in the code sample above.
+The [OpenZeppelin Contracts documentation](/contracts) is a great place to learn about developing secure smart contract systems. It features both guides and a detailed API reference: see for example the [Access Control](/contracts/5.x/access-control) guide to know more about the `Ownable` contract used in the code sample above.
 
 ## Next steps
 

--- a/content/contracts/5.x/learn/developing-smart-contracts.mdx
+++ b/content/contracts/5.x/learn/developing-smart-contracts.mdx
@@ -184,7 +184,7 @@ Reusable modules and libraries are the cornerstone of great software. [**OpenZep
 
 Many of the contracts in the library are not standalone, that is, you’re not expected to deploy them as-is. Instead, you will use them as a starting point to build your own contracts by adding features to them. Solidity provides _multiple inheritance_ as a mechanism to achieve this: take a look at the [Solidity documentation](https://solidity.readthedocs.io/en/latest/contracts.html#inheritance) for more details.
 
-For example, the [`Ownable`](/contracts/5.x/api/access#Ownable) contract marks the deployer account as the contract’s owner, and provides a modifier called `onlyOwner`. When applied to a function, `onlyOwner` will cause all function calls that do not originate from the owner account to revert. Functions to [transfer](contracts:api:access#Ownable-transferOwnership-address-) and [renounce](contracts:api:access#Ownable-renounceOwnership--) ownership are also available.
+For example, the [`Ownable`](../api/access#Ownable) contract marks the deployer account as the contract’s owner, and provides a modifier called `onlyOwner`. When applied to a function, `onlyOwner` will cause all function calls that do not originate from the owner account to revert. Functions to [transfer](contracts:api:access#Ownable-transferOwnership-address-) and [renounce](contracts:api:access#Ownable-renounceOwnership--) ownership are also available.
 
 When used this way, inheritance becomes a powerful mechanism that allows for modularization, without forcing you to deploy and manage multiple contracts.
 
@@ -227,7 +227,7 @@ contract Box is Ownable
 }
 ```
 
-The [OpenZeppelin Contracts documentation](/contracts) is a great place to learn about developing secure smart contract systems. It features both guides and a detailed API reference: see for example the [Access Control](/contracts/5.x/access-control) guide to know more about the `Ownable` contract used in the code sample above.
+The [OpenZeppelin Contracts documentation](/contracts) is a great place to learn about developing secure smart contract systems. It features both guides and a detailed API reference: see for example the [Access Control](../access-control) guide to know more about the `Ownable` contract used in the code sample above.
 
 ## Next steps
 

--- a/content/contracts/5.x/learn/preparing-for-mainnet.mdx
+++ b/content/contracts/5.x/learn/preparing-for-mainnet.mdx
@@ -83,7 +83,7 @@ A good option for securing admin accounts is to use a special contract, such as 
 
 ### Upgrades admin
 
-A special administrator account in an [OpenZeppelin Upgrades Plugins](upgrades-plugins::index) project is the account with the power to [_upgrade_](upgrading-smart-contracts) other contracts. This defaults to the externally owned account used to deploy the contracts: while this is good enough for a local or testnet deployment, in mainnet you need to better secure your contracts. An attacker who gets hold of your upgrade admin account can change any contract in your system!
+A special administrator account in an [OpenZeppelin Upgrades Plugins](/upgrades-plugins) project is the account with the power to [_upgrade_](upgrading-smart-contracts) other contracts. This defaults to the externally owned account used to deploy the contracts: while this is good enough for a local or testnet deployment, in mainnet you need to better secure your contracts. An attacker who gets hold of your upgrade admin account can change any contract in your system!
 
 With this in mind, it is a good idea to ***change the ownership of the ProxyAdmin*** after deployment  - for example, to a multisig. To do this, you can use `admin.transferProxyAdminOwnership` to transfer ownership of our `ProxyAdmin` contract.
 
@@ -93,7 +93,7 @@ When you need to upgrade your contracts, we can use `prepareUpgrade` to validate
 
 It can be argued that admin accounts reflect that a project is not actually _decentralized_. After all, if an account can single-handedly change any contract in the system, we are not exactly creating a trustless environment.
 
-Here is where _governance_ comes in. In many cases there will be some operations in your project that require special privileges, from fine-tuning system parameters, to running full contract upgrades. You will need to choose how those actions will be decided upon: whether it is by a [small group](https://safe.global/wallet) of trusted developers, or by [public voting](contracts::governance) of all project stakeholders.
+Here is where _governance_ comes in. In many cases there will be some operations in your project that require special privileges, from fine-tuning system parameters, to running full contract upgrades. You will need to choose how those actions will be decided upon: whether it is by a [small group](https://safe.global/wallet) of trusted developers, or by [public voting](/contracts/5.x/governance) of all project stakeholders.
 
 There is no right answer here. Which governance scheme you pick for your project will largely depend on what you are building and who your community is.
 

--- a/content/contracts/5.x/learn/preparing-for-mainnet.mdx
+++ b/content/contracts/5.x/learn/preparing-for-mainnet.mdx
@@ -93,7 +93,7 @@ When you need to upgrade your contracts, we can use `prepareUpgrade` to validate
 
 It can be argued that admin accounts reflect that a project is not actually _decentralized_. After all, if an account can single-handedly change any contract in the system, we are not exactly creating a trustless environment.
 
-Here is where _governance_ comes in. In many cases there will be some operations in your project that require special privileges, from fine-tuning system parameters, to running full contract upgrades. You will need to choose how those actions will be decided upon: whether it is by a [small group](https://safe.global/wallet) of trusted developers, or by [public voting](/contracts/5.x/governance) of all project stakeholders.
+Here is where _governance_ comes in. In many cases there will be some operations in your project that require special privileges, from fine-tuning system parameters, to running full contract upgrades. You will need to choose how those actions will be decided upon: whether it is by a [small group](https://safe.global/wallet) of trusted developers, or by [public voting](../governance) of all project stakeholders.
 
 There is no right answer here. Which governance scheme you pick for your project will largely depend on what you are building and who your community is.
 

--- a/content/contracts/5.x/learn/upgrading-smart-contracts.mdx
+++ b/content/contracts/5.x/learn/upgrading-smart-contracts.mdx
@@ -2,7 +2,7 @@
 title: Upgrading smart contracts
 ---
 
-Smart contracts deployed using [OpenZeppelin Upgrades Plugins](upgrades-plugins::index) can be ***upgraded*** to modify their code, while preserving their address, state, and balance. This allows you to iteratively add new features to your project, or fix any bugs you may find [in production](preparing-for-mainnet).
+Smart contracts deployed using [OpenZeppelin Upgrades Plugins](/upgrades-plugins) can be ***upgraded*** to modify their code, while preserving their address, state, and balance. This allows you to iteratively add new features to your project, or fix any bugs you may find [in production](preparing-for-mainnet).
 
 Throughout this guide, we will learn:
 
@@ -28,7 +28,7 @@ To avoid going through this mess, we have built contract upgrades directly into 
 
 ## Upgrading using the Upgrades Plugins
 
-Whenever you deploy a new contract using `deployProxy` in the [OpenZeppelin Upgrades Plugins](upgrades-plugins::index), that contract instance can be ***upgraded*** later. By default, only the address that originally deployed the contract has the rights to upgrade it.
+Whenever you deploy a new contract using `deployProxy` in the [OpenZeppelin Upgrades Plugins](/upgrades-plugins), that contract instance can be ***upgraded*** later. By default, only the address that originally deployed the contract has the rights to upgrade it.
 
 `deployProxy` will create the following transactions:
 
@@ -62,7 +62,7 @@ contract Box
 
 We first need to install the Upgrades Plugin.
 
-Install the [Hardhat Upgrades](upgrades-plugins::hardhat-upgrades) plugin.
+Install the [Hardhat Upgrades](/upgrades-plugins/hardhat-upgrades) plugin.
 ```bash
 npm install --save-dev @openzeppelin/hardhat-upgrades
 ```
@@ -83,7 +83,7 @@ In order to upgrade a contract like `Box` we need to first deploy it as an upgra
 
 With Hardhat, we use [scripts](https://hardhat.org/hardhat-runner/docs/advanced/scripts#writing-scripts-with-hardhat) to deploy upgradeable contracts.
 
-We will create a script to deploy our upgradeable Box contract using [`deployProxy`](upgrades-plugins::api-hardhat-upgrades#deploy-proxy).  We will save this file as `scripts/deploy_upgradeable_box.js`.
+We will create a script to deploy our upgradeable Box contract using [`deployProxy`](/upgrades-plugins/api-hardhat-upgrades#deploy-proxy).  We will save this file as `scripts/deploy_upgradeable_box.js`.
 
 ```js
 const  ethers, upgrades  = require('hardhat');
@@ -150,7 +150,7 @@ After creating the Solidity file, we can now upgrade the instance we had deploye
 1. Deploy the implementation contract (our `BoxV2` contract)
 2. Call the `ProxyAdmin` to update the proxy contract to use the new implementation.
 
-We will create a script to upgrade our `Box` contract to use `BoxV2` using [`upgradeProxy`](upgrades-plugins::api-hardhat-upgrades#upgrade-proxy).  We will save this file as `scripts/upgrade_box.js`.
+We will create a script to upgrade our `Box` contract to use `BoxV2` using [`upgradeProxy`](/upgrades-plugins/api-hardhat-upgrades#upgrade-proxy).  We will save this file as `scripts/upgrade_box.js`.
 We need to specify the address of our proxy contract from when we deployed our `Box` contract.
 
 ```js
@@ -199,13 +199,13 @@ undefined
 
 That’s it! Notice how the `value` of the `Box` was preserved throughout the upgrade, as well as its address. And this process is the same regardless of whether you are working on a local blockchain, a testnet, or the main network.
 
-Let’s see how the [OpenZeppelin Upgrades Plugins](upgrades-plugins::index) accomplish this.
+Let’s see how the [OpenZeppelin Upgrades Plugins](/upgrades-plugins) accomplish this.
 
 ## How upgrades work
 
 _This section will be more theory-heavy than others: feel free to skip over it and return later if you are curious._
 
-When you create a new upgradeable contract instance, the [OpenZeppelin Upgrades Plugins](upgrades-plugins::index) actually deploys three contracts:
+When you create a new upgradeable contract instance, the [OpenZeppelin Upgrades Plugins](/upgrades-plugins) actually deploys three contracts:
 
 1. The contract you have written, which is known as the _implementation contract_ containing the _logic_.
 2. A _proxy_ to the _implementation contract_, which is the contract that you actually interact with.
@@ -227,7 +227,7 @@ You can have multiple proxies using the same implementation contract, so you can
 Any user of the smart contract always interacts with the proxy, **which never changes its address**. This allows you to roll out an upgrade or fix a bug without requesting your users to change anything on their end - they just keep interacting with the same address as always.
 
 <Callout>
-If you want to learn more about how OpenZeppelin proxies work, check out [Proxies](upgrades-plugins::proxies).
+If you want to learn more about how OpenZeppelin proxies work, check out [Proxies](/upgrades-plugins/proxies).
 </Callout>
 
 ## Limitations of contract upgrades
@@ -236,7 +236,7 @@ While any smart contract can be made upgradeable, some restrictions of the Solid
 
 ### Initialization
 
-Upgradeable contracts cannot have a `constructor`. To help you run initialization code, [**OpenZeppelin Contracts**](contracts::index) provides the [`Initializable`](contracts:api:proxy#Initializable) base contract that allows you to tag a method as [`initializer`](contracts:api:proxy#Initializable-initializer--), ensuring it can be run only once.
+Upgradeable contracts cannot have a `constructor`. To help you run initialization code, [**OpenZeppelin Contracts**](/contracts) provides the [`Initializable`](contracts:api:proxy#Initializable) base contract that allows you to tag a method as [`initializer`](contracts:api:proxy#Initializable-initializer--), ensuring it can be run only once.
 
 As an example, let’s write a new version of the `Box` contract with an initializer, storing the address of an `admin` who will be the only one allowed to change its contents.
 
@@ -293,7 +293,7 @@ For all practical purposes, the initializer acts as a constructor. However, keep
 
 You may have noticed that we included a constructor as well as an initializer. This constructor serves the purpose of leaving the implementation contract in an initialized state, which is a mitigation against certain potential attacks.
 
-To learn more about this and other caveats when writing upgradeable contracts, check out our [Writing Upgradeable Contracts](upgrades-plugins::writing-upgradeable) guide.
+To learn more about this and other caveats when writing upgradeable contracts, check out our [Writing Upgradeable Contracts](/upgrades-plugins/writing-upgradeable) guide.
 
 ### Upgrading
 
@@ -318,7 +318,7 @@ Fortunately, this limitation only affects state variables. You can change the co
 If you accidentally mess up with your contract’s storage layout, the Upgrades Plugins will warn you when you try to upgrade.
 </Callout>
 
-To learn more about this limitation, head over to the [Modifying Your Contracts](upgrades-plugins::writing-upgradeable#modifying-your-contracts) guide.
+To learn more about this limitation, head over to the [Modifying Your Contracts](/upgrades-plugins/writing-upgradeable#modifying-your-contracts) guide.
 
 ## Testing
 

--- a/content/contracts/5.x/upgradeable.mdx
+++ b/content/contracts/5.x/upgradeable.mdx
@@ -2,14 +2,14 @@
 title: Using with Upgrades
 ---
 
-If your contract is going to be deployed with upgradeability, such as using the [OpenZeppelin Upgrades Plugins](upgrades-plugins::index), you will need to use the Upgradeable variant of OpenZeppelin Contracts.
+If your contract is going to be deployed with upgradeability, such as using the [OpenZeppelin Upgrades Plugins](/upgrades-plugins), you will need to use the Upgradeable variant of OpenZeppelin Contracts.
 
 This variant is available as a separate package called `@openzeppelin/contracts-upgradeable`, which is hosted in the repository [OpenZeppelin/openzeppelin-contracts-upgradeable](https://github.com/OpenZeppelin/openzeppelin-contracts-upgradeable). It uses `@openzeppelin/contracts` as a peer dependency.
 
-It follows all of the rules for [Writing Upgradeable Contracts](upgrades-plugins::writing-upgradeable): constructors are replaced by initializer functions, state variables are initialized in initializer functions, and we additionally check for storage incompatibilities across minor versions.
+It follows all of the rules for [Writing Upgradeable Contracts](/upgrades-plugins/writing-upgradeable): constructors are replaced by initializer functions, state variables are initialized in initializer functions, and we additionally check for storage incompatibilities across minor versions.
 
 <Callout>
-OpenZeppelin provides a full suite of tools for deploying and securing upgradeable smart contracts. [Check out the full list of resources](openzeppelin::upgrades).
+OpenZeppelin provides a full suite of tools for deploying and securing upgradeable smart contracts. [Check out the full list of resources](/upgrades).
 </Callout>
 
 ## Overview
@@ -49,7 +49,7 @@ Constructors are replaced by internal initializer functions following the naming
 Use with multiple inheritance requires special attention. See the section below titled [Multiple Inheritance](#multiple-inheritance).
 </Callout>
 
-Once this contract is set up and compiled, you can deploy it using the [Upgrades Plugins](upgrades-plugins::index). The following snippet shows an example deployment script using Hardhat.
+Once this contract is set up and compiled, you can deploy it using the [Upgrades Plugins](/upgrades-plugins). The following snippet shows an example deployment script using Hardhat.
 
 ```js
 const { ethers, upgrades } = require("hardhat");
@@ -78,6 +78,6 @@ The function `__ContractName_init_unchained` found in every contract is the init
 
 You may notice that contracts use a struct with the `@custom:storage-location erc7201:<NAMESPACE_ID>` annotation to store the contract’s state variables. This follows the [ERC-7201: Namespaced Storage Layout](https://eips.ethereum.org/EIPS/eip-7201) pattern, where each contract has its own storage layout in a namespace that is separate from other contracts in the inheritance chain.
 
-Without namespaced storage, it isn’t safe to simply add a state variable because it "shifts down" all of the state variables below in the inheritance chain. This makes the storage layouts incompatible, as explained in [Writing Upgradeable Contracts](upgrades-plugins::writing-upgradeable#modifying-your-contracts).
+Without namespaced storage, it isn’t safe to simply add a state variable because it "shifts down" all of the state variables below in the inheritance chain. This makes the storage layouts incompatible, as explained in [Writing Upgradeable Contracts](/upgrades-plugins/writing-upgradeable#modifying-your-contracts).
 
 The namespaced storage pattern used in the Upgradeable package allows us to freely add new state variables in the future without compromising the storage compatibility with existing deployments. It also allows changing the inheritance order with no impact on the resulting storage layout, as long as all inherited contracts use namespaced storage.

--- a/content/contracts/5.x/wizard.mdx
+++ b/content/contracts/5.x/wizard.mdx
@@ -6,7 +6,7 @@ Not sure where to start? Use the interactive generator below to bootstrap your
 contract and learn about the components offered in OpenZeppelin Contracts.
 
 <Callout>
-Place the resulting contract in your `contracts` or `src` directory in order to compile it with a tool like Hardhat or Foundry. Consider reading our guide on [Developing Smart Contracts](learn::developing-smart-contracts) for more guidance!
+Place the resulting contract in your `contracts` or `src` directory in order to compile it with a tool like Hardhat or Foundry. Consider reading our guide on [Developing Smart Contracts](learn/developing-smart-contracts) for more guidance!
 </Callout>
 
 <OZWizard version="5.4.0" />


### PR DESCRIPTION
For Contracts and Community Contracts:
- Fixes relative links (e.g. links that contained `::`, and links between Contracts and Learn)
- Updates absolute links to be relative
