### PR TITLE
Fix 5.x API links, move Callout end tags

### DIFF
--- a/content/community-contracts/api/account.mdx
+++ b/content/community-contracts/api/account.mdx
@@ -106,8 +106,8 @@ authorization logic, such as requiring specific signers or roles.
 
 <Callout>
 Use [`ERC7579DelayedExecutor._scheduleAt`](#ERC7579DelayedExecutor-_scheduleAt-address-bytes32-bytes32-bytes-uint48-uint32-) to schedule operations at a specific points in time. This is
-</Callout>
 useful to pre-schedule operations for non-deployed accounts (e.g. subscriptions).
+</Callout>
 
 <div className="bg-secondary p-4 rounded-md mb-6">
 <h3 style={{ marginTop: "0"}}>Functions</h3>
@@ -442,16 +442,16 @@ and respecting the previous delay and expiration values.
 
 <Callout type="warn">
 This function does not clean up scheduled operations. This means operations
-</Callout>
 could potentially be re-executed if the module is reinstalled later. This is a deliberate
 design choice for efficiency, but module implementations may want to override this behavior
 to clear scheduled operations during uninstallation for their specific use cases.
+</Callout>
 
 <Callout>
 Calling this function directly will remove the expiration ([`ERC7579DelayedExecutor.getExpiration`](#ERC7579DelayedExecutor-getExpiration-address-)) value and
-</Callout>
 will schedule a reset of the delay ([`ERC7579DelayedExecutor.getDelay`](#ERC7579DelayedExecutor-getDelay-address-)) to `0` for the account. Reinstalling the
 module will not immediately reset the delay if the delay reset hasn't taken effect yet.
+</Callout>
 
 </div>
 </div>
@@ -472,9 +472,9 @@ Returns `data` as the execution calldata. See [`ERC7579Executor._execute`](#ERC7
 
 <Callout>
 This function relies on the operation state validation in [`ERC7579DelayedExecutor._execute`](#ERC7579DelayedExecutor-_execute-address-bytes32-bytes32-bytes-) for
-</Callout>
 authorization. Extensions of this module should override this function to implement
 additional validation logic if needed.
+</Callout>
 
 </div>
 </div>
@@ -817,9 +817,9 @@ derived contracts.
 
 <Callout>
 This is a simplified executor that directly executes operations without delay or expiration
-</Callout>
 mechanisms. For a more advanced implementation with time-delayed execution patterns and
 security features, see [`ERC7579DelayedExecutor`](#ERC7579DelayedExecutor).
+</Callout>
 
 <div className="bg-secondary p-4 rounded-md mb-6">
 <h3 style={{ marginTop: "0"}}>Functions</h3>
@@ -908,9 +908,9 @@ Example extension:
 
 <Callout>
 Pack extra data in the `data` arguments (e.g. a signature) to be used in the
-</Callout>
 validation process. Calldata can be sliced to extract it and return only the
 execution calldata.
+</Callout>
 
 </div>
 </div>
@@ -1060,8 +1060,8 @@ disabled until they are added later.
 
 <Callout>
 An account can only call onInstall once. If called directly by the account,
-</Callout>
 the signer will be set to the provided data. Future installations will behave as a no-op.
+</Callout>
 
 </div>
 </div>
@@ -1085,8 +1085,8 @@ See [`ERC7579DelayedExecutor.onUninstall`](#ERC7579DelayedExecutor-onUninstall-b
 
 <Callout type="warn">
 This function has unbounded gas costs and may become uncallable if the set grows too large.
-</Callout>
 See `EnumerableSet-clear`.
+</Callout>
 
 </div>
 </div>
@@ -1109,9 +1109,9 @@ Using `start = 0` and `end = type(uint64).max` will return the entire set of sig
 
 <Callout type="warn">
 Depending on the `start` and `end`, this operation can copy a large amount of data to memory, which
-</Callout>
 can be expensive. This is designed for view accessors queried without gas fees. Using it in state-changing
 functions may become uncallable if the slice grows too large.
+</Callout>
 
 </div>
 </div>
@@ -1553,8 +1553,8 @@ consent to be added. Each signer must sign an EIP-712 message to confirm their a
 
 <Callout>
 Use this module to ensure that all guardians in a social recovery or multisig setup have
-</Callout>
 explicitly agreed to their roles.
+</Callout>
 
 <div className="bg-secondary p-4 rounded-md mb-6">
 <h3 style={{ marginTop: "0"}}>Functions</h3>
@@ -1830,8 +1830,8 @@ signed, otherwise acts as a no-op.
 
 <Callout>
 Does not check if the signer is authorized for the account. Valid signatures from
-</Callout>
 invalid signers won't be executable. See [`ERC7579Multisig._validateSignatures`](#ERC7579Multisig-_validateSignatures-address-bytes32-bytes---bytes---) for more details.
+</Callout>
 
 </div>
 </div>
@@ -1905,9 +1905,9 @@ after the time delay has passed.
 
 <Callout type="warn">
 When setting a threshold value, ensure it matches the scale used for signer weights.
-</Callout>
 For example, if signers have weights like 1, 2, or 3, then a threshold of 4 would require
 signatures with a total weight of at least 4 (e.g., one with weight 1 and one with weight 3).
+</Callout>
 
 <div className="bg-secondary p-4 rounded-md mb-6">
 <h3 style={{ marginTop: "0"}}>Functions</h3>
@@ -1996,8 +1996,8 @@ If weights are not provided but signers are, all signers default to weight 1.
 
 <Callout>
 An account can only call onInstall once. If called directly by the account,
-</Callout>
 the signer will be set to the provided data. Future installations will behave as a no-op.
+</Callout>
 
 </div>
 </div>
@@ -2158,10 +2158,10 @@ Override to validate threshold against total weight instead of signer count.
 
 <Callout>
 This function intentionally does not call `super._validateReachableThreshold` because the base implementation
-</Callout>
 assumes each signer has a weight of 1, which is a subset of this weighted implementation. Consider that multiple
 implementations of this function may exist in the contract, so important side effects may be missed
 depending on the linearization order.
+</Callout>
 
 </div>
 </div>
@@ -2183,8 +2183,8 @@ Overrides the base implementation to use weights instead of count.
 
 <Callout>
 This function intentionally does not call `super._validateThreshold` because the base implementation
-</Callout>
 assumes each signer has a weight of 1, which is incompatible with this weighted implementation.
+</Callout>
 
 </div>
 </div>
@@ -2206,8 +2206,8 @@ Emitted when a signer's weight is changed.
 
 <Callout>
 Not emitted in [`ERC7579Multisig._addSigners`](#ERC7579Multisig-_addSigners-address-bytes---) or [`ERC7579Multisig._removeSigners`](#ERC7579Multisig-_removeSigners-address-bytes---). Indexers must rely on [`ERC7579Multisig.ERC7913SignerAdded`](#ERC7579Multisig-ERC7913SignerAdded-address-bytes-)
-</Callout>
 and [`ERC7579Multisig.ERC7913SignerRemoved`](#ERC7579Multisig-ERC7913SignerRemoved-address-bytes-) to index a default weight of 1. See [`ERC7579MultisigWeighted.signerWeight`](#ERC7579MultisigWeighted-signerWeight-address-bytes-).
+</Callout>
 
 </div>
 </div>
@@ -2340,8 +2340,8 @@ Returns the set of authorized selectors for the specified account.
 
 <Callout type="warn">
 This operation copies the entire selectors set to memory, which
-</Callout>
 can be expensive or may result in unbounded computation.
+</Callout>
 
 </div>
 </div>
@@ -2381,8 +2381,8 @@ Clears all selectors.
 
 <Callout type="warn">
 This function has unbounded gas costs and may become uncallable if the set grows too large.
-</Callout>
 See [`EnumerableSetExtended.clear`](utils#EnumerableSetExtended-clear-struct-EnumerableSetExtended-Bytes32x2Set-).
+</Callout>
 
 </div>
 </div>
@@ -2623,8 +2623,8 @@ See `IERC7579Module-onInstall`.
 
 <Callout>
 An account can only call onInstall once. If called directly by the account,
-</Callout>
 the signer will be set to the provided data. Future installations will behave as a no-op.
+</Callout>
 
 </div>
 </div>
@@ -2645,9 +2645,9 @@ See `IERC7579Module-onUninstall`.
 
 <Callout type="warn">
 The signer's key will be removed if the account calls this function, potentially
-</Callout>
 making the account unusable. As an account operator, make sure to uninstall to a predefined path
 in your account that properly handles side effects of uninstallation.  See `AccountERC7579-uninstallModule`.
+</Callout>
 
 </div>
 </div>
@@ -2889,8 +2889,8 @@ Validation algorithm.
 
 <Callout type="warn">
 Validation is a critical security function. Implementations must carefully
-</Callout>
 handle cryptographic verification to prevent unauthorized access.
+</Callout>
 
 </div>
 </div>
@@ -2925,8 +2925,8 @@ through the internal functions [`PaymasterCore.deposit`](#PaymasterCore-deposit-
 
 <Callout>
 See [Paymaster's unstaked reputation rules](https://eips.ethereum.org/EIPS/eip-7562#unstaked-paymasters-reputation-rules)
-</Callout>
  for more details on the paymaster's storage access limitations.
+</Callout>
 
 <div className="bg-secondary p-4 rounded-md mb-6">
 <h3 style={{ marginTop: "0"}}>Modifiers</h3>
@@ -3094,8 +3094,8 @@ is returned by [`PaymasterCore.validatePaymasterUserOp`](#PaymasterCore-validate
 
 <Callout>
 The `actualUserOpFeePerGas` is not `tx.gasprice`. A user operation can be bundled with other transactions
-</Callout>
 making the gas price of the user operation to differ.
+</Callout>
 
 </div>
 </div>
@@ -3366,9 +3366,9 @@ Returns a `prefundContext` that's passed to the [`PaymasterCore._postOp`](#Payma
 
 <Callout>
 Consider not reverting if the prefund fails when overriding this function. This is to avoid reverting
-</Callout>
 during the validation phase of the user operation, which may penalize the paymaster's reputation according
 to ERC-7562 validation rules.
+</Callout>
 
 </div>
 </div>
@@ -3391,9 +3391,9 @@ Reverts with [`PaymasterERC20.PaymasterERC20FailedRefund`](#PaymasterERC20-Payma
 
 <Callout type="warn">
 This function may revert after the user operation has been executed without
-</Callout>
 reverting the user operation itself. Consider implementing a mechanism to handle
 this case gracefully.
+</Callout>
 
 </div>
 </div>
@@ -3685,8 +3685,8 @@ Otherwise, fallback to [`PaymasterERC20._refund`](#PaymasterERC20-_refund-contra
 
 <Callout>
 For guaranteed user operations where the user paid the `actualGasCost` back, this function
-</Callout>
 doesn't call `super._refund`. Consider whether there are side effects in the parent contract that need to be executed.
+</Callout>
 
 </div>
 </div>
@@ -3707,8 +3707,8 @@ Fetches the guarantor address and validation data from the user operation.
 
 <Callout>
 Return `address(0)` to disable the guarantor feature. If supported, ensure
-</Callout>
 explicit consent (e.g., signature verification) to prevent unauthorized use.
+</Callout>
 
 </div>
 </div>
@@ -3876,8 +3876,8 @@ Returns the context to be passed to postOp and the validation data.
 
 <Callout>
 The default `context` is `bytes(0)`. Developers that add a context when overriding this function MUST
-</Callout>
 also override [`PaymasterCore._postOp`](#PaymasterCore-_postOp-enum-IPaymaster-PostOpMode-bytes-uint256-uint256-) to process the context passed along.
+</Callout>
 
 </div>
 </div>
@@ -4017,8 +4017,8 @@ Returns the context to be passed to postOp and the validation data.
 
 <Callout>
 The `context` returned is `bytes(0)`. Developers overriding this function MUST
-</Callout>
 override [`PaymasterCore._postOp`](#PaymasterCore-_postOp-enum-IPaymaster-PostOpMode-bytes-uint256-uint256-) to process the context passed along.
+</Callout>
 
 </div>
 </div>

--- a/content/community-contracts/api/crosschain.mdx
+++ b/content/community-contracts/api/crosschain.mdx
@@ -228,9 +228,9 @@ This function emits:
 
 <Callout>
 interface requires this function to be payable. Even if we don't expect any value, a gateway may pass
-</Callout>
 some value for unknown reason. In that case we want to register this gateway having delivered the message and
 not revert. Any value accrued that way can be recovered by the admin using the [`ERC7786OpenBridge.sweep`](#ERC7786OpenBridge-sweep-address-payable-) function.
+</Callout>
 
 </div>
 </div>
@@ -741,11 +741,11 @@ workflow into the standard ERC-7786.
 
 <Callout>
 While both ERC-7786 and Axelar do support non-evm chains, this adaptor does not. This limitation comes from
-</Callout>
 the translation of the ERC-7930 interoperable address (binary objects -- bytes) to strings. This is necessary
 because Axelar uses string to represent addresses. For EVM network, this adapter uses a checksum hex string
 representation. Other networks would require a different encoding. Ideally we would have a single encoding for all
 networks (could be base58, base64, ...) but Axelar doesn't support that.
+</Callout>
 
 <div className="bg-secondary p-4 rounded-md mb-6">
 <h3 style={{ marginTop: "0"}}>Functions</h3>

--- a/content/community-contracts/api/proxy.mdx
+++ b/content/community-contracts/api/proxy.mdx
@@ -36,9 +36,9 @@ checks that are not compatible with this proxy design.
 
 <Callout type="warn">
 The fallback mechanism relies on the implementation not to define the `IBeacon-implementation` function.
-</Callout>
 Consider that if your implementation has this function, it'll be assumed as the beacon address, meaning that
 the returned address will be used as this proxy's implementation.
+</Callout>
 
 <div className="bg-secondary p-4 rounded-md mb-6">
 <h3 style={{ marginTop: "0"}}>Functions</h3>
@@ -86,9 +86,9 @@ Returns the current implementation address according to ERC-1967's implementatio
 
 <Callout type="warn">
 The way this function identifies whether the implementation is a beacon, is by checking
-</Callout>
 if it implements the `IBeacon-implementation` function. Consider that an actual implementation could
 define this function, mistakenly identifying it as a beacon.
+</Callout>
 
 </div>
 </div>

--- a/content/community-contracts/api/token.mdx
+++ b/content/community-contracts/api/token.mdx
@@ -1661,8 +1661,8 @@ See [`IERC7943.setFrozen`](interfaces#IERC7943-setFrozen-address-uint256-uint256
 
 <Callout>
 The `amount` is capped to the balance of the `user` to ensure the [`IERC7943.Frozen`](interfaces#IERC7943-Frozen-address-uint256-uint256-) event
-</Callout>
 emits values that consistently reflect the actual amount of tokens that are frozen.
+</Callout>
 
 </div>
 </div>
@@ -1686,10 +1686,10 @@ to the new balance after the transfer.
 
 <Callout>
 This function uses [`ERC20Allowlist._update`](#ERC20Allowlist-_update-address-address-uint256-) to perform the transfer, ensuring all standard ERC20
-</Callout>
 side effects (such as balance updates and events) are preserved. If you override [`ERC20Allowlist._update`](#ERC20Allowlist-_update-address-address-uint256-)
 to add additional restrictions or logic, those changes will also apply here.
 Consider overriding this function to bypass newer restrictions if needed.
+</Callout>
 
 </div>
 </div>

--- a/content/community-contracts/api/utils.mdx
+++ b/content/community-contracts/api/utils.mdx
@@ -348,8 +348,8 @@ Removes all the entries from a map. O(n).
 
 <Callout type="warn">
 Developers should keep in mind that this function has an unbounded cost and using it may render the
-</Callout>
 function uncallable if the map grows to the point where clearing it consumes too much gas to fit in a block.
+</Callout>
 
 </div>
 </div>
@@ -467,10 +467,10 @@ Returns an array containing all the keys
 
 <Callout type="warn">
 This operation will copy the entire storage to memory, which can be quite expensive. This is designed
-</Callout>
 to mostly be used by view accessors that are queried without any gas fees. Developers should keep in mind that
 this function has an unbounded cost, and using it as part of a state-changing function may render the function
 uncallable if the map grows to a point where copying to memory consumes too much gas to fit in a block.
+</Callout>
 
 </div>
 </div>
@@ -491,10 +491,10 @@ Returns an array containing a slice of the keys
 
 <Callout type="warn">
 This operation will copy the entire storage to memory, which can be quite expensive. This is designed
-</Callout>
 to mostly be used by view accessors that are queried without any gas fees. Developers should keep in mind that
 this function has an unbounded cost, and using it as part of a state-changing function may render the function
 uncallable if the map grows to a point where copying to memory consumes too much gas to fit in a block.
+</Callout>
 
 </div>
 </div>
@@ -555,8 +555,8 @@ Removes all the entries from a map. O(n).
 
 <Callout type="warn">
 Developers should keep in mind that this function has an unbounded cost and using it may render the
-</Callout>
 function uncallable if the map grows to the point where clearing it consumes too much gas to fit in a block.
+</Callout>
 
 </div>
 </div>
@@ -674,10 +674,10 @@ Returns an array containing all the keys
 
 <Callout type="warn">
 This operation will copy the entire storage to memory, which can be quite expensive. This is designed
-</Callout>
 to mostly be used by view accessors that are queried without any gas fees. Developers should keep in mind that
 this function has an unbounded cost, and using it as part of a state-changing function may render the function
 uncallable if the map grows to a point where copying to memory consumes too much gas to fit in a block.
+</Callout>
 
 </div>
 </div>
@@ -698,10 +698,10 @@ Returns an array containing a slice of the keys
 
 <Callout type="warn">
 This operation will copy the entire storage to memory, which can be quite expensive. This is designed
-</Callout>
 to mostly be used by view accessors that are queried without any gas fees. Developers should keep in mind that
 this function has an unbounded cost, and using it as part of a state-changing function may render the function
 uncallable if the map grows to a point where copying to memory consumes too much gas to fit in a block.
+</Callout>
 
 </div>
 </div>
@@ -862,8 +862,8 @@ Removes all the values from a set. O(n).
 
 <Callout type="warn">
 Developers should keep in mind that this function has an unbounded cost and using it may render the
-</Callout>
 function uncallable if the set grows to the point where clearing it consumes too much gas to fit in a block.
+</Callout>
 
 </div>
 </div>
@@ -942,10 +942,10 @@ Return the entire set in an array
 
 <Callout type="warn">
 This operation will copy the entire storage to memory, which can be quite expensive. This is designed
-</Callout>
 to mostly be used by view accessors that are queried without any gas fees. Developers should keep in mind that
 this function has an unbounded cost, and using it as part of a state-changing function may render the function
 uncallable if the set grows to a point where copying to memory consumes too much gas to fit in a block.
+</Callout>
 
 </div>
 </div>
@@ -966,10 +966,10 @@ Return a slice of the set in an array
 
 <Callout type="warn">
 This operation will copy the entire storage to memory, which can be quite expensive. This is designed
-</Callout>
 to mostly be used by view accessors that are queried without any gas fees. Developers should keep in mind that
 this function has an unbounded cost, and using it as part of a state-changing function may render the function
 uncallable if the set grows to a point where copying to memory consumes too much gas to fit in a block.
+</Callout>
 
 </div>
 </div>

--- a/content/community-contracts/api/utils/cryptography.mdx
+++ b/content/community-contracts/api/utils/cryptography.mdx
@@ -133,8 +133,8 @@ Emits a [`IDKIMRegistry.KeyHashRegistered`](../interfaces#IDKIMRegistry-KeyHashR
 
 <Callout>
 This function does not validate that keyHash is non-zero. Consider adding
-</Callout>
 validation in derived contracts if needed.
+</Callout>
 
 </div>
 </div>
@@ -158,8 +158,8 @@ Emits a [`IDKIMRegistry.KeyHashRegistered`](../interfaces#IDKIMRegistry-KeyHashR
 
 <Callout>
 This function does not validate that the keyHashes array is non-empty.
-</Callout>
 Consider adding validation in derived contracts if needed.
+</Callout>
 
 </div>
 </div>
@@ -299,8 +299,8 @@ returns true and the calldata view at the object. Otherwise, returns false and a
 
 <Callout>
 The returned `auth` object should not be accessed if `success` is false. Trying to access the data may
-</Callout>
 cause revert/panic.
+</Callout>
 
 </div>
 </div>
@@ -426,8 +426,8 @@ returns true and the calldata view at the object. Otherwise, returns false and a
 
 <Callout>
 The returned `emailProof` object should not be accessed if `success` is false. Trying to access the data may
-</Callout>
 cause revert/panic.
+</Callout>
 
 </div>
 </div>
@@ -488,8 +488,8 @@ contract MyAccountWebAuthn is Account, SignerWebAuthn, Initializable {
 
 <Callout type="warn">
 Failing to call [`ERC7579Signature._setSigner`](../account#ERC7579Signature-_setSigner-address-bytes-) either during construction (if used standalone)
-</Callout>
 or during initialization (if used as a clone) may leave the signer either front-runnable or unusable.
+</Callout>
 
 <div className="bg-secondary p-4 rounded-md mb-6">
 <h3 style={{ marginTop: "0"}}>Functions</h3>
@@ -582,9 +582,9 @@ contract MyAccountZKEmail is Account, SignerZKEmail, Initializable {
 
 <Callout type="warn">
 Failing to call [`SignerZKEmail._setAccountSalt`](#SignerZKEmail-_setAccountSalt-bytes32-), [`SignerZKEmail._setDKIMRegistry`](#SignerZKEmail-_setDKIMRegistry-contract-IDKIMRegistry-), and [`SignerZKEmail._setVerifier`](#SignerZKEmail-_setVerifier-contract-IGroth16Verifier-)
-</Callout>
 either during construction (if used standalone) or during initialization (if used as a clone) may
 leave the signer either front-runnable or unusable.
+</Callout>
 
 <div className="bg-secondary p-4 rounded-md mb-6">
 <h3 style={{ marginTop: "0"}}>Functions</h3>

--- a/content/confidential-contracts/api/finance.mdx
+++ b/content/confidential-contracts/api/finance.mdx
@@ -298,9 +298,9 @@ an asset given its total historical allocation. Returns 0 if the [`VestingWallet
 
 <Callout type="warn">
 The cliff not only makes the schedule return 0, but it also ignores every possible side
-</Callout>
 effect from calling the inherited implementation (i.e. `super._vestingSchedule`). Carefully consider
 this caveat if the overridden implementation of this function has any (e.g. writing to memory or reverting).
+</Callout>
 
 </div>
 </div>
@@ -354,8 +354,8 @@ Since the wallet is `Ownable`, and ownership can be transferred, it is possible 
 
 <Callout>
 When using this contract with any token whose balance is adjusted automatically (i.e. a rebase token), make
-</Callout>
 sure to account the supply/balance adjustment in the vesting schedule to ensure the vested amount is as intended.
+</Callout>
 
 Confidential vesting wallet contracts can be deployed (as clones) using the [`VestingWalletConfidentialFactory`](#VestingWalletConfidentialFactory).
 

--- a/content/confidential-contracts/api/governance.mdx
+++ b/content/confidential-contracts/api/governance.mdx
@@ -195,9 +195,9 @@ configured to use block numbers, this will return the value at the end of the co
 
 <Callout>
 This value is the sum of all available votes, which is not necessarily the sum of all delegated votes.
-</Callout>
 Votes that have not been delegated are still part of total supply, even though they would not participate in a
 vote.
+</Callout>
 
 Requirements:
 

--- a/content/confidential-contracts/api/token.mdx
+++ b/content/confidential-contracts/api/token.mdx
@@ -426,8 +426,8 @@ event. The caller and this contract must be authorized to use the encrypted amou
 
 <Callout>
 This is an asynchronous operation where the actual decryption happens off-chain and
-</Callout>
 [`ConfidentialFungibleToken.finalizeDiscloseEncryptedAmount`](#ConfidentialFungibleToken-finalizeDiscloseEncryptedAmount-uint256-uint64-bytes---) is called with the result.
+</Callout>
 
 </div>
 </div>
@@ -684,8 +684,8 @@ which allows users to transfer `ERC1363` tokens directly to the wrapper with a c
 
 <Callout type="warn">
 Minting assumes the full amount of the underlying token transfer has been received, hence some non-standard
-</Callout>
 tokens such as fee-on-transfer or other deflationary-type tokens are not supported by this wrapper.
+</Callout>
 
 <div className="bg-secondary p-4 rounded-md mb-6">
 <h3 style={{ marginTop: "0"}}>Functions</h3>
@@ -881,8 +881,8 @@ or be an approved operator for `from`. `amount * rate()` underlying tokens are s
 
 <Callout>
 This is an asynchronous function and waits for decryption to be completed off-chain before disbursing
-</Callout>
 tokens.
+</Callout>
 <Callout>
 The caller *must* already be approved by ACL for the given `amount`.
 </Callout>

--- a/content/confidential-contracts/api/utils.mdx
+++ b/content/confidential-contracts/api/utils.mdx
@@ -126,8 +126,8 @@ account `account` with the given persistence flag.
 
 <Callout>
 This function call is gated by `msg.sender` and validated by the
-</Callout>
 [`HandleAccessManager._validateHandleAllowance`](#HandleAccessManager-_validateHandleAllowance-bytes32-) function.
+</Callout>
 
 </div>
 </div>
@@ -212,8 +212,8 @@ Returns previous value and new value.
 
 <Callout type="warn">
 Never accept `key` as a user input, since an arbitrary `type(uint256).max` key set will disable the
-</Callout>
 library.
+</Callout>
 
 </div>
 </div>
@@ -271,8 +271,8 @@ if there is none.
 
 <Callout>
 This is a variant of [`CheckpointsConfidential.upperLookup`](#CheckpointsConfidential-upperLookup-struct-CheckpointsConfidential-TraceEuint64-uint256-) that is optimized to find "recent" checkpoint (checkpoints with high
-</Callout>
 keys).
+</Callout>
 
 </div>
 </div>
@@ -364,8 +364,8 @@ Returns previous value and new value.
 
 <Callout type="warn">
 Never accept `key` as a user input, since an arbitrary `type(uint256).max` key set will disable the
-</Callout>
 library.
+</Callout>
 
 </div>
 </div>
@@ -423,8 +423,8 @@ if there is none.
 
 <Callout>
 This is a variant of [`CheckpointsConfidential.upperLookup`](#CheckpointsConfidential-upperLookup-struct-CheckpointsConfidential-TraceEuint64-uint256-) that is optimized to find "recent" checkpoint (checkpoints with high
-</Callout>
 keys).
+</Callout>
 
 </div>
 </div>
@@ -583,8 +583,8 @@ Returns previous value and new value.
 
 <Callout type="warn">
 Never accept `key` as a user input, since an arbitrary `type(uint256).max` key set will disable the
-</Callout>
 library.
+</Callout>
 
 </div>
 </div>
@@ -642,8 +642,8 @@ if there is none.
 
 <Callout>
 This is a variant of [`CheckpointsConfidential.upperLookup`](#CheckpointsConfidential-upperLookup-struct-CheckpointsConfidential-TraceEuint64-uint256-) that is optimized to find "recent" checkpoint (checkpoints with high
-</Callout>
 keys).
+</Callout>
 
 </div>
 </div>
@@ -735,8 +735,8 @@ Returns previous value and new value.
 
 <Callout type="warn">
 Never accept `key` as a user input, since an arbitrary `type(uint32).max` key set will disable the
-</Callout>
 library.
+</Callout>
 
 </div>
 </div>
@@ -794,8 +794,8 @@ if there is none.
 
 <Callout>
 This is a variant of [`CheckpointsConfidential.upperLookup`](#CheckpointsConfidential-upperLookup-struct-CheckpointsConfidential-TraceEuint64-uint256-) that is optimized to find "recent" checkpoint (checkpoints with high
-</Callout>
 keys).
+</Callout>
 
 </div>
 </div>
@@ -887,8 +887,8 @@ Returns previous value and new value.
 
 <Callout type="warn">
 Never accept `key` as a user input, since an arbitrary `type(uint48).max` key set will disable the
-</Callout>
 library.
+</Callout>
 
 </div>
 </div>
@@ -946,8 +946,8 @@ if there is none.
 
 <Callout>
 This is a variant of [`CheckpointsConfidential.upperLookup`](#CheckpointsConfidential-upperLookup-struct-CheckpointsConfidential-TraceEuint64-uint256-) that is optimized to find "recent" checkpoint (checkpoints with high
-</Callout>
 keys).
+</Callout>
 
 </div>
 </div>
@@ -1039,8 +1039,8 @@ Returns previous value and new value.
 
 <Callout type="warn">
 Never accept `key` as a user input, since an arbitrary `type(uint96).max` key set will disable the
-</Callout>
 library.
+</Callout>
 
 </div>
 </div>
@@ -1098,8 +1098,8 @@ if there is none.
 
 <Callout>
 This is a variant of [`CheckpointsConfidential.upperLookup`](#CheckpointsConfidential-upperLookup-struct-CheckpointsConfidential-TraceEuint64-uint256-) that is optimized to find "recent" checkpoint (checkpoints with high
-</Callout>
 keys).
+</Callout>
 
 </div>
 </div>

--- a/content/contracts-cairo/1.0.0/access.mdx
+++ b/content/contracts-cairo/1.0.0/access.mdx
@@ -100,8 +100,8 @@ after an initial stage with centralized administration is over.
 
 <Callout type='warn'>
 Removing the owner altogether will mean that administrative tasks that are protected by `assert_only_owner`
-</Callout>
 will no longer be callable!
+</Callout>
 
 ### Two step transfer
 
@@ -243,8 +243,8 @@ mod MyContract {
 
 <Callout type='warn'>
 Make sure you fully understand how [AccessControl](api/access#AccessControlComponent) works before
-</Callout>
 using it on your system, or copy-pasting the examples from this guide.
+</Callout>
 
 While clear and explicit, this isn’t anything we wouldn’t have been able to achieve with
 [Ownable](api/access#OwnableComponent). Where [AccessControl](api/access#AccessControlComponent) shines the most is in scenarios where granular
@@ -445,8 +445,8 @@ mod MyContract {
 
 <Callout>
 The `grant_role` and `revoke_role` functions are automatically exposed as `external` functions
-</Callout>
 from the `AccessControlImpl` by leveraging the `#[abi(embed_v0)]` annotation.
+</Callout>
 
 Note that, unlike the previous examples, no accounts are granted the 'minter' or 'burner' roles.
 However, because those roles' admin role is the default admin role, and that role was granted to the 'admin', that

--- a/content/contracts-cairo/1.0.0/components.mdx
+++ b/content/contracts-cairo/1.0.0/components.mdx
@@ -229,8 +229,8 @@ mod Account {
 
 <Callout type='warn'>
 Failing to use a component’s `initializer` can result in irreparable contract deployments.
-</Callout>
 Always read the API documentation for each integrated component.
+</Callout>
 
 Some components require some sort of setup upon construction.
 Usually, this would be a job for a constructor; however, components themselves cannot implement constructors.
@@ -438,8 +438,8 @@ mod MyContract {
 
 <Callout type='warn'>
 Customizing implementations and accessing component storage can potentially corrupt the state, bypass security checks, and undermine the component logic.
-</Callout>
 **Exercise extreme caution**. See [Security](#security).
+</Callout>
 
 ### Hooks
 

--- a/content/contracts-cairo/1.0.0/erc1155.mdx
+++ b/content/contracts-cairo/1.0.0/erc1155.mdx
@@ -155,8 +155,8 @@ In the spirit of the standard, we’ve also included batch operations in the non
 
 <Callout type='warn'>
 While [safe_transfer_from](/api/erc1155#IERC1155-safe_transfer_from) and [safe_batch_transfer_from](/api/erc1155#IERC1155-safe_batch_transfer_from) prevent loss by checking the receiver can handle the
-</Callout>
 tokens, this yields execution to the receiver which can result in a [reentrant call](security#reentrancy-guard).
+</Callout>
 
 ## Receiving tokens
 

--- a/content/contracts-cairo/1.0.0/erc20.mdx
+++ b/content/contracts-cairo/1.0.0/erc20.mdx
@@ -7,9 +7,9 @@ The ERC20 token standard is a specification for [fungible tokens](https://docs.o
 
 <Callout type='warn'>
 Prior to [Contracts v0.7.0](https://github.com/OpenZeppelin/cairo-contracts/releases/tag/v0.7.0), ERC20 contracts store and read `decimals` from storage; however, this implementation returns a static `18`.
-</Callout>
 If upgrading an older ERC20 contract that has a decimals value other than `18`, the upgraded contract **must** use a custom `decimals` implementation.
 See the [Customizing decimals](/erc20#customizing_decimals) guide.
+</Callout>
 
 ## Usage
 

--- a/content/contracts-cairo/1.0.0/finance.mdx
+++ b/content/contracts-cairo/1.0.0/finance.mdx
@@ -12,13 +12,13 @@ This structure allows ownership rights of both the contract and the vested token
 
 <Callout>
 Any assets transferred to this contract will follow the vesting schedule as if they were locked from the beginning of the vesting period.
-</Callout>
 As a result, if the vesting has already started, a portion of the newly transferred tokens may become immediately releasable.
+</Callout>
 
 <Callout>
 By setting the duration to 0, it’s possible to configure this contract to behave like an asset timelock that holds tokens
-</Callout>
 for a beneficiary until a specified date.
+</Callout>
 
 ### Vesting schedule
 
@@ -28,9 +28,9 @@ implementation of the [VestingSchedule](api/finance#VestingComponent-Vesting-Sch
 
 <Callout>
 There’s a ready-made implementation of the [VestingSchedule](api/finance#VestingComponent-Vesting-Schedule) trait available named [LinearVestingSchedule](api/finance#LinearVestingSchedule).
-</Callout>
 It incorporates a cliff period by returning 0 vested amount until the cliff ends. After the cliff, the vested amount
 is calculated as directly proportional to the time elapsed since the beginning of the vesting schedule.
+</Callout>
 
 ### Usage
 

--- a/content/contracts-cairo/1.0.0/governance/governor.mdx
+++ b/content/contracts-cairo/1.0.0/governance/governor.mdx
@@ -31,9 +31,9 @@ The library currently does not include a wrapper for tokens, but it will be adde
 
 <Callout>
 Currently, the clock mode is fixed to block timestamps, since the Votes component uses the block timestamp to track
-</Callout>
 checkpoints. We plan to add support for more flexible clock modes in Votes in a future release, allowing to use, for example,
 block numbers instead.
+</Callout>
 
 ### Governor
 
@@ -228,8 +228,8 @@ GovernorTimelockExecution extension.
 
 <Callout type='warn'>
 When using a timelock, it is the timelock that will execute proposals and thus the timelock that should
-</Callout>
 hold any funds, ownership, and access control roles.
+</Callout>
 
 TimelockController uses an [AccessControl](access#role_based_accesscontrol) setup that we need to understand in order to set up roles.
 

--- a/content/contracts-cairo/1.0.0/governance/timelock.mdx
+++ b/content/contracts-cairo/1.0.0/governance/timelock.mdx
@@ -48,8 +48,8 @@ Therefore, the initial proposers may also cancel operations after they are sched
 
 <Callout type='warn'>
 The `DEFAULT_ADMIN_ROLE` is a sensitive role that will be granted automatically to the timelock itself and optionally to a second account.
-</Callout>
 The latter case may be required to ease a contract’s initial configuration; however, this role should promptly be renounced.
+</Callout>
 
 Furthermore, the timelock component supports the concept of open roles for the `EXECUTOR_ROLE`.
 This allows anyone to execute an operation once it’s in the `Ready` OperationState.

--- a/content/contracts-cairo/1.0.0/guides/erc20-permit.mdx
+++ b/content/contracts-cairo/1.0.0/guides/erc20-permit.mdx
@@ -15,9 +15,9 @@ Although this extension is mostly similar to the [Solidity implementation](https
 
 <Callout>
 Unlike Solidity, there is no enforced format for signatures on Starknet. A signature is represented by an array or span of felts,
-</Callout>
 and there is no universal method for validating signatures of unknown formats. Consequently, a signature provided to the [permit](/api/erc20#ERC20Component-permit) function
 is validated through an external `is_valid_signature` call to the contract at the `owner` address.
+</Callout>
 
 ## Usage
 

--- a/content/contracts-cairo/1.0.0/guides/snip12.mdx
+++ b/content/contracts-cairo/1.0.0/guides/snip12.mdx
@@ -229,8 +229,8 @@ Finally, the full implementation of the `CustomERC20` contract looks like this:
 
 <Callout>
 We are using the [`ISRC6Dispatcher`](/api/account#ISRC6) to verify the signature,
-</Callout>
 and the [`NoncesComponent`](/api/utilities#NoncesComponent) to handle nonces to prevent replay attacks.
+</Callout>
 
 ```cairo
 use core::hash::{HashStateExTrait, HashStateTrait};

--- a/content/contracts-cairo/1.0.0/guides/src5-migration.mdx
+++ b/content/contracts-cairo/1.0.0/guides/src5-migration.mdx
@@ -97,8 +97,8 @@ Finally, `migrate` should include a reinitialization check to ensure that it can
 
 <Callout type='warn'>
 If the original contract implemented `Initializable` at any point and called the `initialize` method, the `InitializableComponent` will not be usable at this time.
-</Callout>
 Instead, the contract can take inspiration from `InitializableComponent` and create its own initialization mechanism.
+</Callout>
 
 ```cairo
 #[starknet::contract]

--- a/content/contracts-cairo/1.0.0/interfaces.mdx
+++ b/content/contracts-cairo/1.0.0/interfaces.mdx
@@ -49,8 +49,8 @@ They describe a contract’s complete interface. This is useful to interface wit
 
 <Callout>
 The library offers an ABI trait for most components, providing all external function signatures
-</Callout>
 even when most of the time all of them don’t need to be implemented at the same time. This can be helpful when interacting with a contract implementing the component, instead of defining a new dispatcher.
+</Callout>
 
 ```cairo
 #[starknet::interface]
@@ -92,16 +92,16 @@ Other types of dispatchers are also auto-generated from the annotated trait. See
 
 <Callout>
 In the example, the `IERC20Dispatcher` is the one used to interact with contracts, but the
-</Callout>
 `IERC20DispatcherTrait` needs to be in scope for the functions to be available.
+</Callout>
 
 ## Dual interfaces
 
 <Callout type='warn'>
 `camelCase` functions are deprecated and maintained only for Backwards Compatibility.
-</Callout>
 It’s recommended to only use `snake_case` interfaces with contracts and components. The `camelCase` functions will be removed in
 future versions.
+</Callout>
 
 Following the [Great Interface Migration](https://community.starknet.io/t/the-great-interface-migration/92107) plan, we added `snake_case` functions to all of our preexisting `camelCase` contracts with the goal of eventually dropping support for the latter.
 

--- a/content/contracts-cairo/1.0.0/introspection.mdx
+++ b/content/contracts-cairo/1.0.0/introspection.mdx
@@ -133,5 +133,5 @@ mod MyContract {
 
 <Callout>
 If you are unsure whether a contract implements SRC5 or not, you can follow the process described in
-</Callout>
 [here](https://github.com/starknet-io/SNIPs/blob/main/SNIPS/snip-5.md#how-to-detect-if-a-contract-implements-src-5).
+</Callout>

--- a/content/contracts-cairo/1.0.0/security.mdx
+++ b/content/contracts-cairo/1.0.0/security.mdx
@@ -214,5 +214,5 @@ mod MyReentrancyContract {
 
 <Callout>
 The guard prevents the execution flow occurring inside `protected_function`
-</Callout>
 to call itself or `another_protected_function`, and vice versa.
+</Callout>

--- a/content/contracts-cairo/1.0.0/udc.mdx
+++ b/content/contracts-cairo/1.0.0/udc.mdx
@@ -110,9 +110,9 @@ The latest iteration of the UDC includes some notable changes to the API which i
 
 <Callout type='warn'>
 Origin-dependent deployments previously meant that the `unique` argument would be `true`.
-</Callout>
 Origin-dependent deployments from the new UDC iteration, however, requires that `from_zero` is `false`.
 It’s especially important to keep this in mind when dealing with `ContractDeployed` events because this change will appear as the opposite boolean per deployment type.
+</Callout>
 
 ## Precomputing contract addresses
 

--- a/content/contracts-cairo/2.0.0/access.mdx
+++ b/content/contracts-cairo/2.0.0/access.mdx
@@ -100,8 +100,8 @@ after an initial stage with centralized administration is over.
 
 <Callout type='warn'>
 Removing the owner altogether will mean that administrative tasks that are protected by `assert_only_owner`
-</Callout>
 will no longer be callable!
+</Callout>
 
 ### Two step transfer
 
@@ -243,8 +243,8 @@ mod MyContract {
 
 <Callout type='warn'>
 Make sure you fully understand how [AccessControl](api/access#AccessControlComponent) works before
-</Callout>
 using it on your system, or copy-pasting the examples from this guide.
+</Callout>
 
 While clear and explicit, this isn’t anything we wouldn’t have been able to achieve with
 [Ownable](api/access#OwnableComponent). Where [AccessControl](api/access#AccessControlComponent) shines the most is in scenarios where granular
@@ -445,8 +445,8 @@ mod MyContract {
 
 <Callout>
 The `grant_role` and `revoke_role` functions are automatically exposed as `external` functions
-</Callout>
 from the `AccessControlImpl` by leveraging the `#[abi(embed_v0)]` annotation.
+</Callout>
 
 Note that, unlike the previous examples, no accounts are granted the 'minter' or 'burner' roles.
 However, because those roles' admin role is the default admin role, and that role was granted to the 'admin', that

--- a/content/contracts-cairo/2.0.0/components.mdx
+++ b/content/contracts-cairo/2.0.0/components.mdx
@@ -229,8 +229,8 @@ mod Account {
 
 <Callout type='warn'>
 Failing to use a component’s `initializer` can result in irreparable contract deployments.
-</Callout>
 Always read the API documentation for each integrated component.
+</Callout>
 
 Some components require some sort of setup upon construction.
 Usually, this would be a job for a constructor; however, components themselves cannot implement constructors.
@@ -438,8 +438,8 @@ mod MyContract {
 
 <Callout type='warn'>
 Customizing implementations and accessing component storage can potentially corrupt the state, bypass security checks, and undermine the component logic.
-</Callout>
 **Exercise extreme caution**. See [Security](#security).
+</Callout>
 
 ### Hooks
 

--- a/content/contracts-cairo/2.0.0/erc1155.mdx
+++ b/content/contracts-cairo/2.0.0/erc1155.mdx
@@ -155,8 +155,8 @@ In the spirit of the standard, we’ve also included batch operations in the non
 
 <Callout type='warn'>
 While [safe_transfer_from](/api/erc1155#IERC1155-safe_transfer_from) and [safe_batch_transfer_from](/api/erc1155#IERC1155-safe_batch_transfer_from) prevent loss by checking the receiver can handle the
-</Callout>
 tokens, this yields execution to the receiver which can result in a [reentrant call](security#reentrancy-guard).
+</Callout>
 
 ## Receiving tokens
 

--- a/content/contracts-cairo/2.0.0/erc20.mdx
+++ b/content/contracts-cairo/2.0.0/erc20.mdx
@@ -7,9 +7,9 @@ The ERC20 token standard is a specification for [fungible tokens](https://docs.o
 
 <Callout type='warn'>
 Prior to [Contracts v0.7.0](https://github.com/OpenZeppelin/cairo-contracts/releases/tag/v0.7.0), ERC20 contracts store and read `decimals` from storage; however, this implementation returns a static `18`.
-</Callout>
 If upgrading an older ERC20 contract that has a decimals value other than `18`, the upgraded contract **must** use a custom `decimals` implementation.
 See the [Customizing decimals](/erc20#customizing_decimals) guide.
+</Callout>
 
 ## Usage
 

--- a/content/contracts-cairo/2.0.0/finance.mdx
+++ b/content/contracts-cairo/2.0.0/finance.mdx
@@ -12,13 +12,13 @@ This structure allows ownership rights of both the contract and the vested token
 
 <Callout>
 Any assets transferred to this contract will follow the vesting schedule as if they were locked from the beginning of the vesting period.
-</Callout>
 As a result, if the vesting has already started, a portion of the newly transferred tokens may become immediately releasable.
+</Callout>
 
 <Callout>
 By setting the duration to 0, it’s possible to configure this contract to behave like an asset timelock that holds tokens
-</Callout>
 for a beneficiary until a specified date.
+</Callout>
 
 ### Vesting schedule
 
@@ -28,9 +28,9 @@ implementation of the [VestingSchedule](api/finance#VestingComponent-Vesting-Sch
 
 <Callout>
 There’s a ready-made implementation of the [VestingSchedule](api/finance#VestingComponent-Vesting-Schedule) trait available named [LinearVestingSchedule](api/finance#LinearVestingSchedule).
-</Callout>
 It incorporates a cliff period by returning 0 vested amount until the cliff ends. After the cliff, the vested amount
 is calculated as directly proportional to the time elapsed since the beginning of the vesting schedule.
+</Callout>
 
 ### Usage
 

--- a/content/contracts-cairo/2.0.0/governance/governor.mdx
+++ b/content/contracts-cairo/2.0.0/governance/governor.mdx
@@ -31,9 +31,9 @@ The library currently does not include a wrapper for tokens, but it will be adde
 
 <Callout>
 Currently, the clock mode is fixed to block timestamps, since the Votes component uses the block timestamp to track
-</Callout>
 checkpoints. We plan to add support for more flexible clock modes in Votes in a future release, allowing to use, for example,
 block numbers instead.
+</Callout>
 
 ### Governor
 
@@ -228,8 +228,8 @@ GovernorTimelockExecution extension.
 
 <Callout type='warn'>
 When using a timelock, it is the timelock that will execute proposals and thus the timelock that should
-</Callout>
 hold any funds, ownership, and access control roles.
+</Callout>
 
 TimelockController uses an [AccessControl](access#role_based_accesscontrol) setup that we need to understand in order to set up roles.
 

--- a/content/contracts-cairo/2.0.0/governance/multisig.mdx
+++ b/content/contracts-cairo/2.0.0/governance/multisig.mdx
@@ -30,8 +30,8 @@ Component supports adding, removing, or replacing signers.
 
 <Callout>
 To prevent unauthorized modifications, only the contract itself can add, remove, or replace signers or change the quorum.
-</Callout>
 This ensures that all modifications pass through the multisig approval process.
+</Callout>
 
 ## Transaction lifecycle
 

--- a/content/contracts-cairo/2.0.0/governance/timelock.mdx
+++ b/content/contracts-cairo/2.0.0/governance/timelock.mdx
@@ -63,8 +63,8 @@ Therefore, the initial proposers may also cancel operations after they are sched
 
 <Callout type='warn'>
 The `DEFAULT_ADMIN_ROLE` is a sensitive role that will be granted automatically to the timelock itself and optionally to a second account.
-</Callout>
 The latter case may be required to ease a contract’s initial configuration; however, this role should promptly be renounced.
+</Callout>
 
 Furthermore, the timelock component supports the concept of open roles for the `EXECUTOR_ROLE`.
 This allows anyone to execute an operation once it’s in the `Ready` OperationState.

--- a/content/contracts-cairo/2.0.0/guides/erc20-permit.mdx
+++ b/content/contracts-cairo/2.0.0/guides/erc20-permit.mdx
@@ -15,9 +15,9 @@ Although this extension is mostly similar to the [Solidity implementation](https
 
 <Callout>
 Unlike Solidity, there is no enforced format for signatures on Starknet. A signature is represented by an array or span of felts,
-</Callout>
 and there is no universal method for validating signatures of unknown formats. Consequently, a signature provided to the [permit](/api/erc20#ERC20Component-permit) function
 is validated through an external `is_valid_signature` call to the contract at the `owner` address.
+</Callout>
 
 ## Usage
 

--- a/content/contracts-cairo/2.0.0/guides/snip12.mdx
+++ b/content/contracts-cairo/2.0.0/guides/snip12.mdx
@@ -230,8 +230,8 @@ Finally, the full implementation of the `CustomERC20` contract looks like this:
 
 <Callout>
 We are using the [`ISRC6Dispatcher`](/api/account#ISRC6) to verify the signature,
-</Callout>
 and the [`NoncesComponent`](/api/utilities#NoncesComponent) to handle nonces to prevent replay attacks.
+</Callout>
 
 ```cairo
 use core::hash::{HashStateExTrait, HashStateTrait};

--- a/content/contracts-cairo/2.0.0/guides/src5-migration.mdx
+++ b/content/contracts-cairo/2.0.0/guides/src5-migration.mdx
@@ -97,8 +97,8 @@ Finally, `migrate` should include a reinitialization check to ensure that it can
 
 <Callout type='warn'>
 If the original contract implemented `Initializable` at any point and called the `initialize` method, the `InitializableComponent` will not be usable at this time.
-</Callout>
 Instead, the contract can take inspiration from `InitializableComponent` and create its own initialization mechanism.
+</Callout>
 
 ```cairo
 #[starknet::contract]

--- a/content/contracts-cairo/2.0.0/interfaces.mdx
+++ b/content/contracts-cairo/2.0.0/interfaces.mdx
@@ -49,8 +49,8 @@ They describe a contract’s complete interface. This is useful to interface wit
 
 <Callout>
 The library offers an ABI trait for most components, providing all external function signatures
-</Callout>
 even when most of the time all of them don’t need to be implemented at the same time. This can be helpful when interacting with a contract implementing the component, instead of defining a new dispatcher.
+</Callout>
 
 ```cairo
 #[starknet::interface]
@@ -92,16 +92,16 @@ Other types of dispatchers are also auto-generated from the annotated trait. See
 
 <Callout>
 In the example, the `IERC20Dispatcher` is the one used to interact with contracts, but the
-</Callout>
 `IERC20DispatcherTrait` needs to be in scope for the functions to be available.
+</Callout>
 
 ## Dual interfaces
 
 <Callout type='warn'>
 `camelCase` functions are deprecated and maintained only for Backwards Compatibility.
-</Callout>
 It’s recommended to only use `snake_case` interfaces with contracts and components. The `camelCase` functions will be removed in
 future versions.
+</Callout>
 
 Following the [Great Interface Migration](https://community.starknet.io/t/the-great-interface-migration/92107) plan, we added `snake_case` functions to all of our preexisting `camelCase` contracts with the goal of eventually dropping support for the latter.
 

--- a/content/contracts-cairo/2.0.0/introspection.mdx
+++ b/content/contracts-cairo/2.0.0/introspection.mdx
@@ -133,5 +133,5 @@ mod MyContract {
 
 <Callout>
 If you are unsure whether a contract implements SRC5 or not, you can follow the process described in
-</Callout>
 [here](https://github.com/starknet-io/SNIPs/blob/main/SNIPS/snip-5.md#how-to-detect-if-a-contract-implements-src-5).
+</Callout>

--- a/content/contracts-cairo/2.0.0/macros/type_hash.mdx
+++ b/content/contracts-cairo/2.0.0/macros/type_hash.mdx
@@ -101,8 +101,8 @@ The list of supported collection types as defined in the SNIP-12 standard is:
 
 <Callout>
 While Span is not directly supported by the SNIP-12 standard, it is treated as an array for the purposes of this macro, since
-</Callout>
-it is sometimes helpful to use `Span<felt252>` instead of `Array<felt252>` in order to save on gas.
+it is sometimes helpful to use `Span
+</Callout><felt252>` instead of `Array<felt252>` in order to save on gas.
 
 ### Examples
 

--- a/content/contracts-cairo/2.0.0/macros/type_hash.mdx
+++ b/content/contracts-cairo/2.0.0/macros/type_hash.mdx
@@ -101,8 +101,8 @@ The list of supported collection types as defined in the SNIP-12 standard is:
 
 <Callout>
 While Span is not directly supported by the SNIP-12 standard, it is treated as an array for the purposes of this macro, since
-it is sometimes helpful to use `Span
-</Callout><felt252>` instead of `Array<felt252>` in order to save on gas.
+it is sometimes helpful to use `Span<felt252>` instead of `Array<felt252>` in order to save on gas.
+</Callout>
 
 ### Examples
 

--- a/content/contracts-cairo/2.0.0/macros/with_components.mdx
+++ b/content/contracts-cairo/2.0.0/macros/with_components.mdx
@@ -13,8 +13,8 @@ This macro simplifies the syntax for adding a set of components to a contract. I
 
 <Callout type='warn'>
 Since the macro does not expose any external implementations, developers must make sure to specify explicitly
-</Callout>
 the ones required by the contract.
+</Callout>
 
 ## Security considerations
 

--- a/content/contracts-cairo/2.0.0/security.mdx
+++ b/content/contracts-cairo/2.0.0/security.mdx
@@ -214,5 +214,5 @@ mod MyReentrancyContract {
 
 <Callout>
 The guard prevents the execution flow occurring inside `protected_function`
-</Callout>
 to call itself or `another_protected_function`, and vice versa.
+</Callout>

--- a/content/contracts-cairo/guides/deploy-udc.mdx
+++ b/content/contracts-cairo/guides/deploy-udc.mdx
@@ -79,8 +79,8 @@ with this functionality enabled.
 
 <Callout>
 Madara declares an account with this functionality enabled as part of the bootstrapping process. You may be able to
-</Callout>
 use that implementation directly to skip this step.
+</Callout>
 
 #### Bootstrapper Contract
 
@@ -214,8 +214,8 @@ sncast -p <profile-name> declare \
 
 <Callout>
 If you followed the [Note on the UDC final address](#note_on_the_udc_final_address) section, your declared class hash should be
-</Callout>
 `0x01b2df6d8861670d4a8ca4670433b2418d78169c2947f46dc614e69f333745c8`.
+</Callout>
 
 #### Previewing the UDC address
 

--- a/content/contracts-compact/api/access.mdx
+++ b/content/contracts-compact/api/access.mdx
@@ -130,8 +130,8 @@ Grants `roleId` to `account`.
 
 <Callout>
 Granting roles to contract addresses is currently disallowed until contract-to-contract interactions are supported in Compact.
-</Callout>
 This restriction prevents permanently disabling access to a circuit.
+</Callout>
 
 Requirements:
 
@@ -207,8 +207,8 @@ Internal circuit without access restriction.
 
 <Callout>
 Granting roles to contract addresses is currently disallowed in this circuit until contract-to-contract interactions are supported in Compact.
-</Callout>
 This restriction prevents permanently disabling access to a circuit.
+</Callout>
 
 Requirements:
 
@@ -228,9 +228,9 @@ Unsafe variant of [_grantRole](#_grantrole).
 
 <Callout type='warn'>
 Granting roles to contract addresses is considered unsafe because contract-to-contract calls are not currently supported.
-</Callout>
 Granting a role to a smart contract may render a circuit permanently inaccessible.
 Once contract-to-contract calls are supported, this circuit may be deprecated.
+</Callout>
 
 Constraints:
 

--- a/content/contracts-compact/api/fungibleToken.mdx
+++ b/content/contracts-compact/api/fungibleToken.mdx
@@ -150,8 +150,8 @@ Moves a `value` amount of tokens from the caller’s account to `to`.
 
 <Callout>
 Transfers to contract addresses are currently disallowed until contract-to-contract interactions are supported in Compact.
-</Callout>
 This restriction prevents assets from being inadvertently locked in contracts that cannot currently handle token receipt.
+</Callout>
 
 Requirements:
 
@@ -174,8 +174,8 @@ Unsafe variant of [transfer](#transfer) which allows transfers to contract addre
 
 <Callout type='warn'>
 Transfers to contract addresses are considered unsafe because contract-to-contract calls are not currently supported. Tokens sent to a contract address may become irretrievable.
-</Callout>
 Once contract-to-contract calls are supported, this circuit may be deprecated.
+</Callout>
 
 Requirements:
 
@@ -232,8 +232,8 @@ Moves `value` tokens from `from` to `to` using the allowance mechanism.
 
 <Callout>
 Transfers to contract addresses are currently disallowed until contract-to-contract interactions are supported in Compact.
-</Callout>
 This restriction prevents assets from being inadvertently locked in contracts that cannot currently handle token receipt.
+</Callout>
 
 Requirements:
 
@@ -258,9 +258,9 @@ Unsafe variant of [transferFrom](#transferfrom) which allows transfers to contra
 
 <Callout type='warn'>
 Transfers to contract addresses are considered unsafe because contract-to-contract calls are not currently supported.
-</Callout>
 Tokens sent to a contract address may become irretrievable.
 Once contract-to-contract calls are supported, this circuit may be deprecated.
+</Callout>
 
 Requirements:
 
@@ -286,8 +286,8 @@ implement automatic token fees, slashing mechanisms, etc.
 
 <Callout>
 Transfers to contract addresses are currently disallowed until contract-to-contract interactions are supported in Compact.
-</Callout>
 This restriction prevents assets from being inadvertently locked in contracts that cannot currently handle token receipt.
+</Callout>
 
 Requirements:
 
@@ -311,8 +311,8 @@ Unsafe variant of [_transfer](#_transfer) which allows transfers to contract add
 
 <Callout type='warn'>
 Transfers to contract addresses are considered unsafe because contract-to-contract calls are not currently supported. Tokens sent to a contract address may become irretrievable.
-</Callout>
 Once contract-to-contract calls are supported, this circuit may be deprecated.
+</Callout>
 
 Requirements:
 
@@ -370,9 +370,9 @@ Unsafe variant of [_mint](#_mint) which allows transfers to contract addresses.
 
 <Callout type='warn'>
 Transfers to contract addresses are considered unsafe because contract-to-contract calls are not currently supported.
-</Callout>
 Tokens sent to a contract address may become irretrievable.
 Once contract-to-contract calls are supported, this circuit may be deprecated.
+</Callout>
 
 Requirements:
 

--- a/content/contracts-compact/api/multitoken.mdx
+++ b/content/contracts-compact/api/multitoken.mdx
@@ -145,8 +145,8 @@ The caller must be `from` or approved to transfer on their behalf.
 
 <Callout>
 Transfers to contract addresses are currently disallowed until contract-to-contract interactions are supported in Compact.
-</Callout>
 This restriction prevents assets from being inadvertently locked in contracts that cannot currently handle token receipt.
+</Callout>
 
 Requirements:
 
@@ -174,8 +174,8 @@ Does not impose restrictions on the caller, making it suitable for composition i
 
 <Callout>
 Transfers to contract addresses are currently disallowed until contract-to-contract interactions are supported in Compact.
-</Callout>
 This restriction prevents assets from being inadvertently locked in contracts that cannot currently handle token receipt.
+</Callout>
 
 Requirements:
 
@@ -222,8 +222,8 @@ The caller must be `from` or approved to transfer on their behalf.
 
 <Callout type='warn'>
 Transfers to contract addresses are considered unsafe because contract-to-contract calls are not currently supported. Tokens sent to a contract address may become irretrievable.
-</Callout>
 Once contract-to-contract calls are supported, this circuit may be deprecated.
+</Callout>
 
 Requirements:
 
@@ -250,8 +250,8 @@ Does not impose restrictions on the caller, making it suitable as a low-level bu
 
 <Callout type='warn'>
 Transfers to contract addresses are considered unsafe because contract-to-contract calls are not currently supported. Tokens sent to a contract address may become irretrievable.
-</Callout>
 Once contract-to-contract calls are supported, this circuit may be deprecated.
+</Callout>
 
 Requirements:
 
@@ -301,8 +301,8 @@ Creates a `value` amount of tokens of type `token_id`, and assigns them to `to`.
 
 <Callout>
 Transfers to contract addresses are currently disallowed until contract-to-contract interactions are supported in Compact.
-</Callout>
 This restriction prevents assets from being inadvertently locked in contracts that cannot currently handle token receipt.
+</Callout>
 
 Requirements:
 
@@ -326,9 +326,9 @@ Unsafe variant of `_mint` which allows transfers to contract addresses.
 
 <Callout type='warn'>
 Transfers to contract addresses are considered unsafe because contract-to-contract calls are not currently supported.
-</Callout>
 Tokens sent to a contract address may become irretrievable.
 Once contract-to-contract calls are supported, this circuit may be deprecated.
+</Callout>
 
 Requirements:
 

--- a/content/contracts-compact/api/nonFungibleToken.mdx
+++ b/content/contracts-compact/api/nonFungibleToken.mdx
@@ -159,9 +159,9 @@ Requirements:
 
 <Callout>
 Native strings and string operations aren’t supported within the Compact language, e.g. concatenating a base URI + token ID is not possible like in other NFT implementations.
-</Callout>
 Therefore, we propose the URI storage approach; whereby, NFTs may or may not have unique "base" URIs.
 It’s up to the implementation to decide on how to handle this.
+</Callout>
 
 Constraints:
 
@@ -282,8 +282,8 @@ Transfers `tokenId` token from `from` to `to`.
 
 <Callout>
 Transfers to contract addresses are currently disallowed until contract-to-contract interactions are supported in Compact.
-</Callout>
 This restriction prevents assets from being inadvertently locked in contracts that cannot currently handle token receipt.
+</Callout>
 
 Requirements:
 
@@ -310,9 +310,9 @@ Unsafe variant of [transferFrom](#transferfrom) which allows transfers to contra
 
 <Callout type='warn'>
 Transfers to contract addresses are considered unsafe because contract-to-contract calls are not currently supported.
-</Callout>
 Tokens sent to a contract address may become irretrievable.
 Once contract-to-contract calls are supported, this circuit may be deprecated.
+</Callout>
 
 Requirements:
 
@@ -466,9 +466,9 @@ Requirements:
 
 <Callout type='warn'>
 Transfers to contract addresses are considered unsafe because contract-to-contract calls are not currently supported.
-</Callout>
 Tokens sent to a contract address may become irretrievable.
 Once contract-to-contract calls are supported, this circuit may be deprecated.
+</Callout>
 
 Constraints:
 
@@ -507,8 +507,8 @@ Transfers `tokenId` from `from` to `to`. As opposed to [transferFrom](#transferf
 
 <Callout>
 Transfers to contract addresses are currently disallowed until contract-to-contract interactions are supported in Compact.
-</Callout>
 This restriction prevents assets from being inadvertently locked in contracts that cannot currently handle token receipt.
+</Callout>
 
 Requirements:
 
@@ -535,8 +535,8 @@ Transfers `tokenId` from `from` to `to`. As opposed to [_unsafeTransferFrom](#_u
 
 <Callout type='warn'>
 Transfers to contract addresses are considered unsafe because contract-to-contract calls are not currently supported. Tokens sent to a contract address may become irretrievable.
-</Callout>
 Once contract-to-contract calls are supported, this circuit may be deprecated.
+</Callout>
 
 Requirements:
 

--- a/content/contracts-compact/api/ownable.mdx
+++ b/content/contracts-compact/api/ownable.mdx
@@ -74,8 +74,8 @@ Transfers ownership of the contract to `newOwner`.
 
 <Callout>
 Ownership transfers to contract addresses are currently disallowed until contract-to-contract interactions are supported in Compact.
-</Callout>
 This restriction prevents permanently disabling access to a circuit.
+</Callout>
 
 Requirements:
 
@@ -98,9 +98,9 @@ Unsafe variant of [`transferOwnership`](#transferownership).
 
 <Callout type='warn'>
 Ownership transfers to contract addresses are considered unsafe because contract-to-contract calls are not currently supported.
-</Callout>
 Ownership privileges sent to a contract address may become uncallable.
 Once contract-to-contract calls are supported, this circuit may be deprecated.
+</Callout>
 
 Requirements:
 
@@ -159,8 +159,8 @@ Transfers ownership of the contract to a `newOwner` without enforcing permission
 
 <Callout>
 Ownership transfers to contract addresses are currently disallowed until contract-to-contract interactions are supported in Compact.
-</Callout>
 This restriction prevents permanently disabling access to a circuit.
+</Callout>
 
 Requirements:
 
@@ -181,9 +181,9 @@ Unsafe variant of [`_transferOwnership`](#_transferownership).
 
 <Callout type='warn'>
 Ownership transfers to contract addresses are considered unsafe because contract-to-contract calls are not currently supported.
-</Callout>
 Ownership privileges sent to a contract address may become uncallable.
 Once contract-to-contract calls are supported, this circuit may be deprecated.
+</Callout>
 
 Requirements:
 

--- a/content/contracts-compact/ownable.mdx
+++ b/content/contracts-compact/ownable.mdx
@@ -108,5 +108,5 @@ export circuit mySensitiveCircuit(): []
 
 <Callout>
 For more complex logic, contracts may transfer ownership to another user irrespective of the caller by leveraging [_transferOwnership](api/ownable#Ownable-_transferOwnership).
-</Callout>
 This is generally more useful when contract addresses are the owner or when a contract has a unique deployment process.
+</Callout>

--- a/content/contracts-stylus/0.1.0/erc721.mdx
+++ b/content/contracts-stylus/0.1.0/erc721.mdx
@@ -59,8 +59,8 @@ For more information about erc721 schema, check out the [ERC-721 specification](
 
 <Callout>
 You’ll notice that the item’s information is included in the metadata, but that information isn’t on-chain!
-</Callout>
 So a game developer could change the underlying metadata, changing the rules of the game!
+</Callout>
 
 ## Extensions
 

--- a/content/contracts-stylus/0.2.0/erc721.mdx
+++ b/content/contracts-stylus/0.2.0/erc721.mdx
@@ -159,8 +159,8 @@ For more information about erc721 schema, check out the [ERC-721 specification](
 
 <Callout>
 You’ll notice that the item’s information is included in the metadata, but that information isn’t on-chain!
-</Callout>
 So a game developer could change the underlying metadata, changing the rules of the game!
+</Callout>
 
 ## Extensions
 

--- a/content/contracts-stylus/erc721.mdx
+++ b/content/contracts-stylus/erc721.mdx
@@ -159,8 +159,8 @@ For more information about erc721 schema, check out the [ERC-721 specification](
 
 <Callout>
 You’ll notice that the item’s information is included in the metadata, but that information isn’t on-chain!
-</Callout>
 So a game developer could change the underlying metadata, changing the rules of the game!
+</Callout>
 
 ## Extensions
 

--- a/content/contracts-stylus/uups-proxy.mdx
+++ b/content/contracts-stylus/uups-proxy.mdx
@@ -201,8 +201,8 @@ fn initialize(&mut self, self_address: Address, owner: Address) -> Result<(), ow
 
 <Callout>
 initialize is typically called only once during deployment, but since it’s public,
-</Callout>
 you must protect it from being re-executed after the proxy is live.
+</Callout>
 
 ## Initializing the Proxy
 

--- a/content/contracts/3.x/api/GSN.mdx
+++ b/content/contracts/3.x/api/GSN.mdx
@@ -30,12 +30,12 @@ and enables GSN support on all contracts in the inheritance tree.
 
 <Callout>
 This contract is abstract. The functions IRelayRecipient-acceptRelayedCall,
-</Callout>
  _preRelayedCall, and _postRelayedCall are not implemented and must be
 provided by derived contracts. See the
 [GSN strategies](ROOT:gsn-strategies#gsn-strategies) for more
 information on how to use the pre-built GSNRecipientSignature and
 GSNRecipientERC20Fee, or how to write your own.
+</Callout>
 
 **Functions**
 
@@ -77,8 +77,8 @@ use the default instance.
 
 <Callout type='warn'>
 After upgrading, the GSNRecipient will no longer be able to receive relayed calls from the old
-</Callout>
 IRelayHub instance. Additionally, all funds should be previously withdrawn via _withdrawDeposits.
+</Callout>
 
 <a id="GSNRecipient-relayHubVersion"></a>
 

--- a/content/contracts/3.x/api/access.mdx
+++ b/content/contracts/3.x/api/access.mdx
@@ -69,8 +69,8 @@ Leaves the contract without owner. It will not be possible to call
 
 <Callout>
 Renouncing ownership will leave the contract without an owner,
-</Callout>
 thereby removing any functionality that is only available to the owner.
+</Callout>
 
 <a id="Ownable-transferOwnership"></a>
 
@@ -117,9 +117,9 @@ _setRoleAdmin.
 
 <Callout type='warn'>
 The `DEFAULT_ADMIN_ROLE` is also its own admin: it has permission to
-</Callout>
 grant and revoke this role. Extra precautions should be taken to secure
 accounts that have been granted it.
+</Callout>
 
 **Functions**
 
@@ -164,10 +164,10 @@ change at any point.
 
 <Callout type='warn'>
 When using getRoleMember and getRoleMemberCount, make sure
-</Callout>
 you perform all queries on the same block. See the following
 [forum post](https://forum.openzeppelin.com/t/iterating-over-elements-on-enumerableset-in-openzeppelin-contracts/2296)
 for more information.
+</Callout>
 
 <a id="Ownable-getRoleAdmin"></a>
 

--- a/content/contracts/3.x/api/cryptography.mdx
+++ b/content/contracts/3.x/api/cryptography.mdx
@@ -40,11 +40,11 @@ half order, and the `v` value to be either 27 or 28.
 
 <Callout type='warn'>
 `hash` _must_ be the result of a hash operation for the
-</Callout>
 verification to be secure: it is possible to craft signatures that
 recover to arbitrary addresses for non-hashed data. A safe way to ensure
 this is by receiving a hash of the original message (which may otherwise
 be too long), and then calling toEthSignedMessageHash on it.
+</Callout>
 
 <a id="ECDSA-recover"></a>
 

--- a/content/contracts/3.x/api/drafts.mdx
+++ b/content/contracts/3.x/api/drafts.mdx
@@ -25,8 +25,8 @@ the chain id to protect against replay attacks on an eventual fork of the chain.
 
 <Callout>
 This contract implements the version of the encoding known as "v4", as implemented by the JSON RPC method
-</Callout>
 [`eth_signTypedDataV4` in MetaMask](https://docs.metamask.io/guide/signing-data.html).
+</Callout>
 
 _Available since v3.4._
 
@@ -50,8 +50,8 @@ The meaning of `name` and `version` is specified in
 
 <Callout>
 These parameters cannot be changed except through a [smart
-</Callout>
 contract upgrade](learn::upgrading-smart-contracts).
+</Callout>
 
 <a id="EIP712-_domainSeparatorV4"></a>
 
@@ -103,8 +103,8 @@ given `owner’s signed approval.
 
 <Callout type='warn'>
 The same issues IERC20-approve has related to transaction
-</Callout>
 ordering also apply here.
+</Callout>
 
 Emits an Approval event.
 

--- a/content/contracts/3.x/api/math.mdx
+++ b/content/contracts/3.x/api/math.mdx
@@ -158,8 +158,8 @@ overflow (when the result is negative).
 
 <Callout type='warn'>
 This function is deprecated because it requires allocating memory for the error
-</Callout>
 message unnecessarily. For custom revert reasons use trySub.
+</Callout>
 
 Counterpart to Solidity’s `-` operator.
 
@@ -176,8 +176,8 @@ division by zero. The result is rounded towards zero.
 
 <Callout type='warn'>
 This function is deprecated because it requires allocating memory for the error
-</Callout>
 message unnecessarily. For custom revert reasons use tryDiv.
+</Callout>
 
 Counterpart to Solidity’s `/` operator. Note: this function uses a
 `revert` opcode (which leaves remaining gas untouched) while Solidity
@@ -196,8 +196,8 @@ reverting with custom message when dividing by zero.
 
 <Callout type='warn'>
 This function is deprecated because it requires allocating memory for the error
-</Callout>
 message unnecessarily. For custom revert reasons use tryMod.
+</Callout>
 
 Counterpart to Solidity’s `%` operator. This function uses a `revert`
 opcode (which leaves remaining gas untouched) while Solidity uses an

--- a/content/contracts/3.x/api/payment.mdx
+++ b/content/contracts/3.x/api/payment.mdx
@@ -128,9 +128,9 @@ eliminates reentrancy concerns.
 
 <Callout>
 If you would like to learn more about reentrancy and alternative ways
-</Callout>
 to protect against it, check out our blog post
 [Reentrancy After Istanbul](https://blog.openzeppelin.com/reentrancy-after-istanbul/).
+</Callout>
 
 To use, derive from the `PullPayment` contract, and use _asyncTransfer
 instead of Solidity’s `transfer` function. Payees can query their due
@@ -160,9 +160,9 @@ withdrawPayments.
 
 <Callout type='warn'>
 Forwarding all gas opens the door to reentrancy vulnerabilities.
-</Callout>
 Make sure you trust the recipient, or are either following the
 checks-effects-interactions pattern or using ReentrancyGuard.
+</Callout>
 
 <a id="PaymentSplitter-payments"></a>
 
@@ -234,9 +234,9 @@ recipient.
 
 <Callout type='warn'>
 Forwarding all gas opens the door to reentrancy vulnerabilities.
-</Callout>
 Make sure you trust the recipient, or are either following the
 checks-effects-interactions pattern or using ReentrancyGuard.
+</Callout>
 
 <a id="PaymentSplitter-Deposited"></a>
 

--- a/content/contracts/3.x/api/proxy.mdx
+++ b/content/contracts/3.x/api/proxy.mdx
@@ -227,9 +227,9 @@ Only the admin can call this function. See ProxyAdmin-getProxyAdmin.
 
 <Callout>
 To get this value clients can read directly from the storage slot shown below (specified by EIP1967) using the
-</Callout>
 [`eth_getStorageAt`](https://eth.wiki/json-rpc/API#eth_getstorageat) RPC call.
 `0xb53127684a568b3173ae13b9f8a6016e243e63b6e8ee1178d6a717850b5d6103`
+</Callout>
 
 <a id="Proxy-implementation"></a>
 
@@ -243,9 +243,9 @@ Only the admin can call this function. See ProxyAdmin-getProxyImplementation.
 
 <Callout>
 To get this value clients can read directly from the storage slot shown below (specified by EIP1967) using the
-</Callout>
 [`eth_getStorageAt`](https://eth.wiki/json-rpc/API#eth_getstorageat) RPC call.
 `0x360894a13ba1a3210667c828492db98dca3e2076cc3735a920a3ca505d382bbc`
+</Callout>
 
 <a id="Proxy-changeAdmin"></a>
 
@@ -503,13 +503,13 @@ function so it can only be called once. The initializer modifier provided by thi
 
 <Callout>
 To avoid leaving the proxy in an uninitialized state, the initializer function should be called as early as
-</Callout>
 possible by providing the encoded function call as the `_data` argument to UpgradeableProxy-constructor.
+</Callout>
 
 <Callout type='warn'>
 When used with inheritance, manual care must be taken to not invoke a parent initializer twice, or to ensure
-</Callout>
 that all initializers are idempotent. This is not verified automatically as constructors are by Solidity.
+</Callout>
 
 **Modifiers**
 

--- a/content/contracts/3.x/api/token/ERC20.mdx
+++ b/content/contracts/3.x/api/token/ERC20.mdx
@@ -101,12 +101,12 @@ Returns a boolean value indicating whether the operation succeeded.
 
 <Callout type='warn'>
 Beware that changing an allowance with this method brings the risk
-</Callout>
 that someone may use both the old and the new allowance by unfortunate
 transaction ordering. One possible solution to mitigate this race
 condition is to first reduce the spender’s allowance to 0 and set the
 desired value afterwards:
 https://github.com/ethereum/EIPs/issues/20#issuecomment-263524729
+</Callout>
 
 Emits an Approval event.
 
@@ -148,9 +148,9 @@ For a generic mechanism see ERC20PresetMinterPauser.
 
 <Callout>
 For a detailed writeup see our guide
-</Callout>
 https://forum.zeppelin.solutions/t/how-to-implement-erc20-supply-mechanisms/226[How
 to implement supply mechanisms].
+</Callout>
 
 We have followed general OpenZeppelin guidelines: functions revert instead
 of returning `false` on failure. This behavior is nonetheless conventional
@@ -232,9 +232,9 @@ called.
 
 <Callout>
 This information is only used for _display_ purposes: it in
-</Callout>
 no way affects any of the arithmetic of the contract, including
 IERC20-balanceOf and IERC20-transfer.
+</Callout>
 
 <a id="IERC20-totalSupply"></a>
 
@@ -391,9 +391,9 @@ Sets decimals to a value other than the default one of 18.
 
 <Callout type='warn'>
 This function should only be called from the constructor. Most
-</Callout>
 applications that interact with token contracts will not expect
 decimals to ever change, and may work incorrectly if it does.
+</Callout>
 
 <a id="IERC20-_beforeTokenTransfer"></a>
 

--- a/content/contracts/3.x/api/utils.mdx
+++ b/content/contracts/3.x/api/utils.mdx
@@ -138,9 +138,9 @@ points to them.
 
 <Callout>
 If you would like to learn more about reentrancy and alternative ways
-</Callout>
 to protect against it, check out our blog post
 [Reentrancy After Istanbul](https://blog.openzeppelin.com/reentrancy-after-istanbul/).
+</Callout>
 
 **Modifiers**
 
@@ -221,10 +221,10 @@ imposed by `transfer`, making them unable to receive funds via
 
 <Callout type='warn'>
 because control is transferred to `recipient`, care must be
-</Callout>
 taken to not create reentrancy vulnerabilities. Consider using
 ReentrancyGuard or the
 [checks-effects-interactions pattern](https://solidity.readthedocs.io/en/v0.5.11/security-considerations.html#use-the-checks-effects-interactions-pattern).
+</Callout>
 
 <a id="Pausable-functionCall"></a>
 
@@ -515,8 +515,8 @@ Same as get, with a custom error message when `key` is not in the map.
 
 <Callout type='warn'>
 This function is deprecated because it requires allocating memory for the error
-</Callout>
 message unnecessarily. For custom revert reasons use tryGet.
+</Callout>
 
 ### ``EnumerableSet``
 

--- a/content/contracts/4.x/api/access.mdx
+++ b/content/contracts/4.x/api/access.mdx
@@ -77,10 +77,10 @@ roles. More complex role relationships can be created by using
 
 <Callout type="warn">
 The `DEFAULT_ADMIN_ROLE` is also its own admin: it has permission to
-</Callout>
 grant and revoke this role. Extra precautions should be taken to secure
 accounts that have been granted it. We recommend using [`AccessControlDefaultAdminRules`](#AccessControlDefaultAdminRules)
 to enforce additional security measures for this role.
+</Callout>
 
 <div className="bg-secondary p-4 rounded-md mb-6">
 <h3 style={{ marginTop: "0"}}>Modifiers</h3>
@@ -944,9 +944,9 @@ be overrode for a custom [`AccessControlDefaultAdminRules.defaultAdminDelay`](#A
 
 <Callout type="warn">
 Make sure to add a reasonable amount of time while overriding this value, otherwise,
-</Callout>
 there's a risk of setting a high new delay that goes into effect almost immediately without the
 possibility of human intervention in the case of an input error (eg. set milliseconds instead of seconds).
+</Callout>
 
 </div>
 </div>
@@ -1304,10 +1304,10 @@ change at any point.
 
 <Callout type="warn">
 When using [`AccessControlEnumerable.getRoleMember`](#AccessControlEnumerable-getRoleMember-bytes32-uint256-) and [`AccessControlEnumerable.getRoleMemberCount`](#AccessControlEnumerable-getRoleMemberCount-bytes32-), make sure
-</Callout>
 you perform all queries on the same block. See the following
 [forum post](https://forum.openzeppelin.com/t/iterating-over-elements-on-enumerableset-in-openzeppelin-contracts/2296)
 for more information.
+</Callout>
 
 </div>
 </div>
@@ -1885,9 +1885,9 @@ be overrode for a custom [`AccessControlDefaultAdminRules.defaultAdminDelay`](#A
 
 <Callout type="warn">
 Make sure to add a reasonable amount of time while overriding this value, otherwise,
-</Callout>
 there's a risk of setting a high new delay that goes into effect almost immediately without the
 possibility of human intervention in the case of an input error (eg. set milliseconds instead of seconds).
+</Callout>
 
 </div>
 </div>
@@ -2026,10 +2026,10 @@ change at any point.
 
 <Callout type="warn">
 When using [`AccessControlEnumerable.getRoleMember`](#AccessControlEnumerable-getRoleMember-bytes32-uint256-) and [`AccessControlEnumerable.getRoleMemberCount`](#AccessControlEnumerable-getRoleMemberCount-bytes32-), make sure
-</Callout>
 you perform all queries on the same block. See the following
 [forum post](https://forum.openzeppelin.com/t/iterating-over-elements-on-enumerableset-in-openzeppelin-contracts/2296)
 for more information.
+</Callout>
 
 </div>
 </div>

--- a/content/contracts/4.x/api/crosschain.mdx
+++ b/content/contracts/4.x/api/crosschain.mdx
@@ -149,8 +149,8 @@ triggered the current function call.
 
 <Callout type="warn">
 Should revert with `NotCrossChainCall` if the current function
-</Callout>
 call is not the result of a cross-chain message.
+</Callout>
 
 </div>
 </div>
@@ -431,10 +431,10 @@ _Available since v4.6._
 
 <Callout type="warn">
 There is currently a bug in Arbitrum that causes this contract to
-</Callout>
 fail to detect cross-chain calls when deployed behind a proxy. This will be
 fixed when the network is upgraded to Arbitrum Nitro, currently scheduled for
 August 31st 2022.
+</Callout>
 
 <div className="bg-secondary p-4 rounded-md mb-6">
 <h3 style={{ marginTop: "0"}}>Functions</h3>
@@ -573,10 +573,10 @@ originating from L1. For the other side, use [`LibArbitrumL1`](#LibArbitrumL1).
 
 <Callout type="warn">
 There is currently a bug in Arbitrum that causes this contract to
-</Callout>
 fail to detect cross-chain calls when deployed behind a proxy. This will be
 fixed when the network is upgraded to Arbitrum Nitro, currently scheduled for
 August 31st 2022.
+</Callout>
 
 <div className="bg-secondary p-4 rounded-md mb-6">
 <h3 style={{ marginTop: "0"}}>Functions</h3>

--- a/content/contracts/4.x/api/governance.mdx
+++ b/content/contracts/4.x/api/governance.mdx
@@ -1797,10 +1797,10 @@ Initializes the contract with the following parameters:
 
 <Callout type="warn">
 The optional admin can aid with initial configuration of roles after deployment
-</Callout>
 without being subject to delay, but this role should be subsequently renounced in favor of
 administration through timelocked proposals. Previous versions of this contract would assign
 this admin to the deployer automatically and should be renounced as well.
+</Callout>
 
 </div>
 </div>
@@ -4249,10 +4249,10 @@ inaccessible.
 
 <Callout type="warn">
 Setting up the TimelockController to have additional proposers besides the governor is very risky, as it
-</Callout>
 grants them powers that they must be trusted or known not to use: 1) [`Governor.onlyGovernance`](#Governor-onlyGovernance--) functions like [`Governor.relay`](#Governor-relay-address-uint256-bytes-) are
 available to them through the timelock, and 2) approved governance proposals can be blocked by them, effectively
 executing a Denial of Service attack. This risk will be mitigated in a future release.
+</Callout>
 
 _Available since v4.3._
 

--- a/content/contracts/4.x/api/interfaces.mdx
+++ b/content/contracts/4.x/api/interfaces.mdx
@@ -1533,9 +1533,9 @@ address.
 
 <Callout type="warn">
 A proxy pointing at a proxiable contract should not be considered proxiable itself, because this risks
-</Callout>
 bricking a proxy that upgrades to it, by delegating to itself until out of gas. Thus it is critical that this
 function revert if invoked through a proxy.
+</Callout>
 
 </div>
 </div>

--- a/content/contracts/4.x/api/metatx.mdx
+++ b/content/contracts/4.x/api/metatx.mdx
@@ -31,9 +31,9 @@ Context variant with ERC2771 support.
 
 <Callout type="warn">
 The usage of `delegatecall` in this contract is dangerous and may result in context corruption.
-</Callout>
 Any forwarded request to this contract triggering a `delegatecall` to itself will result in an invalid [`ERC2771Context._msgSender`](#ERC2771Context-_msgSender--)
 recovery.
+</Callout>
 
 <div className="bg-secondary p-4 rounded-md mb-6">
 <h3 style={{ marginTop: "0"}}>Functions</h3>

--- a/content/contracts/4.x/api/proxy.mdx
+++ b/content/contracts/4.x/api/proxy.mdx
@@ -1258,10 +1258,10 @@ implementation.
 
 <Callout type="warn">
 It is not recommended to extend this contract to add additional external functions. If you do so, the compiler
-</Callout>
 will not check that there are no selector conflicts, due to the note above. A selector clash between any new function
 and the functions declared in [`ITransparentUpgradeableProxy`](#ITransparentUpgradeableProxy) will be resolved in favor of the new one. This could
 render the admin operations inaccessible, which could prevent upgradeability. Transparency may also be compromised.
+</Callout>
 
 <div className="bg-secondary p-4 rounded-md mb-6">
 <h3 style={{ marginTop: "0"}}>Modifiers</h3>
@@ -1752,9 +1752,9 @@ implementation. It is used to validate the implementation's compatibility when p
 
 <Callout type="warn">
 A proxy pointing at a proxiable contract should not be considered proxiable itself, because this risks
-</Callout>
 bricking a proxy that upgrades to it, by delegating to itself until out of gas. Thus it is critical that this
 function revert if invoked through a proxy. This is guaranteed by the `notDelegated` modifier.
+</Callout>
 
 </div>
 </div>

--- a/content/contracts/4.x/api/security.mdx
+++ b/content/contracts/4.x/api/security.mdx
@@ -341,9 +341,9 @@ receive funds this way, by having a separate account call
 
 <Callout type="warn">
 Forwarding all gas opens the door to reentrancy vulnerabilities.
-</Callout>
 Make sure you trust the recipient, or are either following the
 checks-effects-interactions pattern or using [`ReentrancyGuard`](#ReentrancyGuard).
+</Callout>
 
 </div>
 </div>

--- a/content/contracts/4.x/api/token/ERC1155.mdx
+++ b/content/contracts/4.x/api/token/ERC1155.mdx
@@ -1001,11 +1001,11 @@ event of a large bug.
 
 <Callout type="warn">
 This contract does not include public pause and unpause functions. In
-</Callout>
 addition to inheriting this contract, you must define both functions, invoking the
 [`Pausable._pause`](../security#Pausable-_pause--) and [`Pausable._unpause`](../security#Pausable-_unpause--) internal functions, with appropriate
 access control, e.g. using [`AccessControl`](../access#AccessControl) or [`Ownable`](../access#Ownable). Not doing so will
 make the contract unpausable.
+</Callout>
 
 _Available since v3.1._
 

--- a/content/contracts/4.x/api/token/ERC20.mdx
+++ b/content/contracts/4.x/api/token/ERC20.mdx
@@ -740,12 +740,12 @@ Returns a boolean value indicating whether the operation succeeded.
 
 <Callout type="warn">
 Beware that changing an allowance with this method brings the risk
-</Callout>
 that someone may use both the old and the new allowance by unfortunate
 transaction ordering. One possible solution to mitigate this race
 condition is to first reduce the spender's allowance to 0 and set the
 desired value afterwards:
 https://github.com/ethereum/EIPs/issues/20#issuecomment-263524729
+</Callout>
 
 Emits an [`IERC20.Approval`](#IERC20-Approval-address-address-uint256-) event.
 
@@ -1216,11 +1216,11 @@ event of a large bug.
 
 <Callout type="warn">
 This contract does not include public pause and unpause functions. In
-</Callout>
 addition to inheriting this contract, you must define both functions, invoking the
 [`Pausable._pause`](../security#Pausable-_pause--) and [`Pausable._unpause`](../security#Pausable-_unpause--) internal functions, with appropriate
 access control, e.g. using [`AccessControl`](../access#AccessControl) or [`Ownable`](../access#Ownable). Not doing so will
 make the contract unpausable.
+</Callout>
 
 <div className="bg-secondary p-4 rounded-md mb-6">
 <h3 style={{ marginTop: "0"}}>Functions</h3>
@@ -1404,8 +1404,8 @@ given ``owner``'s signed approval.
 
 <Callout type="warn">
 The same issues [`IERC20.approve`](#IERC20-approve-address-uint256-) has related to transaction
-</Callout>
 ordering also apply here.
+</Callout>
 
 Emits an [`IERC20.Approval`](#IERC20-Approval-address-address-uint256-) event.
 
@@ -3092,8 +3092,8 @@ given ``owner``'s signed approval.
 
 <Callout type="warn">
 The same issues [`IERC20.approve`](#IERC20-approve-address-uint256-) has related to transaction
-</Callout>
 ordering also apply here.
+</Callout>
 
 Emits an [`IERC20.Approval`](#IERC20-Approval-address-address-uint256-) event.
 

--- a/content/contracts/4.x/api/token/ERC721.mdx
+++ b/content/contracts/4.x/api/token/ERC721.mdx
@@ -745,9 +745,9 @@ Unsafe write access to the balances, used by extensions that "mint" tokens using
 
 <Callout type="warn">
 Anyone calling this MUST ensure that the balances remain consistent with the ownership. The invariant
-</Callout>
 being that for any address `a` the value returned by `balanceOf(a)` must be equal to the number of tokens such
 that `ownerOf(tokenId)` is `a`.
+</Callout>
 
 </div>
 </div>
@@ -906,9 +906,9 @@ Transfers `tokenId` token from `from` to `to`.
 
 <Callout type="warn">
 Note that the caller is responsible to confirm that the recipient is capable of receiving ERC721
-</Callout>
 or else they may be permanently lost. Usage of [`ERC1155.safeTransferFrom`](ERC1155#ERC1155-safeTransferFrom-address-address-uint256-uint256-bytes-) prevents loss, though the caller must
 understand this adds an external call which potentially creates a reentrancy vulnerability.
+</Callout>
 
 Requirements:
 
@@ -1236,15 +1236,15 @@ regained after construction. During construction, only batch minting is allowed.
 
 <Callout type="warn">
 This extension bypasses the hooks [`ERC1155._beforeTokenTransfer`](ERC1155#ERC1155-_beforeTokenTransfer-address-address-address-uint256---uint256---bytes-) and [`ERC1155._afterTokenTransfer`](ERC1155#ERC1155-_afterTokenTransfer-address-address-address-uint256---uint256---bytes-) for tokens minted in
-</Callout>
 batch. When using this extension, you should consider the `_beforeConsecutiveTokenTransfer` and
 `_afterConsecutiveTokenTransfer` hooks in addition to [`ERC1155._beforeTokenTransfer`](ERC1155#ERC1155-_beforeTokenTransfer-address-address-address-uint256---uint256---bytes-) and [`ERC1155._afterTokenTransfer`](ERC1155#ERC1155-_afterTokenTransfer-address-address-address-uint256---uint256---bytes-).
+</Callout>
 
 <Callout type="warn">
 When overriding [`ERC1155._afterTokenTransfer`](ERC1155#ERC1155-_afterTokenTransfer-address-address-address-uint256---uint256---bytes-), be careful about call ordering. [`ERC721.ownerOf`](#ERC721-ownerOf-uint256-) may return invalid
-</Callout>
 values during the [`ERC1155._afterTokenTransfer`](ERC1155#ERC1155-_afterTokenTransfer-address-address-address-uint256---uint256---bytes-) execution if the super call is not called first. To be safe, execute the
 super call before your custom logic.
+</Callout>
 
 _Available since v4.8._
 
@@ -1602,11 +1602,11 @@ event of a large bug.
 
 <Callout type="warn">
 This contract does not include public pause and unpause functions. In
-</Callout>
 addition to inheriting this contract, you must define both functions, invoking the
 [`Pausable._pause`](../security#Pausable-_pause--) and [`Pausable._unpause`](../security#Pausable-_unpause--) internal functions, with appropriate
 access control, e.g. using [`AccessControl`](../access#AccessControl) or [`Ownable`](../access#Ownable). Not doing so will
 make the contract unpausable.
+</Callout>
 
 <div className="bg-secondary p-4 rounded-md mb-6">
 <h3 style={{ marginTop: "0"}}>Functions</h3>
@@ -1716,9 +1716,9 @@ specific token ids via [`ERC2981._setTokenRoyalty`](common#ERC2981-_setTokenRoya
 
 <Callout type="warn">
 ERC-2981 only specifies a way to signal royalty information and does not enforce its payment. See
-</Callout>
 [Rationale](https://eips.ethereum.org/EIPS/eip-2981#optional-royalty-payments) in the EIP. Marketplaces are expected to
 voluntarily pay royalties together with sales, but note that this standard is not yet widely supported.
+</Callout>
 
 _Available since v4.5._
 
@@ -2280,8 +2280,8 @@ is accepted from [`ERC20Wrapper.depositFor`](ERC20#ERC20Wrapper-depositFor-addre
 
 <Callout type="warn">
 Doesn't work with unsafe transfers (eg. [`IERC721.transferFrom`](#IERC721-transferFrom-address-address-uint256-)). Use [`ERC721Wrapper._recover`](#ERC721Wrapper-_recover-address-uint256-)
-</Callout>
 for recovering in that scenario.
+</Callout>
 
 </div>
 </div>

--- a/content/contracts/4.x/api/token/common.mdx
+++ b/content/contracts/4.x/api/token/common.mdx
@@ -38,9 +38,9 @@ fee is specified in basis points by default.
 
 <Callout type="warn">
 ERC-2981 only specifies a way to signal royalty information and does not enforce its payment. See
-</Callout>
 [Rationale](https://eips.ethereum.org/EIPS/eip-2981#optional-royalty-payments) in the EIP. Marketplaces are expected to
 voluntarily pay royalties together with sales, but note that this standard is not yet widely supported.
+</Callout>
 
 _Available since v4.5._
 

--- a/content/contracts/4.x/api/utils.mdx
+++ b/content/contracts/4.x/api/utils.mdx
@@ -215,10 +215,10 @@ imposed by `transfer`, making them unable to receive funds via
 
 <Callout type="warn">
 because control is transferred to `recipient`, care must be
-</Callout>
 taken to not create reentrancy vulnerabilities. Consider using
 [`ReentrancyGuard`](security#ReentrancyGuard) or the
 [checks-effects-interactions pattern](https://solidity.readthedocs.io/en/v0.8.0/security-considerations.html#use-the-checks-effects-interactions-pattern).
+</Callout>
 
 </div>
 </div>
@@ -1529,8 +1529,8 @@ Return the length of a string that was encoded to `ShortString` or written to st
 
 <Callout type="warn">
 This will return the "byte length" of the string. This may not reflect the actual length in terms of
-</Callout>
 actual characters as the UTF-8 encoding of a single character can span over multiple bytes.
+</Callout>
 
 </div>
 </div>
@@ -2197,11 +2197,11 @@ half order, and the `v` value to be either 27 or 28.
 
 <Callout type="warn">
 `hash` _must_ be the result of a hash operation for the
-</Callout>
 verification to be secure: it is possible to craft signatures that
 recover to arbitrary addresses for non-hashed data. A safe way to ensure
 this is by receiving a hash of the original message (which may otherwise
 be too long), and then calling [`ECDSA.toEthSignedMessageHash`](#ECDSA-toEthSignedMessageHash-bytes-) on it.
+</Callout>
 
 Documentation for signature generation:
 - with [Web3.js](https://web3js.readthedocs.io/en/v1.3.4/web3-eth-accounts.html#sign)
@@ -2233,11 +2233,11 @@ half order, and the `v` value to be either 27 or 28.
 
 <Callout type="warn">
 `hash` _must_ be the result of a hash operation for the
-</Callout>
 verification to be secure: it is possible to craft signatures that
 recover to arbitrary addresses for non-hashed data. A safe way to ensure
 this is by receiving a hash of the original message (which may otherwise
 be too long), and then calling [`ECDSA.toEthSignedMessageHash`](#ECDSA-toEthSignedMessageHash-bytes-) on it.
+</Callout>
 
 </div>
 </div>
@@ -2579,12 +2579,12 @@ You will find a quickstart guide in the readme.
 
 <Callout type="warn">
 You should avoid using leaf values that are 64 bytes long prior to
-</Callout>
 hashing, or use a hash function other than keccak256 for hashing leaves.
 This is because the concatenation of a sorted pair of internal nodes in
 the merkle tree could be reinterpreted as a leaf value.
 OpenZeppelin's JavaScript library generates merkle trees that are safe
 against this attack out of the box.
+</Callout>
 
 <div className="bg-secondary p-4 rounded-md mb-6">
 <h3 style={{ marginTop: "0"}}>Functions</h3>
@@ -2924,9 +2924,9 @@ recipient.
 
 <Callout type="warn">
 Forwarding all gas opens the door to reentrancy vulnerabilities.
-</Callout>
 Make sure you trust the recipient, or are either following the
 checks-effects-interactions pattern or using [`ReentrancyGuard`](security#ReentrancyGuard).
+</Callout>
 
 </div>
 </div>
@@ -3032,9 +3032,9 @@ recipient.
 
 <Callout type="warn">
 Forwarding all gas opens the door to reentrancy vulnerabilities.
-</Callout>
 Make sure you trust the recipient, or are either following the
 checks-effects-interactions pattern or using [`ReentrancyGuard`](security#ReentrancyGuard).
+</Callout>
 
 </div>
 </div>
@@ -7272,10 +7272,10 @@ Return the an array containing all the keys
 
 <Callout type="warn">
 This operation will copy the entire storage to memory, which can be quite expensive. This is designed
-</Callout>
 to mostly be used by view accessors that are queried without any gas fees. Developers should keep in mind that
 this function has an unbounded cost, and using it as part of a state-changing function may render the function
 uncallable if the map grows to a point where copying to memory consumes too much gas to fit in a block.
+</Callout>
 
 </div>
 </div>
@@ -7452,10 +7452,10 @@ Return the an array containing all the keys
 
 <Callout type="warn">
 This operation will copy the entire storage to memory, which can be quite expensive. This is designed
-</Callout>
 to mostly be used by view accessors that are queried without any gas fees. Developers should keep in mind that
 this function has an unbounded cost, and using it as part of a state-changing function may render the function
 uncallable if the map grows to a point where copying to memory consumes too much gas to fit in a block.
+</Callout>
 
 </div>
 </div>
@@ -7632,10 +7632,10 @@ Return the an array containing all the keys
 
 <Callout type="warn">
 This operation will copy the entire storage to memory, which can be quite expensive. This is designed
-</Callout>
 to mostly be used by view accessors that are queried without any gas fees. Developers should keep in mind that
 this function has an unbounded cost, and using it as part of a state-changing function may render the function
 uncallable if the map grows to a point where copying to memory consumes too much gas to fit in a block.
+</Callout>
 
 </div>
 </div>
@@ -7812,10 +7812,10 @@ Return the an array containing all the keys
 
 <Callout type="warn">
 This operation will copy the entire storage to memory, which can be quite expensive. This is designed
-</Callout>
 to mostly be used by view accessors that are queried without any gas fees. Developers should keep in mind that
 this function has an unbounded cost, and using it as part of a state-changing function may render the function
 uncallable if the map grows to a point where copying to memory consumes too much gas to fit in a block.
+</Callout>
 
 </div>
 </div>
@@ -7992,10 +7992,10 @@ Return the an array containing all the keys
 
 <Callout type="warn">
 This operation will copy the entire storage to memory, which can be quite expensive. This is designed
-</Callout>
 to mostly be used by view accessors that are queried without any gas fees. Developers should keep in mind that
 this function has an unbounded cost, and using it as part of a state-changing function may render the function
 uncallable if the map grows to a point where copying to memory consumes too much gas to fit in a block.
+</Callout>
 
 </div>
 </div>
@@ -8187,10 +8187,10 @@ Return the entire set in an array
 
 <Callout type="warn">
 This operation will copy the entire storage to memory, which can be quite expensive. This is designed
-</Callout>
 to mostly be used by view accessors that are queried without any gas fees. Developers should keep in mind that
 this function has an unbounded cost, and using it as part of a state-changing function may render the function
 uncallable if the set grows to a point where copying to memory consumes too much gas to fit in a block.
+</Callout>
 
 </div>
 </div>
@@ -8309,10 +8309,10 @@ Return the entire set in an array
 
 <Callout type="warn">
 This operation will copy the entire storage to memory, which can be quite expensive. This is designed
-</Callout>
 to mostly be used by view accessors that are queried without any gas fees. Developers should keep in mind that
 this function has an unbounded cost, and using it as part of a state-changing function may render the function
 uncallable if the set grows to a point where copying to memory consumes too much gas to fit in a block.
+</Callout>
 
 </div>
 </div>
@@ -8431,10 +8431,10 @@ Return the entire set in an array
 
 <Callout type="warn">
 This operation will copy the entire storage to memory, which can be quite expensive. This is designed
-</Callout>
 to mostly be used by view accessors that are queried without any gas fees. Developers should keep in mind that
 this function has an unbounded cost, and using it as part of a state-changing function may render the function
 uncallable if the set grows to a point where copying to memory consumes too much gas to fit in a block.
+</Callout>
 
 </div>
 </div>

--- a/content/contracts/5.x/api/access.mdx
+++ b/content/contracts/5.x/api/access.mdx
@@ -95,10 +95,10 @@ roles. More complex role relationships can be created by using
 
 <Callout type="warn">
 The `DEFAULT_ADMIN_ROLE` is also its own admin: it has permission to
-</Callout>
 grant and revoke this role. Extra precautions should be taken to secure
 accounts that have been granted it. We recommend using [`AccessControlDefaultAdminRules`](#AccessControlDefaultAdminRules)
 to enforce additional security measures for this role.
+</Callout>
 
 <div className="bg-secondary p-4 rounded-md mb-6">
 <h3 style={{ marginTop: "0"}}>Modifiers</h3>
@@ -820,8 +820,8 @@ Leaves the contract without owner. It will not be possible to call
 
 <Callout>
 Renouncing ownership will leave the contract without an owner,
-</Callout>
 thereby disabling any functionality that is only available to the owner.
+</Callout>
 
 </div>
 </div>
@@ -1290,9 +1290,9 @@ After its execution, it will not be possible to call `onlyRole(DEFAULT_ADMIN_ROL
 
 <Callout>
 Renouncing `DEFAULT_ADMIN_ROLE` will leave the contract without a [`AccessControlDefaultAdminRules.defaultAdmin`](#AccessControlDefaultAdminRules-defaultAdmin--),
-</Callout>
 thereby disabling any functionality that is only available for it, and the possibility of reassigning a
 non-administrated role.
+</Callout>
 
 </div>
 </div>
@@ -1316,8 +1316,8 @@ role has been previously renounced.
 
 <Callout>
 Exposing this function through another mechanism may make the `DEFAULT_ADMIN_ROLE`
-</Callout>
 assignable again. Make sure to guarantee this is the expected behavior in your implementation.
+</Callout>
 
 </div>
 </div>
@@ -1422,8 +1422,8 @@ the acceptance schedule.
 
 <Callout>
 If a delay change has been scheduled, it will take effect as soon as the schedule passes, making this
-</Callout>
 function returns the new delay. See [`AccessControlDefaultAdminRules.changeDefaultAdminDelay`](#AccessControlDefaultAdminRules-changeDefaultAdminDelay-uint48-).
+</Callout>
 
 </div>
 </div>
@@ -1449,8 +1449,8 @@ A zero value only in `effectSchedule` indicates no pending delay change.
 
 <Callout>
 A zero value only for `newDelay` means that the next [`AccessControlDefaultAdminRules.defaultAdminDelay`](#AccessControlDefaultAdminRules-defaultAdminDelay--)
-</Callout>
 will be zero after the effect schedule.
+</Callout>
 
 </div>
 </div>
@@ -1477,9 +1477,9 @@ be overrode for a custom [`AccessControlDefaultAdminRules.defaultAdminDelay`](#A
 
 <Callout type="warn">
 Make sure to add a reasonable amount of time while overriding this value, otherwise,
-</Callout>
 there's a risk of setting a high new delay that goes into effect almost immediately without the
 possibility of human intervention in the case of an input error (eg. set milliseconds instead of seconds).
+</Callout>
 
 </div>
 </div>
@@ -1848,10 +1848,10 @@ change at any point.
 
 <Callout type="warn">
 When using [`AccessControlEnumerable.getRoleMember`](#AccessControlEnumerable-getRoleMember-bytes32-uint256-) and [`AccessControlEnumerable.getRoleMemberCount`](#AccessControlEnumerable-getRoleMemberCount-bytes32-), make sure
-</Callout>
 you perform all queries on the same block. See the following
 [forum post](https://forum.openzeppelin.com/t/iterating-over-elements-on-enumerableset-in-openzeppelin-contracts/2296)
 for more information.
+</Callout>
 
 </div>
 </div>
@@ -1890,10 +1890,10 @@ Return all accounts that have `role`
 
 <Callout type="warn">
 This operation will copy the entire storage to memory, which can be quite expensive. This is designed
-</Callout>
 to mostly be used by view accessors that are queried without any gas fees. Developers should keep in mind that
 this function has an unbounded cost, and using it as part of a state-changing function may render the function
 uncallable if the set grows to a point where copying to memory consumes too much gas to fit in a block.
+</Callout>
 
 </div>
 </div>
@@ -2060,8 +2060,8 @@ the acceptance schedule.
 
 <Callout>
 If a delay change has been scheduled, it will take effect as soon as the schedule passes, making this
-</Callout>
 function returns the new delay. See [`AccessControlDefaultAdminRules.changeDefaultAdminDelay`](#AccessControlDefaultAdminRules-changeDefaultAdminDelay-uint48-).
+</Callout>
 
 </div>
 </div>
@@ -2087,8 +2087,8 @@ A zero value only in `effectSchedule` indicates no pending delay change.
 
 <Callout>
 A zero value only for `newDelay` means that the next [`AccessControlDefaultAdminRules.defaultAdminDelay`](#AccessControlDefaultAdminRules-defaultAdminDelay--)
-</Callout>
 will be zero after the effect schedule.
+</Callout>
 
 </div>
 </div>
@@ -2255,9 +2255,9 @@ be overrode for a custom [`AccessControlDefaultAdminRules.defaultAdminDelay`](#A
 
 <Callout type="warn">
 Make sure to add a reasonable amount of time while overriding this value, otherwise,
-</Callout>
 there's a risk of setting a high new delay that goes into effect almost immediately without the
 possibility of human intervention in the case of an input error (eg. set milliseconds instead of seconds).
+</Callout>
 
 </div>
 </div>
@@ -2465,10 +2465,10 @@ change at any point.
 
 <Callout type="warn">
 When using [`AccessControlEnumerable.getRoleMember`](#AccessControlEnumerable-getRoleMember-bytes32-uint256-) and [`AccessControlEnumerable.getRoleMemberCount`](#AccessControlEnumerable-getRoleMemberCount-bytes32-), make sure
-</Callout>
 you perform all queries on the same block. See the following
 [forum post](https://forum.openzeppelin.com/t/iterating-over-elements-on-enumerableset-in-openzeppelin-contracts/2296)
 for more information.
+</Callout>
 
 </div>
 </div>
@@ -2513,8 +2513,8 @@ implementing a policy that allows certain callers to access certain functions.
 
 <Callout type="warn">
 The `restricted` modifier should never be used on `internal` functions, judiciously used in `public`
-</Callout>
 functions, and ideally only used in `external` functions. See [`AccessManaged.restricted`](#AccessManaged-restricted--).
+</Callout>
 
 <div className="bg-secondary p-4 rounded-md mb-6">
 <h3 style={{ marginTop: "0"}}>Modifiers</h3>
@@ -2746,23 +2746,23 @@ they will be highly secured (e.g., a multisig or a well-configured DAO).
 
 <Callout>
 This contract implements a form of the [`IAuthority`](#IAuthority) interface, but [`AccessManager.canCall`](#AccessManager-canCall-address-address-bytes4-) has additional return data so it
-</Callout>
 doesn't inherit `IAuthority`. It is however compatible with the `IAuthority` interface since the first 32 bytes of
 the return data are a boolean as expected by that interface.
+</Callout>
 
 <Callout>
 Systems that implement other access control mechanisms (for example using [`Ownable`](#Ownable)) can be paired with an
-</Callout>
 [`AccessManager`](#AccessManager) by transferring permissions (ownership in the case of [`Ownable`](#Ownable)) directly to the [`AccessManager`](#AccessManager).
 Users will be able to interact with these contracts through the [`AccessManager.execute`](#AccessManager-execute-address-bytes-) function, following the access rules
 registered in the [`AccessManager`](#AccessManager). Keep in mind that in that context, the msg.sender seen by restricted functions
 will be [`AccessManager`](#AccessManager) itself.
+</Callout>
 
 <Callout type="warn">
 When granting permissions over an [`Ownable`](#Ownable) or [`AccessControl`](#AccessControl) contract to an [`AccessManager`](#AccessManager), be very
-</Callout>
 mindful of the danger associated with functions such as [`Ownable.renounceOwnership`](#Ownable-renounceOwnership--) or
 [`AccessControl.renounceRole`](#AccessControl-renounceRole-bytes32-address-).
+</Callout>
 
 <div className="bg-secondary p-4 rounded-md mb-6">
 <h3 style={{ marginTop: "0"}}>Modifiers</h3>
@@ -2920,14 +2920,14 @@ the operation can be executed if and only if delay is greater than 0.
 
 <Callout>
 The IAuthority interface does not include the `uint32` delay. This is an extension of that interface that
-</Callout>
 is backward compatible. Some contracts may thus ignore the second return argument. In that case they will fail
 to identify the indirect workflow, and will consider calls that require a delay to be forbidden.
+</Callout>
 
 <Callout>
 This function does not report the permissions of the admin functions in the manager itself. These are defined by the
-</Callout>
 [`AccessManager`](#AccessManager) documentation.
+</Callout>
 
 </div>
 </div>
@@ -2948,8 +2948,8 @@ Expiration delay for scheduled proposals. Defaults to 1 week.
 
 <Callout type="warn">
 Avoid overriding the expiration with 0. Otherwise every contract proposal will be expired immediately,
-</Callout>
 disabling any scheduling usage.
+</Callout>
 
 </div>
 </div>
@@ -3362,8 +3362,8 @@ Emits a [`IAccessControl.RoleAdminChanged`](#IAccessControl-RoleAdminChanged-byt
 
 <Callout>
 Setting the admin role as the `PUBLIC_ROLE` is allowed, but it will effectively allow
-</Callout>
 anyone to set grant or revoke such role.
+</Callout>
 
 </div>
 </div>
@@ -3386,8 +3386,8 @@ Emits a [`IAccessManager.RoleGuardianChanged`](#IAccessManager-RoleGuardianChang
 
 <Callout>
 Setting the guardian role as the `PUBLIC_ROLE` is allowed, but it will effectively allow
-</Callout>
 anyone to cancel any scheduled operation for such role.
+</Callout>
 
 </div>
 </div>
@@ -3599,9 +3599,9 @@ Emits a [`IAccessManager.OperationScheduled`](#IAccessManager-OperationScheduled
 
 <Callout>
 It is not possible to concurrently schedule more than one operation with the same `target` and `data`. If
-</Callout>
 this is necessary, a random byte can be appended to `data` to act as a salt that will be ignored by the target
 contract if it is using standard Solidity ABI encoding.
+</Callout>
 
 </div>
 </div>
@@ -4079,14 +4079,14 @@ the operation can be executed if and only if delay is greater than 0.
 
 <Callout>
 The IAuthority interface does not include the `uint32` delay. This is an extension of that interface that
-</Callout>
 is backward compatible. Some contracts may thus ignore the second return argument. In that case they will fail
 to identify the indirect workflow, and will consider calls that require a delay to be forbidden.
+</Callout>
 
 <Callout>
 This function does not report the permissions of the admin functions in the manager itself. These are defined by the
-</Callout>
 [`AccessManager`](#AccessManager) documentation.
+</Callout>
 
 </div>
 </div>
@@ -4107,8 +4107,8 @@ Expiration delay for scheduled proposals. Defaults to 1 week.
 
 <Callout type="warn">
 Avoid overriding the expiration with 0. Otherwise every contract proposal will be expired immediately,
-</Callout>
 disabling any scheduling usage.
+</Callout>
 
 </div>
 </div>
@@ -4595,9 +4595,9 @@ Emits a [`IAccessManager.OperationScheduled`](#IAccessManager-OperationScheduled
 
 <Callout>
 It is not possible to concurrently schedule more than one operation with the same `target` and `data`. If
-</Callout>
 this is necessary, a random byte can be appended to `data` to act as a salt that will be ignored by the target
 contract if it is using standard Solidity ABI encoding.
+</Callout>
 
 </div>
 </div>
@@ -4795,9 +4795,9 @@ Emitted when `account` is granted `roleId`.
 
 <Callout>
 The meaning of the `since` argument depends on the `newMember` argument.
-</Callout>
 If the role is granted to a new member, the `since` argument indicates when the account becomes a member of the role,
 otherwise it indicates the execution delay for this account and roleId is updated.
+</Callout>
 
 </div>
 </div>

--- a/content/contracts/5.x/api/account.mdx
+++ b/content/contracts/5.x/api/account.mdx
@@ -53,15 +53,15 @@ Developers must implement the [`AbstractSigner._rawSignatureValidation`](utils/c
 
 <Callout>
 This core account doesn't include any mechanism for performing arbitrary external calls. This is an essential
-</Callout>
 feature that all Account should have. We leave it up to the developers to implement the mechanism of their choice.
 Common choices include ERC-6900, ERC-7579 and ERC-7821 (among others).
+</Callout>
 
 <Callout type="warn">
 Implementing a mechanism to validate signatures is a security-sensitive operation as it may allow an
-</Callout>
 attacker to bypass the account's security measures. Check out [`SignerECDSA`](utils/cryptography#SignerECDSA), [`SignerP256`](utils/cryptography#SignerP256), or [`SignerRSA`](utils/cryptography#SignerRSA) for
 digital signature validation implementations.
+</Callout>
 
 @custom:stateless
 
@@ -234,8 +234,8 @@ signable hash (produced by [`Account._signableUserOpHash`](#Account-_signableUse
 
 <Callout>
 The userOpHash is assumed to be correct. Calling this function with a userOpHash that does not match the
-</Callout>
 userOp will result in undefined behavior.
+</Callout>
 
 </div>
 </div>
@@ -672,8 +672,8 @@ Implement ERC-1271 through IERC7579Validator modules. If module based validation
 
 <Callout>
 when combined with [`ERC7739`](utils/cryptography#ERC7739), resolution ordering may have an impact ([`ERC7739`](utils/cryptography#ERC7739) does not call super).
-</Callout>
 Manual resolution might be necessary.
+</Callout>
 
 </div>
 </div>
@@ -847,10 +847,10 @@ To construct a nonce key, set nonce as follows:
 ```
 <Callout>
 The default behavior of this function replicates the behavior of
-</Callout>
 [Safe adapter](https://github.com/rhinestonewtf/safe7579/blob/bb29e8b1a66658790c4169e72608e27d220f79be/src/Safe7579.sol#L266),
 [Etherspot's Prime Account](https://github.com/etherspot/etherspot-prime-contracts/blob/cfcdb48c4172cea0d66038324c0bae3288aa8caa/src/modular-etherspot-wallet/wallet/ModularEtherspotWallet.sol#L227), and
 [ERC7579 reference implementation](https://github.com/erc7579/erc7579-implementation/blob/16138d1afd4e9711f6c1425133538837bd7787b5/src/MSAAdvanced.sol#L247).
+</Callout>
 
 This is not standardized in ERC-7579 (or in any follow-up ERC). Some accounts may want to override these internal functions.
 
@@ -883,11 +883,11 @@ signature data:
 
 <Callout>
 The default behavior of this function replicates the behavior of
-</Callout>
 [Safe adapter](https://github.com/rhinestonewtf/safe7579/blob/bb29e8b1a66658790c4169e72608e27d220f79be/src/Safe7579.sol#L350),
 [Biconomy's Nexus](https://github.com/bcnmy/nexus/blob/54f4e19baaff96081a8843672977caf712ef19f4/contracts/Nexus.sol#L239),
 [Etherspot's Prime Account](https://github.com/etherspot/etherspot-prime-contracts/blob/cfcdb48c4172cea0d66038324c0bae3288aa8caa/src/modular-etherspot-wallet/wallet/ModularEtherspotWallet.sol#L252), and
 [ERC7579 reference implementation](https://github.com/erc7579/erc7579-implementation/blob/16138d1afd4e9711f6c1425133538837bd7787b5/src/MSAAdvanced.sol#L296).
+</Callout>
 
 This is not standardized in ERC-7579 (or in any follow-up ERC). Some accounts may want to override these internal functions.
 
@@ -910,11 +910,11 @@ Extract the function selector from initData/deInitData for MODULE_TYPE_FALLBACK
 
 <Callout>
 If we had calldata here, we could use calldata slice which are cheaper to manipulate and don't require
-</Callout>
 actual copy. However, this would require `_installModule` to get a calldata bytes object instead of a memory
 bytes object. This would prevent calling `_installModule` from a contract constructor and would force the use
 of external initializers. That may change in the future, as most accounts will probably be deployed as
 clones/proxy/ERC-7702 delegates and therefore rely on initializers anyway.
+</Callout>
 
 </div>
 </div>
@@ -976,11 +976,11 @@ with [`AccountERC7579._execute`](#AccountERC7579-_execute-Mode-bytes-) (includin
 
 <Callout>
 Hook modules break the check-effect-interaction pattern. In particular, the [`IERC7579Hook.preCheck`](interfaces#IERC7579Hook-preCheck-address-uint256-bytes-) hook can
-</Callout>
 lead to potentially dangerous reentrancy. Using the `withHook()` modifier is safe if no effect is performed
 before the preHook or after the postHook. That is the case on all functions here, but it may not be the case if
 functions that have this modifier are overridden. Developers should be extremely careful when implementing hook
 modules or further overriding functions that involve hooks.
+</Callout>
 
 <div className="bg-secondary p-4 rounded-md mb-6">
 <h3 style={{ marginTop: "0"}}>Modifiers</h3>
@@ -1295,8 +1295,8 @@ Executes the calls in `executionData` with no optional `opData` support.
 
 <Callout>
 Access to this function is controlled by [`ERC7821._erc7821AuthorizedExecutor`](#ERC7821-_erc7821AuthorizedExecutor-address-bytes32-bytes-). Changing access permissions, for
-</Callout>
 example to approve calls by the ERC-4337 entrypoint, should be implemented by overriding it.
+</Callout>
 
 Reverts and bubbles up error if any call fails.
 

--- a/content/contracts/5.x/api/finance.mdx
+++ b/content/contracts/5.x/api/finance.mdx
@@ -41,22 +41,22 @@ a beneficiary until a specified time.
 
 <Callout>
 Since the wallet is [`Ownable`](access#Ownable), and ownership can be transferred, it is possible to sell unvested tokens.
-</Callout>
 Preventing this in a smart contract is difficult, considering that: 1) a beneficiary address could be a
 counterfactually deployed contract, 2) there is likely to be a migration path for EOAs to become contracts in the
 near future.
+</Callout>
 
 <Callout>
 When using this contract with any token whose balance is adjusted automatically (i.e. a rebase token), make
-</Callout>
 sure to account the supply/balance adjustment in the vesting schedule to ensure the vested amount is as intended.
+</Callout>
 
 <Callout>
 Chains with support for native ERC20s may allow the vesting wallet to withdraw the underlying asset as both an
-</Callout>
 ERC20 and as native currency. For example, if chain C supports token A and the wallet gets deposited 100 A, then
 at 50% of the vesting period, the beneficiary can withdraw 50 A as ERC20 and 25 A as native currency (totaling 75 A).
 Consider disabling one of the withdrawal methods.
+</Callout>
 
 <div className="bg-secondary p-4 rounded-md mb-6">
 <h3 style={{ marginTop: "0"}}>Functions</h3>
@@ -501,9 +501,9 @@ an asset given its total historical allocation. Returns 0 if the [`VestingWallet
 
 <Callout type="warn">
 The cliff not only makes the schedule return 0, but it also ignores every possible side
-</Callout>
 effect from calling the inherited implementation (i.e. `super._vestingSchedule`). Carefully consider
 this caveat if the overridden implementation of this function has any (e.g. writing to memory or reverting).
+</Callout>
 
 </div>
 </div>

--- a/content/contracts/5.x/api/governance.mdx
+++ b/content/contracts/5.x/api/governance.mdx
@@ -840,8 +840,8 @@ will revert.
 
 <Callout>
 Calling this function directly will NOT check the current state of the proposal, or emit the
-</Callout>
 `ProposalQueued` event. Queuing a proposal should be done using [`Governor.queue`](#Governor-queue-address---uint256---bytes---bytes32-).
+</Callout>
 
 </div>
 </div>
@@ -888,8 +888,8 @@ performed (for example adding a vault/timelock).
 
 <Callout>
 Calling this function directly will NOT check the current state of the proposal, set the executed flag to
-</Callout>
 true or emit the `ProposalExecuted` event. Executing a proposal should be done using [`AccessManager.execute`](access#AccessManager-execute-address-bytes-).
+</Callout>
 
 </div>
 </div>
@@ -1367,8 +1367,8 @@ proposal starts.
 
 <Callout>
 While this interface returns a uint256, timepoints are stored as uint48 following the ERC-6372 clock type.
-</Callout>
 Consequently this value must fit in a uint48 (when added to the current clock). See [`IERC6372.clock`](interfaces#IERC6372-clock--).
+</Callout>
 
 </div>
 </div>
@@ -1390,14 +1390,14 @@ Delay between the vote start and vote end. The unit this duration is expressed i
 
 <Callout>
 The [`Governor.votingDelay`](#Governor-votingDelay--) can delay the start of the vote. This must be considered when setting the voting
-</Callout>
 duration compared to the voting delay.
+</Callout>
 
 <Callout>
 This value is stored when the proposal is submitted so that possible changes to the value do not affect
-</Callout>
 proposals that have already been submitted. The type used to save it is a uint32. Consequently, while this
 interface returns a uint256, the value it returns should fit in a uint32.
+</Callout>
 
 </div>
 </div>
@@ -1418,8 +1418,8 @@ Minimum number of cast voted required for a proposal to be successful.
 
 <Callout>
 The `timepoint` parameter corresponds to the snapshot used for counting vote. This allows to scale the
-</Callout>
 quorum depending on values such as the totalSupply of a token at this timepoint (see [`ERC20Votes`](token/ERC20#ERC20Votes)).
+</Callout>
 
 </div>
 </div>
@@ -1474,8 +1474,8 @@ Interface of the [`Governor`](#Governor) core.
 
 <Callout>
 Event parameters lack the `indexed` keyword for compatibility with GovernorBravo events.
-</Callout>
 Making event parameters `indexed` affects how events are decoded, potentially breaking existing indexers.
+</Callout>
 
 <div className="bg-secondary p-4 rounded-md mb-6">
 <h3 style={{ marginTop: "0"}}>Functions</h3>
@@ -1617,9 +1617,9 @@ name that describes the behavior. For example:
 
 <Callout>
 The string can be decoded by the standard
-</Callout>
 [`URLSearchParams`](https://developer.mozilla.org/en-US/docs/Web/API/URLSearchParams)
 JavaScript class.
+</Callout>
 
 </div>
 </div>
@@ -1806,8 +1806,8 @@ proposal starts.
 
 <Callout>
 While this interface returns a uint256, timepoints are stored as uint48 following the ERC-6372 clock type.
-</Callout>
 Consequently this value must fit in a uint48 (when added to the current clock). See [`IERC6372.clock`](interfaces#IERC6372-clock--).
+</Callout>
 
 </div>
 </div>
@@ -1829,14 +1829,14 @@ Delay between the vote start and vote end. The unit this duration is expressed i
 
 <Callout>
 The [`Governor.votingDelay`](#Governor-votingDelay--) can delay the start of the vote. This must be considered when setting the voting
-</Callout>
 duration compared to the voting delay.
+</Callout>
 
 <Callout>
 This value is stored when the proposal is submitted so that possible changes to the value do not affect
-</Callout>
 proposals that have already been submitted. The type used to save it is a uint32. Consequently, while this
 interface returns a uint256, the value it returns should fit in a uint32.
+</Callout>
 
 </div>
 </div>
@@ -1857,8 +1857,8 @@ Minimum number of cast voted required for a proposal to be successful.
 
 <Callout>
 The `timepoint` parameter corresponds to the snapshot used for counting vote. This allows to scale the
-</Callout>
 quorum depending on values such as the totalSupply of a token at this timepoint (see [`ERC20Votes`](token/ERC20#ERC20Votes)).
+</Callout>
 
 </div>
 </div>
@@ -1936,11 +1936,11 @@ Emits a [`IGovernor.ProposalCreated`](#IGovernor-ProposalCreated-uint256-address
 
 <Callout>
 The state of the Governor and `targets` may change between the proposal creation and its execution.
-</Callout>
 This may be the result of third party actions on the targeted contracts, or other governor proposals.
 For example, the balance of this contract could be updated or its access control permissions may be modified,
 possibly compromising the proposal's ability to execute successfully (e.g. the governor doesn't have enough
 value to cover a proposal with multiple transfers).
+</Callout>
 
 </div>
 </div>
@@ -2318,8 +2318,8 @@ counting from right to left.
 
 <Callout>
 If `expectedState` is `bytes32(0)`, the proposal is expected to not be in any state (i.e. not exist).
-</Callout>
 This is the case when a proposal that is expected to be unset is already initiated (the proposal is duplicated).
+</Callout>
 
 See [`Governor._encodeStateBitmap`](#Governor-_encodeStateBitmap-enum-IGovernor-ProposalState-).
 
@@ -2668,10 +2668,10 @@ Initializes the contract with the following parameters:
 
 <Callout type="warn">
 The optional admin can aid with initial configuration of roles after deployment
-</Callout>
 without being subject to delay, but this role should be subsequently renounced in favor of
 administration through timelocked proposals. Previous versions of this contract would assign
 this admin to the deployer automatically and should be renounced as well.
+</Callout>
 
 </div>
 </div>
@@ -3475,9 +3475,9 @@ name that describes the behavior. For example:
 
 <Callout>
 The string can be decoded by the standard
-</Callout>
 [`URLSearchParams`](https://developer.mozilla.org/en-US/docs/Web/API/URLSearchParams)
 JavaScript class.
+</Callout>
 
 </div>
 </div>
@@ -3604,11 +3604,11 @@ their checkpointed total weight minus votes already cast on the proposal). This 
 
 <Callout>
 Consider that fractional voting restricts the number of casted votes (in each category) to 128 bits.
-</Callout>
 Depending on how many decimals the underlying token has, a single voter may require to split their vote into
 multiple vote operations. For precision higher than ~30 decimals, large token holders may require a
 potentially large number of calls to cast all their votes. The voter has the possibility to cast all the
 remaining votes in a single operation using the traditional "bravo" vote.
+</Callout>
 
 </div>
 </div>
@@ -3830,9 +3830,9 @@ name that describes the behavior. For example:
 
 <Callout>
 The string can be decoded by the standard
-</Callout>
 [`URLSearchParams`](https://developer.mozilla.org/en-US/docs/Web/API/URLSearchParams)
 JavaScript class.
+</Callout>
 
 </div>
 </div>
@@ -3853,10 +3853,10 @@ See [`IGovernor.hasVoted`](#IGovernor-hasVoted-uint256-address-).
 
 <Callout>
 Calling [`Governor.castVote`](#Governor-castVote-uint256-uint8-) (or similar) casts a vote using the voting power that is delegated to the voter.
-</Callout>
 Conversely, calling [`GovernorCountingOverridable.castOverrideVote`](#GovernorCountingOverridable-castOverrideVote-uint256-uint8-string-) (or similar) uses the voting power of the account itself, from its asset
 balances. Casting an "override vote" does not count as voting and won't be reflected by this getter. Consider
 using [`GovernorCountingOverridable.hasVotedOverride`](#GovernorCountingOverridable-hasVotedOverride-uint256-address-) to check if an account has casted an "override vote" for a given proposal id.
+</Callout>
 
 </div>
 </div>
@@ -3945,8 +3945,8 @@ See [`Governor._countVote`](#Governor-_countVote-uint256-address-uint8-uint256-b
 
 <Callout>
 called by [`Governor._castVote`](#Governor-_castVote-uint256-address-uint8-string-bytes-) which emits the [`IGovernor.VoteCast`](#IGovernor-VoteCast-address-uint256-uint8-uint256-string-) (or [`IGovernor.VoteCastWithParams`](#IGovernor-VoteCastWithParams-address-uint256-uint8-uint256-string-bytes-))
-</Callout>
 event.
+</Callout>
 
 </div>
 </div>
@@ -4274,9 +4274,9 @@ name that describes the behavior. For example:
 
 <Callout>
 The string can be decoded by the standard
-</Callout>
 [`URLSearchParams`](https://developer.mozilla.org/en-US/docs/Web/API/URLSearchParams)
 JavaScript class.
+</Callout>
 
 </div>
 </div>
@@ -4563,8 +4563,8 @@ Check the signature against keyed nonce and falls back to the traditional nonce.
 
 <Callout>
 This function won't call `super._validateVoteSig` if the keyed nonce is valid.
-</Callout>
 Side effects may be skipped depending on the linearization of the function.
+</Callout>
 
 </div>
 </div>
@@ -4585,8 +4585,8 @@ Check the signature against keyed nonce and falls back to the traditional nonce.
 
 <Callout>
 This function won't call `super._validateExtendedVoteSig` if the keyed nonce is valid.
-</Callout>
 Side effects may be skipped depending on the linearization of the function.
+</Callout>
 
 </div>
 </div>
@@ -6261,13 +6261,13 @@ without waiting for the proposal deadline.
 
 <Callout>
 The `timepoint` parameter corresponds to the snapshot used for counting the vote. This enables scaling of the
-</Callout>
 quorum depending on values such as the `totalSupply` of a token at this timepoint (see [`ERC20Votes`](token/ERC20#ERC20Votes)).
+</Callout>
 
 <Callout>
 Make sure the value specified for the super quorum is greater than [`Governor.quorum`](#Governor-quorum-uint256-), otherwise, it may be
-</Callout>
 possible to pass a proposal with less votes than the default quorum.
+</Callout>
 
 </div>
 </div>
@@ -6307,12 +6307,12 @@ quorum.
 
 <Callout>
 If the proposal reaches super quorum but [`Governor._voteSucceeded`](#Governor-_voteSucceeded-uint256-) returns false, eg, assuming the super quorum
-</Callout>
 has been set low enough that both FOR and AGAINST votes have exceeded it and AGAINST votes exceed FOR votes,
 the proposal continues to be active until [`Governor._voteSucceeded`](#Governor-_voteSucceeded-uint256-) returns true or the proposal deadline is reached.
 This means that with a low super quorum it is also possible that a vote can succeed prematurely before enough
 AGAINST voters have a chance to vote. Hence, it is recommended to set a high enough super quorum to avoid these
 types of scenarios.
+</Callout>
 
 </div>
 </div>
@@ -6359,8 +6359,8 @@ possible. All of the governor's own functions (e.g., [`GovernorTimelockAccess.se
 
 <Callout>
 `AccessManager` does not support scheduling more than one operation with the same target and calldata at
-</Callout>
 the same time. See [`AccessManager.schedule`](access#AccessManager-schedule-address-bytes-uint48-) for a workaround.
+</Callout>
 
 <div className="bg-secondary p-4 rounded-md mb-6">
 <h3 style={{ marginTop: "0"}}>Functions</h3>
@@ -6565,8 +6565,8 @@ demanded by the authority.
 
 <Callout>
 Execution delays are processed by the `AccessManager` contracts, and according to that contract are
-</Callout>
 expressed in seconds. Therefore, the base delay is also in seconds, regardless of the governor's clock mode.
+</Callout>
 
 </div>
 </div>
@@ -6725,8 +6725,8 @@ Mechanism to queue a proposal, potentially scheduling some of its operations in 
 
 <Callout>
 The execution delay is chosen based on the delay information retrieved in [`Governor.propose`](#Governor-propose-address---uint256---bytes---string-). This value may be
-</Callout>
 off if the delay was updated since proposal creation. In this case, the proposal needs to be recreated.
+</Callout>
 
 </div>
 </div>
@@ -7235,10 +7235,10 @@ inaccessible from a proposal, unless executed via [`Governor.relay`](#Governor-r
 
 <Callout type="warn">
 Setting up the TimelockController to have additional proposers or cancelers besides the governor is very
-</Callout>
 risky, as it grants them the ability to: 1) execute operations as the timelock, and thus possibly performing
 operations or accessing funds that are expected to only be accessible through a vote, and 2) block governance
 proposals that have been approved by the voters, effectively executing a Denial of Service attack.
+</Callout>
 
 <div className="bg-secondary p-4 rounded-md mb-6">
 <h3 style={{ marginTop: "0"}}>Functions</h3>
@@ -8492,12 +8492,12 @@ quorum.
 
 <Callout>
 If the proposal reaches super quorum but [`Governor._voteSucceeded`](#Governor-_voteSucceeded-uint256-) returns false, eg, assuming the super quorum
-</Callout>
 has been set low enough that both FOR and AGAINST votes have exceeded it and AGAINST votes exceed FOR votes,
 the proposal continues to be active until [`Governor._voteSucceeded`](#Governor-_voteSucceeded-uint256-) returns true or the proposal deadline is reached.
 This means that with a low super quorum it is also possible that a vote can succeed prematurely before enough
 AGAINST voters have a chance to vote. Hence, it is recommended to set a high enough super quorum to avoid these
 types of scenarios.
+</Callout>
 
 </div>
 </div>
@@ -8666,9 +8666,9 @@ configured to use block numbers, this will return the value at the end of the co
 
 <Callout>
 This value is the sum of all available votes, which is not necessarily the sum of all delegated votes.
-</Callout>
 Votes that have not been delegated are still part of total supply, even though they would not participate in a
 vote.
+</Callout>
 
 </div>
 </div>
@@ -8984,9 +8984,9 @@ configured to use block numbers, this will return the value at the end of the co
 
 <Callout>
 This value is the sum of all available votes, which is not necessarily the sum of all delegated votes.
-</Callout>
 Votes that have not been delegated are still part of total supply, even though they would not participate in a
 vote.
+</Callout>
 
 Requirements:
 
@@ -9222,9 +9222,9 @@ Extension of [`Votes`](#Votes) that adds checkpoints for delegations and balance
 
 <Callout type="warn">
 While this contract extends [`Votes`](#Votes), valid uses of [`Votes`](#Votes) may not be compatible with
-</Callout>
 [`VotesExtended`](#VotesExtended) without additional considerations. This implementation of [`Votes._transferVotingUnits`](#Votes-_transferVotingUnits-address-address-uint256-) must
 run AFTER the voting weight movement is registered, such that it is reflected on [`Votes._getVotingUnits`](#Votes-_getVotingUnits-address-).
+</Callout>
 
 Said differently, [`VotesExtended`](#VotesExtended) MUST be integrated in a way that calls [`Votes._transferVotingUnits`](#Votes-_transferVotingUnits-address-address-uint256-) AFTER the
 asset transfer is registered and balances are updated:

--- a/content/contracts/5.x/api/governance.mdx
+++ b/content/contracts/5.x/api/governance.mdx
@@ -12,7 +12,7 @@ This modular system of Governor contracts allows the deployment on-chain voting 
 <Callout>
 For a guided experience, set up your Governor contract using [Contracts Wizard](https://wizard.openzeppelin.com/#governor).
 
-For a written walkthrough, check out our guide on [How to set up on-chain governance](ROOT:governance.adoc).
+For a written walkthrough, check out our guide on [How to set up on-chain governance](../governance).
 </Callout>
 
 * [`Governor`](#Governor): The core contract that contains all the logic and primitives. It is abstract and requires choosing one of each of the modules below, or custom ones.

--- a/content/contracts/5.x/api/interfaces.mdx
+++ b/content/contracts/5.x/api/interfaces.mdx
@@ -347,9 +347,9 @@ by `operator` from `from`, this function is called.
 
 <Callout>
 To accept the transfer, this must return
-</Callout>
 `bytes4(keccak256("onTransferReceived(address,address,uint256,bytes)"))`
 (i.e. 0x88a7ca5c, or its own function selector).
+</Callout>
 
 </div>
 </div>
@@ -397,9 +397,9 @@ to spend their tokens, this function is called.
 
 <Callout>
 To accept the approval, this must return
-</Callout>
 `bytes4(keccak256("onApprovalReceived(address,uint256,bytes)"))`
 (i.e. 0x7b04a2d0, or its own function selector).
+</Callout>
 
 </div>
 </div>
@@ -896,8 +896,8 @@ exchange. The royalty amount is denominated and should be paid in that same unit
 
 <Callout>
 ERC-2981 allows setting the royalty to 100% of the price. In that case all the price would be sent to the
-</Callout>
 royalty receiver and 0 tokens to the seller. Contracts dealing with royalty should consider empty transfers.
+</Callout>
 
 </div>
 </div>
@@ -1151,9 +1151,9 @@ scenario where all the conditions are met.
 
 <Callout>
 This calculation MAY NOT reflect the “per-user” price-per-share, and instead should reflect the
-</Callout>
 “average-user’s” price-per-share, meaning what the average user should expect to see when exchanging to and
 from.
+</Callout>
 
 </div>
 </div>
@@ -1180,9 +1180,9 @@ scenario where all the conditions are met.
 
 <Callout>
 This calculation MAY NOT reflect the “per-user” price-per-share, and instead should reflect the
-</Callout>
 “average-user’s” price-per-share, meaning what the average user should expect to see when exchanging to and
 from.
+</Callout>
 
 </div>
 </div>
@@ -1234,8 +1234,8 @@ current on-chain conditions.
 
 <Callout>
 any unfavorable discrepancy between convertToShares and previewDeposit SHOULD be considered slippage in
-</Callout>
 share price or some other type of condition, meaning the depositor will lose assets by depositing.
+</Callout>
 
 </div>
 </div>
@@ -1312,8 +1312,8 @@ current on-chain conditions.
 
 <Callout>
 any unfavorable discrepancy between convertToAssets and previewMint SHOULD be considered slippage in
-</Callout>
 share price or some other type of condition, meaning the depositor will lose assets by minting.
+</Callout>
 
 </div>
 </div>
@@ -1392,8 +1392,8 @@ given current on-chain conditions.
 
 <Callout>
 any unfavorable discrepancy between convertToShares and previewWithdraw SHOULD be considered slippage in
-</Callout>
 share price or some other type of condition, meaning the depositor will lose assets by depositing.
+</Callout>
 
 </div>
 </div>
@@ -1471,8 +1471,8 @@ given current on-chain conditions.
 
 <Callout>
 any unfavorable discrepancy between convertToAssets and previewRedeem SHOULD be considered slippage in
-</Callout>
 share price or some other type of condition, meaning the depositor will lose assets by redeeming.
+</Callout>
 
 </div>
 </div>
@@ -1499,8 +1499,8 @@ Burns exactly shares from owner and sends assets of underlying tokens to receive
 
 <Callout>
 some implementations will require pre-requesting to the Vault before a withdrawal may be performed.
-</Callout>
 Those methods should be performed separately.
+</Callout>
 
 </div>
 </div>
@@ -2486,9 +2486,9 @@ address.
 
 <Callout type="warn">
 A proxy pointing at a proxiable contract should not be considered proxiable itself, because this risks
-</Callout>
 bricking a proxy that upgrades to it, by delegating to itself until out of gas. Thus it is critical that this
 function revert if invoked through a proxy.
+</Callout>
 
 </div>
 </div>

--- a/content/contracts/5.x/api/metatx.mdx
+++ b/content/contracts/5.x/api/metatx.mdx
@@ -36,17 +36,17 @@ Context variant with ERC-2771 support.
 
 <Callout type="warn">
 Avoid using this pattern in contracts that rely in a specific calldata length as they'll
-</Callout>
 be affected by any forwarder whose `msg.data` is suffixed with the `from` address according to the ERC-2771
 specification adding the address size in bytes (20) to the calldata size. An example of an unexpected
 behavior could be an unintended fallback (or another function) invocation while trying to invoke the `receive`
 function only accessible if `msg.data.length == 0`.
+</Callout>
 
 <Callout type="warn">
 The usage of `delegatecall` in this contract is dangerous and may result in context corruption.
-</Callout>
 Any forwarded request to this contract triggering a `delegatecall` to itself will result in an invalid [`ERC2771Context._msgSender`](#ERC2771Context-_msgSender--)
 recovery.
+</Callout>
 
 <div className="bg-secondary p-4 rounded-md mb-6">
 <h3 style={{ marginTop: "0"}}>Functions</h3>
@@ -199,11 +199,11 @@ multiple accounts.
 
 <Callout>
 Batching requests includes an optional refund for unused `msg.value` that is achieved by
-</Callout>
 performing a call with empty calldata. While this is within the bounds of ERC-2771 compliance,
 if the refund receiver happens to consider the forwarder a trusted forwarder, it MUST properly
 handle `msg.data.length == 0`. `ERC2771Context` in OpenZeppelin Contracts versions prior to 4.9.3
 do not handle this properly.
+</Callout>
 
 ==== Security Considerations
 
@@ -305,8 +305,8 @@ A transaction is considered valid when the target trusts this forwarder, the req
 
 <Callout>
 A request may return false here but it won't cause [`TimelockController.executeBatch`](governance#TimelockController-executeBatch-address---uint256---bytes---bytes32-bytes32-) to revert if a refund
-</Callout>
 receiver is provided.
+</Callout>
 
 </div>
 </div>
@@ -367,9 +367,9 @@ Requirements:
 
 <Callout>
 Setting a zero `refundReceiver` guarantees an all-or-nothing requests execution only for
-</Callout>
 the first-level forwarded calls. In case a forwarded request calls to a contract with another
 subcall, the second-level call may revert without the top-level call reverting.
+</Callout>
 
 </div>
 </div>
@@ -439,8 +439,8 @@ Emits an [`ERC2771Forwarder.ExecutedForwardRequest`](#ERC2771Forwarder-ExecutedF
 
 <Callout type="warn">
 Using this function doesn't check that all the `msg.value` was sent, potentially
-</Callout>
 leaving value stuck in the contract.
+</Callout>
 
 </div>
 </div>
@@ -464,8 +464,8 @@ This function performs a static call to the target contract calling the
 
 <Callout>
 Consider the execution of this forwarder is permissionless. Without this check, anyone may transfer assets
-</Callout>
 that are owned by, or are approved to this forwarder.
+</Callout>
 
 </div>
 </div>
@@ -487,9 +487,9 @@ Emitted when a `ForwardRequest` is executed.
 
 <Callout>
 An unsuccessful forward request could be due to an invalid signature, an expired deadline,
-</Callout>
 or simply a revert in the requested call. The contract guarantees that the relayer is not able to force
 the requested call to run out of gas.
+</Callout>
 
 </div>
 </div>

--- a/content/contracts/5.x/api/proxy.mdx
+++ b/content/contracts/5.x/api/proxy.mdx
@@ -3,7 +3,7 @@ title: "Proxy"
 description: "Smart contract proxy utilities and implementations"
 ---
 
-This is a low-level set of contracts implementing different proxy patterns with and without upgradeability. For an in-depth overview of this pattern check out the [Proxy Upgrade Pattern](upgrades-plugins::proxies.adoc) page.
+This is a low-level set of contracts implementing different proxy patterns with and without upgradeability. For an in-depth overview of this pattern check out the [Proxy Upgrade Pattern](/upgrades-plugins/proxies) page.
 
 Most of the proxies below are built on an abstract base contract.
 
@@ -20,7 +20,7 @@ There are two alternative ways to add upgradeability to an ERC-1967 proxy. Their
 * [`UUPSUpgradeable`](#UUPSUpgradeable): An upgradeability mechanism to be included in the implementation contract.
 
 **🔥 CAUTION**\
-Using upgradeable proxies correctly and securely is a difficult task that requires deep knowledge of the proxy pattern, Solidity, and the EVM. Unless you want a lot of low level control, we recommend using the [OpenZeppelin Upgrades Plugins](upgrades-plugins::index.adoc) for Hardhat and Foundry.
+Using upgradeable proxies correctly and securely is a difficult task that requires deep knowledge of the proxy pattern, Solidity, and the EVM. Unless you want a lot of low level control, we recommend using the [OpenZeppelin Upgrades Plugins](/upgrades-plugins) for Hardhat and Foundry.
 
 A different family of proxies are beacon proxies. This pattern, popularized by Dharma, allows multiple proxies to be upgraded to a different implementation in a single transaction.
 
@@ -2032,7 +2032,7 @@ See [`UUPSUpgradeable.notDelegated`](#UUPSUpgradeable-notDelegated--).
 Function that should revert when `msg.sender` is not authorized to upgrade the contract. Called by
 [`ERC1967Utils.upgradeToAndCall`](#ERC1967Utils-upgradeToAndCall-address-bytes-).
 
-Normally, this function will use an xref:access.adoc[access control] modifier such as [`Ownable.onlyOwner`](access#Ownable-onlyOwner--).
+Normally, this function will use an [access control](access) modifier such as [`Ownable.onlyOwner`](access#Ownable-onlyOwner--).
 
 ```solidity
 function _authorizeUpgrade(address) internal onlyOwner {}

--- a/content/contracts/5.x/api/proxy.mdx
+++ b/content/contracts/5.x/api/proxy.mdx
@@ -156,9 +156,9 @@ This function uses the create opcode, which should never revert.
 
 <Callout type="warn">
 This function does not check if `implementation` has code. A clone that points to an address
-</Callout>
 without code cannot be initialized. Initialization calls may appear to be successful when, in reality, they
 have no effect and leave the clone uninitialized, allowing a third party to initialize it later.
+</Callout>
 
 </div>
 </div>
@@ -180,14 +180,14 @@ to the new contract.
 
 <Callout type="warn">
 This function does not check if `implementation` has code. A clone that points to an address
-</Callout>
 without code cannot be initialized. Initialization calls may appear to be successful when, in reality, they
 have no effect and leave the clone uninitialized, allowing a third party to initialize it later.
+</Callout>
 
 <Callout>
 Using a non-zero value at creation will require the contract using this function (e.g. a factory)
-</Callout>
 to always have enough balance for new deployments. Consider exposing this function under a payable method.
+</Callout>
 
 </div>
 </div>
@@ -212,9 +212,9 @@ the clones cannot be deployed twice at the same address.
 
 <Callout type="warn">
 This function does not check if `implementation` has code. A clone that points to an address
-</Callout>
 without code cannot be initialized. Initialization calls may appear to be successful when, in reality, they
 have no effect and leave the clone uninitialized, allowing a third party to initialize it later.
+</Callout>
 
 </div>
 </div>
@@ -236,14 +236,14 @@ a `value` parameter to send native currency to the new contract.
 
 <Callout type="warn">
 This function does not check if `implementation` has code. A clone that points to an address
-</Callout>
 without code cannot be initialized. Initialization calls may appear to be successful when, in reality, they
 have no effect and leave the clone uninitialized, allowing a third party to initialize it later.
+</Callout>
 
 <Callout>
 Using a non-zero value at creation will require the contract using this function (e.g. a factory)
-</Callout>
 to always have enough balance for new deployments. Consider exposing this function under a payable method.
+</Callout>
 
 </div>
 </div>
@@ -302,9 +302,9 @@ This function uses the create opcode, which should never revert.
 
 <Callout type="warn">
 This function does not check if `implementation` has code. A clone that points to an address
-</Callout>
 without code cannot be initialized. Initialization calls may appear to be successful when, in reality, they
 have no effect and leave the clone uninitialized, allowing a third party to initialize it later.
+</Callout>
 
 </div>
 </div>
@@ -326,14 +326,14 @@ parameter to send native currency to the new contract.
 
 <Callout type="warn">
 This function does not check if `implementation` has code. A clone that points to an address
-</Callout>
 without code cannot be initialized. Initialization calls may appear to be successful when, in reality, they
 have no effect and leave the clone uninitialized, allowing a third party to initialize it later.
+</Callout>
 
 <Callout>
 Using a non-zero value at creation will require the contract using this function (e.g. a factory)
-</Callout>
 to always have enough balance for new deployments. Consider exposing this function under a payable method.
+</Callout>
 
 </div>
 </div>
@@ -360,9 +360,9 @@ at the same address.
 
 <Callout type="warn">
 This function does not check if `implementation` has code. A clone that points to an address
-</Callout>
 without code cannot be initialized. Initialization calls may appear to be successful when, in reality, they
 have no effect and leave the clone uninitialized, allowing a third party to initialize it later.
+</Callout>
 
 </div>
 </div>
@@ -384,14 +384,14 @@ but with a `value` parameter to send native currency to the new contract.
 
 <Callout type="warn">
 This function does not check if `implementation` has code. A clone that points to an address
-</Callout>
 without code cannot be initialized. Initialization calls may appear to be successful when, in reality, they
 have no effect and leave the clone uninitialized, allowing a third party to initialize it later.
+</Callout>
 
 <Callout>
 Using a non-zero value at creation will require the contract using this function (e.g. a factory)
-</Callout>
 to always have enough balance for new deployments. Consider exposing this function under a payable method.
+</Callout>
 
 </div>
 </div>
@@ -543,9 +543,9 @@ Returns the current implementation address.
 
 <Callout>
 To get this value clients can read directly from the storage slot shown below (specified by ERC-1967) using
-</Callout>
 the [`eth_getStorageAt`](https://eth.wiki/json-rpc/API#eth_getstorageat) RPC call.
 `0x360894a13ba1a3210667c828492db98dca3e2076cc3735a920a3ca505d382bbc`
+</Callout>
 
 </div>
 </div>
@@ -645,9 +645,9 @@ Returns the current admin.
 
 <Callout>
 To get this value clients can read directly from the storage slot shown below (specified by ERC-1967) using
-</Callout>
 the [`eth_getStorageAt`](https://eth.wiki/json-rpc/API#eth_getstorageat) RPC call.
 `0xb53127684a568b3173ae13b9f8a6016e243e63b6e8ee1178d6a717850b5d6103`
+</Callout>
 
 </div>
 </div>
@@ -917,8 +917,8 @@ the beacon to not upgrade the implementation maliciously.
 
 <Callout type="warn">
 Do not use the implementation logic to modify the beacon storage slot. Doing so would leave the proxy in
-</Callout>
 an inconsistent state where the beacon storage slot does not match the beacon address.
+</Callout>
 
 <div className="bg-secondary p-4 rounded-md mb-6">
 <h3 style={{ marginTop: "0"}}>Functions</h3>
@@ -1394,31 +1394,31 @@ interface of the proxy, including the ability to change who can trigger upgrades
 
 <Callout>
 The real interface of this proxy is that defined in `ITransparentUpgradeableProxy`. This contract does not
-</Callout>
 inherit from that interface, and instead `upgradeToAndCall` is implicitly implemented using a custom dispatch
 mechanism in `_fallback`. Consequently, the compiler will not produce an ABI for this contract. This is necessary to
 fully implement transparency without decoding reverts caused by selector clashes between the proxy and the
 implementation.
+</Callout>
 
 <Callout>
 This proxy does not inherit from [`Context`](utils#Context) deliberately. The [`ProxyAdmin`](#ProxyAdmin) of this contract won't send a
-</Callout>
 meta-transaction in any way, and any other meta-transaction setup should be made in the implementation contract.
+</Callout>
 
 <Callout type="warn">
 This contract avoids unnecessary storage reads by setting the admin only during construction as an
-</Callout>
 immutable variable, preventing any changes thereafter. However, the admin slot defined in ERC-1967 can still be
 overwritten by the implementation logic pointed to by this proxy. In such cases, the contract may end up in an
 undesirable state where the admin slot is different from the actual admin. Relying on the value of the admin slot
 is generally fine if the implementation is trusted.
+</Callout>
 
 <Callout type="warn">
 It is not recommended to extend this contract to add additional external functions. If you do so, the
-</Callout>
 compiler will not check that there are no selector conflicts, due to the note above. A selector clash between any new
 function and the functions declared in [`ITransparentUpgradeableProxy`](#ITransparentUpgradeableProxy) will be resolved in favor of the new one. This
 could render the `upgradeToAndCall` function inaccessible, preventing upgradeability and compromising transparency.
+</Callout>
 
 <div className="bg-secondary p-4 rounded-md mb-6">
 <h3 style={{ marginTop: "0"}}>Functions</h3>
@@ -1557,8 +1557,8 @@ contract MyTokenV2 is MyToken, ERC20PermitUpgradeable {
 
 <Callout>
 To avoid leaving the proxy in an uninitialized state, the initializer function should be called as early as
-</Callout>
 possible by providing the encoded function call as the `_data` argument to [`ERC1967Proxy.constructor`](#ERC1967Proxy-constructor-address-bytes-).
+</Callout>
 
 CAUTION: When used with inheritance, manual care must be taken to not invoke a parent initializer twice, or to ensure
 that all initializers are idempotent. This is not verified automatically as constructors are by Solidity.
@@ -1952,9 +1952,9 @@ implementation. It is used to validate the implementation's compatibility when p
 
 <Callout type="warn">
 A proxy pointing at a proxiable contract should not be considered proxiable itself, because this risks
-</Callout>
 bricking a proxy that upgrades to it, by delegating to itself until out of gas. Thus it is critical that this
 function revert if invoked through a proxy. This is guaranteed by the `notDelegated` modifier.
+</Callout>
 
 </div>
 </div>

--- a/content/contracts/5.x/api/token/ERC1155.mdx
+++ b/content/contracts/5.x/api/token/ERC1155.mdx
@@ -316,7 +316,7 @@ acceptance magic value.
 </div>
 <div className="px-4">
 
-xref:ROOT:erc1155.adoc#batch-operations[Batched] version of [`ERC1155.safeTransferFrom`](#ERC1155-safeTransferFrom-address-address-uint256-uint256-bytes-).
+[Batched](../../erc1155#batch-operations) version of [`ERC1155.safeTransferFrom`](#ERC1155-safeTransferFrom-address-address-uint256-uint256-bytes-).
 
 <Callout type="warn">
 This function can potentially allow a reentrancy attack when transferring tokens
@@ -429,7 +429,7 @@ acceptance magic value.
 </div>
 <div className="px-4">
 
-xref:ROOT:erc1155.adoc#batch-operations[Batched] version of [`ERC1155._safeTransferFrom`](#ERC1155-_safeTransferFrom-address-address-uint256-uint256-bytes-).
+[Batched](../../erc1155#batch-operations) version of [`ERC1155._safeTransferFrom`](#ERC1155-_safeTransferFrom-address-address-uint256-uint256-bytes-).
 
 Emits a [`IERC1155.TransferBatch`](#IERC1155-TransferBatch-address-address-address-uint256---uint256---) event.
 
@@ -512,7 +512,7 @@ acceptance magic value.
 </div>
 <div className="px-4">
 
-xref:ROOT:erc1155.adoc#batch-operations[Batched] version of [`ERC1155._mint`](#ERC1155-_mint-address-uint256-uint256-bytes-).
+[Batched](../../erc1155#batch-operations) version of [`ERC1155._mint`](#ERC1155-_mint-address-uint256-uint256-bytes-).
 
 Emits a [`IERC1155.TransferBatch`](#IERC1155-TransferBatch-address-address-address-uint256---uint256---) event.
 
@@ -562,7 +562,7 @@ Requirements:
 </div>
 <div className="px-4">
 
-xref:ROOT:erc1155.adoc#batch-operations[Batched] version of [`ERC1155._burn`](#ERC1155-_burn-address-uint256-uint256-).
+[Batched](../../erc1155#batch-operations) version of [`ERC1155._burn`](#ERC1155-_burn-address-uint256-uint256-).
 
 Emits a [`IERC1155.TransferBatch`](#IERC1155-TransferBatch-address-address-address-uint256---uint256---) event.
 
@@ -671,7 +671,7 @@ Returns the value of tokens of token type `id` owned by `account`.
 </div>
 <div className="px-4">
 
-xref:ROOT:erc1155.adoc#batch-operations[Batched] version of [`IERC777.balanceOf`](../interfaces#IERC777-balanceOf-address-).
+[Batched](../../erc1155#batch-operations) version of [`IERC777.balanceOf`](../interfaces#IERC777-balanceOf-address-).
 
 Requirements:
 
@@ -768,7 +768,7 @@ acceptance magic value.
 </div>
 <div className="px-4">
 
-xref:ROOT:erc1155.adoc#batch-operations[Batched] version of [`ERC1155.safeTransferFrom`](#ERC1155-safeTransferFrom-address-address-uint256-uint256-bytes-).
+[Batched](../../erc1155#batch-operations) version of [`ERC1155.safeTransferFrom`](#ERC1155-safeTransferFrom-address-address-uint256-uint256-bytes-).
 
 <Callout type="warn">
 This function can potentially allow a reentrancy attack when transferring tokens

--- a/content/contracts/5.x/api/token/ERC1155.mdx
+++ b/content/contracts/5.x/api/token/ERC1155.mdx
@@ -286,10 +286,10 @@ Transfers a `value` amount of tokens of type `id` from `from` to `to`.
 
 <Callout type="warn">
 This function can potentially allow a reentrancy attack when transferring tokens
-</Callout>
 to an untrusted contract, when invoking [`IERC1155Receiver.onERC1155Received`](#IERC1155Receiver-onERC1155Received-address-address-uint256-uint256-bytes-) on the receiver.
 Ensure to follow the checks-effects-interactions pattern and consider employing
 reentrancy guards when interacting with untrusted contracts.
+</Callout>
 
 Emits a [`IERC1155.TransferSingle`](#IERC1155-TransferSingle-address-address-address-uint256-uint256-) event.
 
@@ -320,10 +320,10 @@ acceptance magic value.
 
 <Callout type="warn">
 This function can potentially allow a reentrancy attack when transferring tokens
-</Callout>
 to an untrusted contract, when invoking [`IERC1155Receiver.onERC1155BatchReceived`](#IERC1155Receiver-onERC1155BatchReceived-address-address-uint256---uint256---bytes-) on the receiver.
 Ensure to follow the checks-effects-interactions pattern and consider employing
 reentrancy guards when interacting with untrusted contracts.
+</Callout>
 
 Emits either a [`IERC1155.TransferSingle`](#IERC1155-TransferSingle-address-address-address-uint256-uint256-) or a [`IERC1155.TransferBatch`](#IERC1155-TransferBatch-address-address-address-uint256---uint256---) event, depending on the length of the array arguments.
 
@@ -384,9 +384,9 @@ contains code (eg. is a smart contract at the moment of execution).
 
 <Callout type="warn">
 Overriding this function is discouraged because it poses a reentrancy risk from the receiver. So any
-</Callout>
 update to the contract state after this function would break the check-effect-interaction pattern. Consider
 overriding [`ERC1155._update`](#ERC1155-_update-address-address-uint256---uint256---) instead.
+</Callout>
 
 </div>
 </div>
@@ -738,10 +738,10 @@ Transfers a `value` amount of tokens of type `id` from `from` to `to`.
 
 <Callout type="warn">
 This function can potentially allow a reentrancy attack when transferring tokens
-</Callout>
 to an untrusted contract, when invoking [`IERC1155Receiver.onERC1155Received`](#IERC1155Receiver-onERC1155Received-address-address-uint256-uint256-bytes-) on the receiver.
 Ensure to follow the checks-effects-interactions pattern and consider employing
 reentrancy guards when interacting with untrusted contracts.
+</Callout>
 
 Emits a [`IERC1155.TransferSingle`](#IERC1155-TransferSingle-address-address-address-uint256-uint256-) event.
 
@@ -772,10 +772,10 @@ acceptance magic value.
 
 <Callout type="warn">
 This function can potentially allow a reentrancy attack when transferring tokens
-</Callout>
 to an untrusted contract, when invoking [`IERC1155Receiver.onERC1155BatchReceived`](#IERC1155Receiver-onERC1155BatchReceived-address-address-uint256---uint256---bytes-) on the receiver.
 Ensure to follow the checks-effects-interactions pattern and consider employing
 reentrancy guards when interacting with untrusted contracts.
+</Callout>
 
 Emits either a [`IERC1155.TransferSingle`](#IERC1155-TransferSingle-address-address-address-uint256-uint256-) or a [`IERC1155.TransferBatch`](#IERC1155-TransferBatch-address-address-address-uint256---uint256---) event, depending on the length of the array arguments.
 
@@ -909,9 +909,9 @@ called at the end of a `safeTransferFrom` after the balance has been updated.
 
 <Callout>
 To accept the transfer, this must return
-</Callout>
 `bytes4(keccak256("onERC1155Received(address,address,uint256,uint256,bytes)"))`
 (i.e. 0xf23a6e61, or its own function selector).
+</Callout>
 
 </div>
 </div>
@@ -934,9 +934,9 @@ been updated.
 
 <Callout>
 To accept the transfer(s), this must return
-</Callout>
 `bytes4(keccak256("onERC1155BatchReceived(address,address,uint256[],uint256[],bytes)"))`
 (i.e. 0xbc197c81, or its own function selector).
+</Callout>
 
 </div>
 </div>
@@ -1081,11 +1081,11 @@ event of a large bug.
 
 <Callout type="warn">
 This contract does not include public pause and unpause functions. In
-</Callout>
 addition to inheriting this contract, you must define both functions, invoking the
 [`Pausable._pause`](../utils#Pausable-_pause--) and [`Pausable._unpause`](../utils#Pausable-_unpause--) internal functions, with appropriate
 access control, e.g. using [`AccessControl`](../access#AccessControl) or [`Ownable`](../access#Ownable). Not doing so will
 make the contract pause mechanism of the contract unreachable, and thus unusable.
+</Callout>
 
 <div className="bg-secondary p-4 rounded-md mb-6">
 <h3 style={{ marginTop: "0"}}>Functions</h3>
@@ -1210,8 +1210,8 @@ same id are not going to be minted.
 
 <Callout>
 This contract implies a global limit of 2**256 - 1 to the number of tokens
-</Callout>
 that can be minted.
+</Callout>
 
 CAUTION: This extension should not be added in an upgrade to an already deployed contract.
 
@@ -1603,8 +1603,8 @@ Simple implementation of `IERC1155Receiver` that will allow a contract to hold E
 
 <Callout type="warn">
 When inheriting this contract, you must include a way to use the received tokens, otherwise they will be
-</Callout>
 stuck.
+</Callout>
 
 <div className="bg-secondary p-4 rounded-md mb-6">
 <h3 style={{ marginTop: "0"}}>Functions</h3>

--- a/content/contracts/5.x/api/token/ERC20.mdx
+++ b/content/contracts/5.x/api/token/ERC20.mdx
@@ -104,9 +104,9 @@ that a supply mechanism has to be added in a derived contract using [`ERC1155._m
 
 <Callout>
 For a detailed writeup see our guide
-</Callout>
 [How
 to implement supply mechanisms](https://forum.openzeppelin.com/t/how-to-implement-erc20-supply-mechanisms/226).
+</Callout>
 
 The default value of [`IERC6909Metadata.decimals`](../interfaces#IERC6909Metadata-decimals-uint256-) is 18. To change this, you should override
 this function so it returns a different value.
@@ -244,9 +244,9 @@ it's overridden.
 
 <Callout>
 This information is only used for _display_ purposes: it in
-</Callout>
 no way affects any of the arithmetic of the contract, including
 [`IERC20.balanceOf`](#IERC20-balanceOf-address-) and [`IERC20.transfer`](#IERC20-transfer-address-uint256-).
+</Callout>
 
 </div>
 </div>
@@ -344,8 +344,8 @@ See [`IERC20.approve`](#IERC20-approve-address-uint256-).
 
 <Callout>
 If `value` is the maximum `uint256`, the allowance is not updated on
-</Callout>
 `transferFrom`. This is semantically equivalent to an infinite approval.
+</Callout>
 
 Requirements:
 
@@ -373,8 +373,8 @@ required by the ERC. See [_approve](#ERC20-_approve-address-address-uint256-bool
 
 <Callout>
 Does not update the allowance if the current allowance
-</Callout>
 is the maximum `uint256`.
+</Callout>
 
 Requirements:
 
@@ -697,12 +697,12 @@ Returns a boolean value indicating whether the operation succeeded.
 
 <Callout type="warn">
 Beware that changing an allowance with this method brings the risk
-</Callout>
 that someone may use both the old and the new allowance by unfortunate
 transaction ordering. One possible solution to mitigate this race
 condition is to first reduce the spender's allowance to 0 and set the
 desired value afterwards:
 https://github.com/ethereum/EIPs/issues/20#issuecomment-263524729
+</Callout>
 
 Emits an [`IERC6909.Approval`](../interfaces#IERC6909-Approval-address-address-uint256-uint256-) event.
 
@@ -1381,9 +1381,9 @@ level. By default there is no fee, but this can be changed by overriding [`IERC3
 
 <Callout>
 When this extension is used along with the [`ERC20Capped`](#ERC20Capped) or [`ERC20Votes`](#ERC20Votes) extensions,
-</Callout>
 [`IERC3156FlashLender.maxFlashLoan`](../interfaces#IERC3156FlashLender-maxFlashLoan-address-) will not correctly reflect the maximum that can be flash minted. We recommend
 overriding [`IERC3156FlashLender.maxFlashLoan`](../interfaces#IERC3156FlashLender-maxFlashLoan-address-) so that it correctly reflects the supply cap.
+</Callout>
 
 <div className="bg-secondary p-4 rounded-md mb-6">
 <h3 style={{ marginTop: "0"}}>Functions</h3>
@@ -1620,11 +1620,11 @@ event of a large bug.
 
 <Callout type="warn">
 This contract does not include public pause and unpause functions. In
-</Callout>
 addition to inheriting this contract, you must define both functions, invoking the
 [`Pausable._pause`](../utils#Pausable-_pause--) and [`Pausable._unpause`](../utils#Pausable-_unpause--) internal functions, with appropriate
 access control, e.g. using [`AccessControl`](../access#AccessControl) or [`Ownable`](../access#Ownable). Not doing so will
 make the contract pause mechanism of the contract unreachable, and thus unusable.
+</Callout>
 
 <div className="bg-secondary p-4 rounded-md mb-6">
 <h3 style={{ marginTop: "0"}}>Functions</h3>
@@ -1853,8 +1853,8 @@ given ``owner``'s signed approval.
 
 <Callout type="warn">
 The same issues [`IERC20.approve`](#IERC20-approve-address-uint256-) has related to transaction
-</Callout>
 ordering also apply here.
+</Callout>
 
 Emits an [`IERC6909.Approval`](../interfaces#IERC6909-Approval-address-address-uint256-uint256-) event.
 
@@ -2146,8 +2146,8 @@ Returns the voting units of an `account`.
 
 <Callout type="warn">
 Overriding this function may compromise the internal vote accounting.
-</Callout>
 `ERC20Votes` assumes tokens map to voting units 1:1 and this is not easy to change.
+</Callout>
 
 </div>
 </div>
@@ -2227,10 +2227,10 @@ wrapping of an existing "basic" ERC-20 into a governance token.
 
 <Callout type="warn">
 Any mechanism in which the underlying token changes the [`IERC777.balanceOf`](../interfaces#IERC777-balanceOf-address-) of an account without an explicit transfer
-</Callout>
 may desynchronize this contract's supply and its underlying balance. Please exercise caution when wrapping tokens that
 may undercollateralize the wrapper (i.e. wrapper's total supply is higher than its underlying balance). See [`ERC20Wrapper._recover`](#ERC20Wrapper-_recover-address-)
 for recovering value accrued to the wrapper.
+</Callout>
 
 <div className="bg-secondary p-4 rounded-md mb-6">
 <h3 style={{ marginTop: "0"}}>Functions</h3>
@@ -2645,9 +2645,9 @@ scenario where all the conditions are met.
 
 <Callout>
 This calculation MAY NOT reflect the “per-user” price-per-share, and instead should reflect the
-</Callout>
 “average-user’s” price-per-share, meaning what the average user should expect to see when exchanging to and
 from.
+</Callout>
 
 </div>
 </div>
@@ -2674,9 +2674,9 @@ scenario where all the conditions are met.
 
 <Callout>
 This calculation MAY NOT reflect the “per-user” price-per-share, and instead should reflect the
-</Callout>
 “average-user’s” price-per-share, meaning what the average user should expect to see when exchanging to and
 from.
+</Callout>
 
 </div>
 </div>
@@ -2791,8 +2791,8 @@ current on-chain conditions.
 
 <Callout>
 any unfavorable discrepancy between convertToShares and previewDeposit SHOULD be considered slippage in
-</Callout>
 share price or some other type of condition, meaning the depositor will lose assets by depositing.
+</Callout>
 
 </div>
 </div>
@@ -2822,8 +2822,8 @@ current on-chain conditions.
 
 <Callout>
 any unfavorable discrepancy between convertToAssets and previewMint SHOULD be considered slippage in
-</Callout>
 share price or some other type of condition, meaning the depositor will lose assets by minting.
+</Callout>
 
 </div>
 </div>
@@ -2854,8 +2854,8 @@ given current on-chain conditions.
 
 <Callout>
 any unfavorable discrepancy between convertToShares and previewWithdraw SHOULD be considered slippage in
-</Callout>
 share price or some other type of condition, meaning the depositor will lose assets by depositing.
+</Callout>
 
 </div>
 </div>
@@ -2885,8 +2885,8 @@ given current on-chain conditions.
 
 <Callout>
 any unfavorable discrepancy between convertToAssets and previewRedeem SHOULD be considered slippage in
-</Callout>
 share price or some other type of condition, meaning the depositor will lose assets by redeeming.
+</Callout>
 
 </div>
 </div>
@@ -2993,8 +2993,8 @@ Burns exactly shares from owner and sends assets of underlying tokens to receive
 
 <Callout>
 some implementations will require pre-requesting to the Vault before a withdrawal may be performed.
-</Callout>
 Those methods should be performed separately.
+</Callout>
 
 </div>
 </div>
@@ -3321,8 +3321,8 @@ given ``owner``'s signed approval.
 
 <Callout type="warn">
 The same issues [`IERC20.approve`](#IERC20-approve-address-uint256-) has related to transaction
-</Callout>
 ordering also apply here.
+</Callout>
 
 Emits an [`IERC6909.Approval`](../interfaces#IERC6909-Approval-address-address-uint256-uint256-) event.
 
@@ -3756,8 +3756,8 @@ Does NOT emit an [`IERC6909.Approval`](../interfaces#IERC6909-Approval-address-a
 to consuming the persistent allowance.
 <Callout>
 This function skips calling `super._spendAllowance` if the temporary allowance
-</Callout>
 is enough to cover the spending.
+</Callout>
 
 </div>
 </div>
@@ -4012,10 +4012,10 @@ non-reverting calls are assumed to be successful.
 
 <Callout type="warn">
 If the token implements ERC-7674 (ERC-20 with temporary allowance), and if the "client"
-</Callout>
 smart contract uses ERC-7674 to set temporary allowances, then the "client" smart contract should avoid using
 this function. Performing a [`SafeERC20.safeIncreaseAllowance`](#SafeERC20-safeIncreaseAllowance-contract-IERC20-address-uint256-) or [`SafeERC20.safeDecreaseAllowance`](#SafeERC20-safeDecreaseAllowance-contract-IERC20-address-uint256-) operation on a token contract
 that has a non-zero temporary allowance (for that particular owner-spender) will result in unexpected behavior.
+</Callout>
 
 </div>
 </div>
@@ -4037,10 +4037,10 @@ value, non-reverting calls are assumed to be successful.
 
 <Callout type="warn">
 If the token implements ERC-7674 (ERC-20 with temporary allowance), and if the "client"
-</Callout>
 smart contract uses ERC-7674 to set temporary allowances, then the "client" smart contract should avoid using
 this function. Performing a [`SafeERC20.safeIncreaseAllowance`](#SafeERC20-safeIncreaseAllowance-contract-IERC20-address-uint256-) or [`SafeERC20.safeDecreaseAllowance`](#SafeERC20-safeDecreaseAllowance-contract-IERC20-address-uint256-) operation on a token contract
 that has a non-zero temporary allowance (for that particular owner-spender) will result in unexpected behavior.
+</Callout>
 
 </div>
 </div>
@@ -4063,9 +4063,9 @@ to be set to zero before setting it to a non-zero value, such as USDT.
 
 <Callout>
 If the token implements ERC-7674, this function will not modify any temporary allowance. This function
-</Callout>
 only sets the "standard" allowance. Any temporary allowance will remain active, in addition to the value being
 set here.
+</Callout>
 
 </div>
 </div>
@@ -4130,9 +4130,9 @@ targeting contracts.
 
 <Callout>
 When the recipient address (`to`) has no code (i.e. is an EOA), this function behaves as [`SafeERC20.forceApprove`](#SafeERC20-forceApprove-contract-IERC20-address-uint256-).
-</Callout>
 Opposedly, when the recipient address (`to`) has code, this function only attempts to call [`ERC1363.approveAndCall`](#ERC1363-approveAndCall-address-uint256-bytes-)
 once without retrying, and relies on the returned value to be true.
+</Callout>
 
 Reverts if the returned value is other than `true`.
 

--- a/content/contracts/5.x/api/token/ERC20.mdx
+++ b/content/contracts/5.x/api/token/ERC20.mdx
@@ -6,7 +6,7 @@ description: "Smart contract ERC20 utilities and implementations"
 This set of interfaces, contracts, and utilities are all related to the [ERC-20 Token Standard](https://eips.ethereum.org/EIPS/eip-20).
 
 <Callout>
-For an overview of ERC-20 tokens and a walk through on how to create a token contract read our [ERC-20 guide](ROOT:erc20.adoc).
+For an overview of ERC-20 tokens and a walk through on how to create a token contract read our [ERC-20 guide](../../erc20).
 </Callout>
 
 There are a few core contracts that implement the behavior specified in the ERC-20 standard:
@@ -2448,7 +2448,7 @@ itself determines the initial exchange rate. While not fully preventing the atta
 offset (0) makes it non-profitable even if an attacker is able to capture value from multiple user deposits, as a result
 of the value being captured by the virtual shares (out of the attacker's donation) matching the attacker's expected gains.
 With a larger offset, the attack becomes orders of magnitude more expensive than it is profitable. More details about the
-underlying math can be found xref:ROOT:erc4626.adoc#inflation-attack[here].
+underlying math can be found [here](../../erc4626#security-concern-inflation-attack).
 
 The drawback of this approach is that the virtual shares do capture (a very small) part of the value being accrued
 to the vault. Also, if the vault experiences losses, the users try to exit the vault, the virtual shares and assets
@@ -2456,7 +2456,7 @@ will cause the first user to exit to experience reduced losses in detriment to t
 bigger losses. Developers willing to revert back to the pre-v4.9 behavior just need to override the
 `_convertToShares` and `_convertToAssets` functions.
 
-To learn more, check out our xref:ROOT:erc4626.adoc[ERC-4626 guide].
+To learn more, check out our [ERC-4626 guide](../../erc4626).
 </Callout>
 
 <div className="bg-secondary p-4 rounded-md mb-6">

--- a/content/contracts/5.x/api/token/ERC721.mdx
+++ b/content/contracts/5.x/api/token/ERC721.mdx
@@ -422,9 +422,9 @@ Transfers `tokenId` token from `from` to `to`.
 
 <Callout type="warn">
 Note that the caller is responsible to confirm that the recipient is capable of receiving ERC-721
-</Callout>
 or else they may be permanently lost. Usage of [`ERC1155.safeTransferFrom`](ERC1155#ERC1155-safeTransferFrom-address-address-uint256-uint256-bytes-) prevents loss, though the caller must
 understand this adds an external call which potentially creates a reentrancy vulnerability.
+</Callout>
 
 Requirements:
 
@@ -512,10 +512,10 @@ Returns the owner of the `tokenId`. Does NOT revert if token doesn't exist
 
 <Callout type="warn">
 Any overrides to this function that add ownership of tokens not tracked by the
-</Callout>
 core ERC-721 logic MUST be matched with the use of [`ERC721._increaseBalance`](#ERC721-_increaseBalance-address-uint128-) to keep balances
 consistent with ownership. The invariant to preserve is that for any address `a` the value returned by
 `balanceOf(a)` must be equal to the number of tokens such that `_ownerOf(tokenId)` is `a`.
+</Callout>
 
 </div>
 </div>
@@ -554,8 +554,8 @@ particular (ignoring whether it is owned by `owner`).
 
 <Callout type="warn">
 This function assumes that `owner` is the actual owner of `tokenId` and does not verify this
-</Callout>
 assumption.
+</Callout>
 
 </div>
 </div>
@@ -579,8 +579,8 @@ Reverts if:
 
 <Callout type="warn">
 This function assumes that `owner` is the actual owner of `tokenId` and does not verify this
-</Callout>
 assumption.
+</Callout>
 
 </div>
 </div>
@@ -601,14 +601,14 @@ Unsafe write access to the balances, used by extensions that "mint" tokens using
 
 <Callout>
 the value is limited to type(uint128).max. This protect against _balance overflow. It is unrealistic that
-</Callout>
 a uint256 would ever overflow from increments when these increments are bounded to uint128 values.
+</Callout>
 
 <Callout type="warn">
 Increasing an account's balance using this function tends to be paired with an override of the
-</Callout>
 [`ERC721._ownerOf`](#ERC721-_ownerOf-uint256-) function to resolve the ownership of the corresponding tokens so that balances and ownership
 remain consistent with one another.
+</Callout>
 
 </div>
 </div>
@@ -1052,9 +1052,9 @@ Transfers `tokenId` token from `from` to `to`.
 
 <Callout type="warn">
 Note that the caller is responsible to confirm that the recipient is capable of receiving ERC-721
-</Callout>
 or else they may be permanently lost. Usage of [`ERC1155.safeTransferFrom`](ERC1155#ERC1155-safeTransferFrom-address-address-uint256-uint256-bytes-) prevents loss, though the caller must
 understand this adds an external call which potentially creates a reentrancy vulnerability.
+</Callout>
 
 Requirements:
 
@@ -1407,15 +1407,15 @@ regained after construction. During construction, only batch minting is allowed.
 
 <Callout type="warn">
 This extension does not call the [`ERC1155._update`](ERC1155#ERC1155-_update-address-address-uint256---uint256---) function for tokens minted in batch. Any logic added to this
-</Callout>
 function through overrides will not be triggered when token are minted in batch. You may want to also override
 [`ERC721._increaseBalance`](#ERC721-_increaseBalance-address-uint128-) or [`ERC721Consecutive._mintConsecutive`](#ERC721Consecutive-_mintConsecutive-address-uint96-) to account for these mints.
+</Callout>
 
 <Callout type="warn">
 When overriding [`ERC721Consecutive._mintConsecutive`](#ERC721Consecutive-_mintConsecutive-address-uint96-), be careful about call ordering. [`ERC721.ownerOf`](#ERC721-ownerOf-uint256-) may return invalid
-</Callout>
 values during the [`ERC721Consecutive._mintConsecutive`](#ERC721Consecutive-_mintConsecutive-address-uint96-) execution if the super call is not called first. To be safe, execute the
 super call before your custom logic.
+</Callout>
 
 <div className="bg-secondary p-4 rounded-md mb-6">
 <h3 style={{ marginTop: "0"}}>Functions</h3>
@@ -1524,8 +1524,8 @@ tokens.
 
 <Callout>
 Overriding the default value of 5000 will not cause on-chain issues, but may result in the asset not being
-</Callout>
 correctly supported by off-chain indexing services (including marketplaces).
+</Callout>
 
 </div>
 </div>
@@ -1594,8 +1594,8 @@ See [`ERC721._update`](#ERC721-_update-address-uint256-address-). Override versi
 
 <Callout type="warn">
 Using [`ERC721Consecutive`](#ERC721Consecutive) prevents minting during construction in favor of [`ERC721Consecutive._mintConsecutive`](#ERC721Consecutive-_mintConsecutive-address-uint96-).
-</Callout>
 After construction, [`ERC721Consecutive._mintConsecutive`](#ERC721Consecutive-_mintConsecutive-address-uint96-) is no longer available and minting through [`ERC1155._update`](ERC1155#ERC1155-_update-address-address-uint256---uint256---) becomes available.
+</Callout>
 
 </div>
 </div>
@@ -1974,11 +1974,11 @@ event of a large bug.
 
 <Callout type="warn">
 This contract does not include public pause and unpause functions. In
-</Callout>
 addition to inheriting this contract, you must define both functions, invoking the
 [`Pausable._pause`](../utils#Pausable-_pause--) and [`Pausable._unpause`](../utils#Pausable-_unpause--) internal functions, with appropriate
 access control, e.g. using [`AccessControl`](../access#AccessControl) or [`Ownable`](../access#Ownable). Not doing so will
 make the contract pause mechanism of the contract unreachable, and thus unusable.
+</Callout>
 
 <div className="bg-secondary p-4 rounded-md mb-6">
 <h3 style={{ marginTop: "0"}}>Functions</h3>
@@ -2115,9 +2115,9 @@ for specific token ids via [`ERC2981._setTokenRoyalty`](common#ERC2981-_setToken
 
 <Callout type="warn">
 ERC-2981 only specifies a way to signal royalty information and does not enforce its payment. See
-</Callout>
 [Rationale](https://eips.ethereum.org/EIPS/eip-2981#optional-royalty-payments) in the ERC. Marketplaces are expected to
 voluntarily pay royalties together with sales, but note that this standard is not yet widely supported.
+</Callout>
 
 <div className="bg-secondary p-4 rounded-md mb-6">
 <h3 style={{ marginTop: "0"}}>Functions</h3>
@@ -2775,8 +2775,8 @@ is accepted from [`ERC20Wrapper.depositFor`](ERC20#ERC20Wrapper-depositFor-addre
 
 <Callout type="warn">
 Doesn't work with unsafe transfers (eg. [`IERC721.transferFrom`](#IERC721-transferFrom-address-address-uint256-)). Use [`ERC721Wrapper._recover`](#ERC721Wrapper-_recover-address-uint256-)
-</Callout>
 for recovering in that scenario.
+</Callout>
 
 </div>
 </div>

--- a/content/contracts/5.x/api/token/ERC721.mdx
+++ b/content/contracts/5.x/api/token/ERC721.mdx
@@ -6,7 +6,7 @@ description: "Smart contract ERC721 utilities and implementations"
 This set of interfaces, contracts, and utilities is all related to the [ERC-721 Non-Fungible Token Standard](https://eips.ethereum.org/EIPS/eip-721).
 
 <Callout>
-For a walk through on how to create an ERC-721 token read our [ERC-721 guide](ROOT:erc721.adoc).
+For a walk through on how to create an ERC-721 token read our [ERC-721 guide](../../erc721).
 </Callout>
 
 The ERC specifies four interfaces:

--- a/content/contracts/5.x/api/token/common.mdx
+++ b/content/contracts/5.x/api/token/common.mdx
@@ -38,9 +38,9 @@ fee is specified in basis points by default.
 
 <Callout type="warn">
 ERC-2981 only specifies a way to signal royalty information and does not enforce its payment. See
-</Callout>
 [Rationale](https://eips.ethereum.org/EIPS/eip-2981#optional-royalty-payments) in the ERC. Marketplaces are expected to
 voluntarily pay royalties together with sales, but note that this standard is not yet widely supported.
+</Callout>
 
 <div className="bg-secondary p-4 rounded-md mb-6">
 <h3 style={{ marginTop: "0"}}>Functions</h3>
@@ -110,8 +110,8 @@ exchange. The royalty amount is denominated and should be paid in that same unit
 
 <Callout>
 ERC-2981 allows setting the royalty to 100% of the price. In that case all the price would be sent to the
-</Callout>
 royalty receiver and 0 tokens to the seller. Contracts dealing with royalty should consider empty transfers.
+</Callout>
 
 </div>
 </div>

--- a/content/contracts/5.x/api/utils.mdx
+++ b/content/contracts/5.x/api/utils.mdx
@@ -199,10 +199,10 @@ imposed by `transfer`, making them unable to receive funds via
 
 <Callout type="warn">
 because control is transferred to `recipient`, care must be
-</Callout>
 taken to not create reentrancy vulnerabilities. Consider using
 [`ReentrancyGuard`](#ReentrancyGuard) or the
 [checks-effects-interactions pattern](https://solidity.readthedocs.io/en/v0.8.20/security-considerations.html#use-the-checks-effects-interactions-pattern).
+</Callout>
 
 </div>
 </div>
@@ -421,10 +421,10 @@ convenience, but that returned value can be discarded safely if the caller has a
 
 <Callout>
 this function's cost is `O(n · log(n))` in average and `O(n²)` in the worst case, with n the length of the
-</Callout>
 array. Using it in view functions that are executed through `eth_call` is safe, but one should be very careful
 when executing this as part of a transaction. If the array being sorted is too large, the sort operation may
 consume more gas than is available in a block, leading to potential DoS.
+</Callout>
 
 <Callout type="warn">
 Consider memory side-effects when using custom comparator functions that access memory in an unsafe way.
@@ -469,10 +469,10 @@ convenience, but that returned value can be discarded safely if the caller has a
 
 <Callout>
 this function's cost is `O(n · log(n))` in average and `O(n²)` in the worst case, with n the length of the
-</Callout>
 array. Using it in view functions that are executed through `eth_call` is safe, but one should be very careful
 when executing this as part of a transaction. If the array being sorted is too large, the sort operation may
 consume more gas than is available in a block, leading to potential DoS.
+</Callout>
 
 <Callout type="warn">
 Consider memory side-effects when using custom comparator functions that access memory in an unsafe way.
@@ -517,10 +517,10 @@ convenience, but that returned value can be discarded safely if the caller has a
 
 <Callout>
 this function's cost is `O(n · log(n))` in average and `O(n²)` in the worst case, with n the length of the
-</Callout>
 array. Using it in view functions that are executed through `eth_call` is safe, but one should be very careful
 when executing this as part of a transaction. If the array being sorted is too large, the sort operation may
 consume more gas than is available in a block, leading to potential DoS.
+</Callout>
 
 <Callout type="warn">
 Consider memory side-effects when using custom comparator functions that access memory in an unsafe way.
@@ -565,14 +565,14 @@ returned. Time complexity O(log n).
 
 <Callout>
 The `array` is expected to be sorted in ascending order, and to
-</Callout>
 contain no repeated elements.
+</Callout>
 
 <Callout type="warn">
 Deprecated. This implementation behaves as [`Arrays.lowerBound`](#Arrays-lowerBound-uint256---uint256-) but lacks
-</Callout>
 support for repeated elements in the array. The [`Arrays.lowerBound`](#Arrays-lowerBound-uint256---uint256-) function should
 be used instead.
+</Callout>
 
 </div>
 </div>
@@ -1057,8 +1057,8 @@ For blocks older than 8191 or future blocks, it returns zero, matching the `BLOC
 
 <Callout>
 After EIP-2935 activation, it takes 8191 blocks to completely fill the history.
-</Callout>
 Before that, only block hashes since the fork block will be available.
+</Callout>
 
 <div className="bg-secondary p-4 rounded-md mb-6">
 <h3 style={{ marginTop: "0"}}>Functions</h3>
@@ -1083,8 +1083,8 @@ Retrieves the block hash for any historical block within the supported range.
 
 <Callout>
 The function gracefully handles future blocks and blocks beyond the history window
-</Callout>
 by returning zero, consistent with the EVM's native `BLOCKHASH` behavior.
+</Callout>
 
 </div>
 </div>
@@ -1280,11 +1280,11 @@ account_address:   [-.%a-zA-Z0-9]{1,128}
 
 <Callout type="warn">
 According to [CAIP-10's canonicalization section](https://github.com/ChainAgnostic/CAIPs/blob/main/CAIPs/caip-10.md#canonicalization),
-</Callout>
 the implementation remains at the developer's discretion. Please note that case variations may introduce ambiguity.
 For example, when building hashes to identify accounts or data associated to them, multiple representations of the
 same account would derive to different hashes. For EVM chains, we recommend using checksummed addresses for the
 "account_address" part. They can be generated onchain using [`Strings.toChecksumHexString`](#Strings-toChecksumHexString-address-).
+</Callout>
 
 <div className="bg-secondary p-4 rounded-md mb-6">
 <h3 style={{ marginTop: "0"}}>Functions</h3>
@@ -1349,8 +1349,8 @@ Parse a CAIP-10 identifier into its components.
 
 <Callout>
 This function does not verify that the CAIP-10 input is properly formatted. The `caip2` return can be
-</Callout>
 parsed using the [`CAIP2`](#CAIP2) library.
+</Callout>
 
 </div>
 </div>
@@ -1380,10 +1380,10 @@ reference:   [-_a-zA-Z0-9]{1,32}
 
 <Callout type="warn">
 In some cases, multiple CAIP-2 identifiers may all be valid representation of a single chain.
-</Callout>
 For EVM chains, it is recommended to use `eip155:xxx` as the canonical representation (where `xxx` is
 the EIP-155 chain id). Consider the possible ambiguity when processing CAIP-2 identifiers or when using them
 in the context of hashes.
+</Callout>
 
 <div className="bg-secondary p-4 rounded-md mb-6">
 <h3 style={{ marginTop: "0"}}>Functions</h3>
@@ -1787,8 +1787,8 @@ Collection of common custom errors used in multiple contracts
 
 <Callout type="warn">
 Backwards compatibility is not guaranteed in future versions of the library.
-</Callout>
 It is recommended to avoid relying on the error API for critical functionality.
+</Callout>
 
 _Available since v5.1._
 
@@ -1894,10 +1894,10 @@ selectors won't filter calls nested within a [`Multicall.multicall`](#Multicall-
 
 <Callout>
 Since 5.0.1 and 4.9.4, this contract identifies non-canonical contexts (i.e. `msg.sender` is not [`Context._msgSender`](#Context-_msgSender--)).
-</Callout>
 If a non-canonical context is identified, the following self `delegatecall` appends the last bytes of `msg.data`
 to the subcall. This makes it safe to use with [`ERC2771Context`](metatx#ERC2771Context). Contexts that don't affect the resolution of
 [`Context._msgSender`](#Context-_msgSender--) are not propagated to subcalls.
+</Callout>
 
 <div className="bg-secondary p-4 rounded-md mb-6">
 <h3 style={{ marginTop: "0"}}>Functions</h3>
@@ -2049,9 +2049,9 @@ Follows the [ERC-4337's semi-abstracted nonce system](https://eips.ethereum.org/
 
 <Callout>
 This contract inherits from [`Nonces`](#Nonces) and reuses its storage for the first nonce key (i.e. `0`). This
-</Callout>
 makes upgrading from [`Nonces`](#Nonces) to [`NoncesKeyed`](#NoncesKeyed) safe when using their upgradeable versions (e.g. `NoncesKeyedUpgradeable`).
 Doing so will NOT reset the current state of nonces, avoiding replay attacks where a nonce is reused after the upgrade.
+</Callout>
 
 <div className="bg-secondary p-4 rounded-md mb-6">
 <h3 style={{ marginTop: "0"}}>Functions</h3>
@@ -5967,14 +5967,14 @@ points to them.
 
 <Callout>
 If EIP-1153 (transient storage) is available on the chain you're deploying at,
-</Callout>
 consider using [`ReentrancyGuardTransient`](#ReentrancyGuardTransient) instead.
+</Callout>
 
 <Callout>
 If you would like to learn more about reentrancy and alternative ways
-</Callout>
 to protect against it, check out our blog post
 [Reentrancy After Istanbul](https://blog.openzeppelin.com/reentrancy-after-istanbul/).
+</Callout>
 
 <div className="bg-secondary p-4 rounded-md mb-6">
 <h3 style={{ marginTop: "0"}}>Modifiers</h3>
@@ -6355,8 +6355,8 @@ Return the length of a string that was encoded to `ShortString` or written to st
 
 <Callout type="warn">
 This will return the "byte length" of the string. This may not reflect the actual length in terms of
-</Callout>
 actual characters as the UTF-8 encoding of a single character can span over multiple bytes.
+</Callout>
 
 </div>
 </div>
@@ -6439,8 +6439,8 @@ Consider using this library along with [`StorageSlot`](#StorageSlot).
 
 <Callout>
 This library provides a way to manipulate storage locations in a non-standard way. Tooling for checking
-</Callout>
 upgrade safety will ignore the slots accessed through this library.
+</Callout>
 
 _Available since v5.1._
 
@@ -7376,9 +7376,9 @@ This function should only be used in double quoted JSON strings. Single quotes a
 
 <Callout>
 This function escapes all unicode characters, and not just the ones in ranges defined in section 2.5 of
-</Callout>
 RFC-4627 (U+0000 to U+001F, U+0022 and U+005C). ECMAScript's `JSON.parse` does recover escaped unicode
 characters that are not in this range, but other tooling may provide different results.
+</Callout>
 
 </div>
 </div>
@@ -8250,9 +8250,9 @@ Branchless ternary evaluation for `a ? b : c`. Gas costs are constant.
 
 <Callout type="warn">
 This function may reduce bytecode size and consume less gas when used standalone.
-</Callout>
 However, the compiler may optimize Solidity ternary operations (i.e. `a ? b : c`) to only compute
 one branch when needed, making this function more expensive.
+</Callout>
 
 </div>
 </div>
@@ -8422,8 +8422,8 @@ If the input value is not inversible, 0 is returned.
 
 <Callout>
 If you know for sure that n is (big) a prime, it may be cheaper to use Fermat's little theorem and get the
-</Callout>
 inverse using `Math.modExp(a, n - 2, n)`. See [`Math.invModPrime`](#Math-invModPrime-uint256-uint256-).
+</Callout>
 
 </div>
 </div>
@@ -8473,11 +8473,11 @@ Requirements:
 
 <Callout type="warn">
 The result is only valid if the underlying call succeeds. When using this function, make
-</Callout>
 sure the chain you're using it on supports the precompiled contract for modular exponentiation
 at address 0x05 as specified in [EIP-198](https://eips.ethereum.org/EIPS/eip-198). Otherwise,
 the underlying function will succeed given the lack of a revert, but the result may be incorrectly
 interpreted as 0.
+</Callout>
 
 </div>
 </div>
@@ -8500,10 +8500,10 @@ to operate modulo 0 or if the underlying precompile reverted.
 
 <Callout type="warn">
 The result is only valid if the success flag is true. When using this function, make sure the chain
-</Callout>
 you're using it on supports the precompiled contract for modular exponentiation at address 0x05 as specified in
 [EIP-198](https://eips.ethereum.org/EIPS/eip-198). Otherwise, the underlying function will succeed given the lack
 of a revert, but the result may be incorrectly interpreted as 0.
+</Callout>
 
 </div>
 </div>
@@ -10506,9 +10506,9 @@ Branchless ternary evaluation for `a ? b : c`. Gas costs are constant.
 
 <Callout type="warn">
 This function may reduce bytecode size and consume less gas when used standalone.
-</Callout>
 However, the compiler may optimize Solidity ternary operations (i.e. `a ? b : c`) to only compute
 one branch when needed, making this function more expensive.
+</Callout>
 
 </div>
 </div>
@@ -10765,8 +10765,8 @@ Returns previous value and new value.
 
 <Callout type="warn">
 Never accept `key` as a user input, since an arbitrary `type(uint32).max` key set will disable the
-</Callout>
 library.
+</Callout>
 
 </div>
 </div>
@@ -10824,8 +10824,8 @@ if there is none.
 
 <Callout>
 This is a variant of [`Checkpoints.upperLookup`](#Checkpoints-upperLookup-struct-Checkpoints-Trace160-uint96-) that is optimized to find "recent" checkpoint (checkpoints with high
-</Callout>
 keys).
+</Callout>
 
 </div>
 </div>
@@ -10917,8 +10917,8 @@ Returns previous value and new value.
 
 <Callout type="warn">
 Never accept `key` as a user input, since an arbitrary `type(uint48).max` key set will disable the
-</Callout>
 library.
+</Callout>
 
 </div>
 </div>
@@ -10976,8 +10976,8 @@ if there is none.
 
 <Callout>
 This is a variant of [`Checkpoints.upperLookup`](#Checkpoints-upperLookup-struct-Checkpoints-Trace160-uint96-) that is optimized to find "recent" checkpoint (checkpoints with high
-</Callout>
 keys).
+</Callout>
 
 </div>
 </div>
@@ -11069,8 +11069,8 @@ Returns previous value and new value.
 
 <Callout type="warn">
 Never accept `key` as a user input, since an arbitrary `type(uint96).max` key set will disable the
-</Callout>
 library.
+</Callout>
 
 </div>
 </div>
@@ -11128,8 +11128,8 @@ if there is none.
 
 <Callout>
 This is a variant of [`Checkpoints.upperLookup`](#Checkpoints-upperLookup-struct-Checkpoints-Trace160-uint96-) that is optimized to find "recent" checkpoint (checkpoints with high
-</Callout>
 keys).
+</Callout>
 
 </div>
 </div>
@@ -11305,8 +11305,8 @@ If the CircularBuffer was already setup and used, calling that function again wi
 
 <Callout>
 The size of the buffer will affect the execution of [`CircularBuffer.includes`](#CircularBuffer-includes-struct-CircularBuffer-Bytes32CircularBuffer-bytes32-) function, as it has a complexity of O(N).
-</Callout>
 Consider a large buffer size may render the function unusable.
+</Callout>
 
 </div>
 </div>
@@ -11628,8 +11628,8 @@ Resets the queue back to being empty.
 
 <Callout>
 The current items are left behind in storage. This does not affect the functioning of the queue, but misses
-</Callout>
 out on potential gas refunds.
+</Callout>
 
 </div>
 </div>
@@ -11897,8 +11897,8 @@ Removes all the entries from a map. O(n).
 
 <Callout type="warn">
 Developers should keep in mind that this function has an unbounded cost and using it may render the
-</Callout>
 function uncallable if the map grows to the point where clearing it consumes too much gas to fit in a block.
+</Callout>
 
 </div>
 </div>
@@ -12016,10 +12016,10 @@ Returns an array containing all the keys
 
 <Callout type="warn">
 This operation will copy the entire storage to memory, which can be quite expensive. This is designed
-</Callout>
 to mostly be used by view accessors that are queried without any gas fees. Developers should keep in mind that
 this function has an unbounded cost, and using it as part of a state-changing function may render the function
 uncallable if the map grows to a point where copying to memory consumes too much gas to fit in a block.
+</Callout>
 
 </div>
 </div>
@@ -12040,10 +12040,10 @@ Returns an array containing a slice of the keys
 
 <Callout type="warn">
 This operation will copy the entire storage to memory, which can be quite expensive. This is designed
-</Callout>
 to mostly be used by view accessors that are queried without any gas fees. Developers should keep in mind that
 this function has an unbounded cost, and using it as part of a state-changing function may render the function
 uncallable if the map grows to a point where copying to memory consumes too much gas to fit in a block.
+</Callout>
 
 </div>
 </div>
@@ -12104,9 +12104,9 @@ Removes all the entries from a map. O(n).
 
 <Callout type="warn">
 This function has an unbounded cost that scales with map size. Developers should keep in mind that
-</Callout>
 using it may render the function uncallable if the map grows to the point where clearing it consumes too much
 gas to fit in a block.
+</Callout>
 
 </div>
 </div>
@@ -12223,10 +12223,10 @@ Returns an array containing all the keys
 
 <Callout type="warn">
 This operation will copy the entire storage to memory, which can be quite expensive. This is designed
-</Callout>
 to mostly be used by view accessors that are queried without any gas fees. Developers should keep in mind that
 this function has an unbounded cost, and using it as part of a state-changing function may render the function
 uncallable if the map grows to a point where copying to memory consumes too much gas to fit in a block.
+</Callout>
 
 </div>
 </div>
@@ -12247,10 +12247,10 @@ Returns an array containing a slice of the keys
 
 <Callout type="warn">
 This operation will copy the entire storage to memory, which can be quite expensive. This is designed
-</Callout>
 to mostly be used by view accessors that are queried without any gas fees. Developers should keep in mind that
 this function has an unbounded cost, and using it as part of a state-changing function may render the function
 uncallable if the map grows to a point where copying to memory consumes too much gas to fit in a block.
+</Callout>
 
 </div>
 </div>
@@ -12311,9 +12311,9 @@ Removes all the entries from a map. O(n).
 
 <Callout type="warn">
 This function has an unbounded cost that scales with map size. Developers should keep in mind that
-</Callout>
 using it may render the function uncallable if the map grows to the point where clearing it consumes too much
 gas to fit in a block.
+</Callout>
 
 </div>
 </div>
@@ -12430,10 +12430,10 @@ Returns an array containing all the keys
 
 <Callout type="warn">
 This operation will copy the entire storage to memory, which can be quite expensive. This is designed
-</Callout>
 to mostly be used by view accessors that are queried without any gas fees. Developers should keep in mind that
 this function has an unbounded cost, and using it as part of a state-changing function may render the function
 uncallable if the map grows to a point where copying to memory consumes too much gas to fit in a block.
+</Callout>
 
 </div>
 </div>
@@ -12454,10 +12454,10 @@ Returns an array containing a slice of the keys
 
 <Callout type="warn">
 This operation will copy the entire storage to memory, which can be quite expensive. This is designed
-</Callout>
 to mostly be used by view accessors that are queried without any gas fees. Developers should keep in mind that
 this function has an unbounded cost, and using it as part of a state-changing function may render the function
 uncallable if the map grows to a point where copying to memory consumes too much gas to fit in a block.
+</Callout>
 
 </div>
 </div>
@@ -12518,9 +12518,9 @@ Removes all the entries from a map. O(n).
 
 <Callout type="warn">
 This function has an unbounded cost that scales with map size. Developers should keep in mind that
-</Callout>
 using it may render the function uncallable if the map grows to the point where clearing it consumes too much
 gas to fit in a block.
+</Callout>
 
 </div>
 </div>
@@ -12637,10 +12637,10 @@ Returns an array containing all the keys
 
 <Callout type="warn">
 This operation will copy the entire storage to memory, which can be quite expensive. This is designed
-</Callout>
 to mostly be used by view accessors that are queried without any gas fees. Developers should keep in mind that
 this function has an unbounded cost, and using it as part of a state-changing function may render the function
 uncallable if the map grows to a point where copying to memory consumes too much gas to fit in a block.
+</Callout>
 
 </div>
 </div>
@@ -12661,10 +12661,10 @@ Returns an array containing a slice of the keys
 
 <Callout type="warn">
 This operation will copy the entire storage to memory, which can be quite expensive. This is designed
-</Callout>
 to mostly be used by view accessors that are queried without any gas fees. Developers should keep in mind that
 this function has an unbounded cost, and using it as part of a state-changing function may render the function
 uncallable if the map grows to a point where copying to memory consumes too much gas to fit in a block.
+</Callout>
 
 </div>
 </div>
@@ -12725,9 +12725,9 @@ Removes all the entries from a map. O(n).
 
 <Callout type="warn">
 This function has an unbounded cost that scales with map size. Developers should keep in mind that
-</Callout>
 using it may render the function uncallable if the map grows to the point where clearing it consumes too much
 gas to fit in a block.
+</Callout>
 
 </div>
 </div>
@@ -12844,10 +12844,10 @@ Returns an array containing all the keys
 
 <Callout type="warn">
 This operation will copy the entire storage to memory, which can be quite expensive. This is designed
-</Callout>
 to mostly be used by view accessors that are queried without any gas fees. Developers should keep in mind that
 this function has an unbounded cost, and using it as part of a state-changing function may render the function
 uncallable if the map grows to a point where copying to memory consumes too much gas to fit in a block.
+</Callout>
 
 </div>
 </div>
@@ -12868,10 +12868,10 @@ Returns an array containing a slice of the keys
 
 <Callout type="warn">
 This operation will copy the entire storage to memory, which can be quite expensive. This is designed
-</Callout>
 to mostly be used by view accessors that are queried without any gas fees. Developers should keep in mind that
 this function has an unbounded cost, and using it as part of a state-changing function may render the function
 uncallable if the map grows to a point where copying to memory consumes too much gas to fit in a block.
+</Callout>
 
 </div>
 </div>
@@ -12932,9 +12932,9 @@ Removes all the entries from a map. O(n).
 
 <Callout type="warn">
 This function has an unbounded cost that scales with map size. Developers should keep in mind that
-</Callout>
 using it may render the function uncallable if the map grows to the point where clearing it consumes too much
 gas to fit in a block.
+</Callout>
 
 </div>
 </div>
@@ -13051,10 +13051,10 @@ Returns an array containing all the keys
 
 <Callout type="warn">
 This operation will copy the entire storage to memory, which can be quite expensive. This is designed
-</Callout>
 to mostly be used by view accessors that are queried without any gas fees. Developers should keep in mind that
 this function has an unbounded cost, and using it as part of a state-changing function may render the function
 uncallable if the map grows to a point where copying to memory consumes too much gas to fit in a block.
+</Callout>
 
 </div>
 </div>
@@ -13075,10 +13075,10 @@ Returns an array containing a slice of the keys
 
 <Callout type="warn">
 This operation will copy the entire storage to memory, which can be quite expensive. This is designed
-</Callout>
 to mostly be used by view accessors that are queried without any gas fees. Developers should keep in mind that
 this function has an unbounded cost, and using it as part of a state-changing function may render the function
 uncallable if the map grows to a point where copying to memory consumes too much gas to fit in a block.
+</Callout>
 
 </div>
 </div>
@@ -13139,9 +13139,9 @@ Removes all the entries from a map. O(n).
 
 <Callout type="warn">
 This function has an unbounded cost that scales with map size. Developers should keep in mind that
-</Callout>
 using it may render the function uncallable if the map grows to the point where clearing it consumes too much
 gas to fit in a block.
+</Callout>
 
 </div>
 </div>
@@ -13258,10 +13258,10 @@ Returns an array containing all the keys
 
 <Callout type="warn">
 This operation will copy the entire storage to memory, which can be quite expensive. This is designed
-</Callout>
 to mostly be used by view accessors that are queried without any gas fees. Developers should keep in mind that
 this function has an unbounded cost, and using it as part of a state-changing function may render the function
 uncallable if the map grows to a point where copying to memory consumes too much gas to fit in a block.
+</Callout>
 
 </div>
 </div>
@@ -13282,10 +13282,10 @@ Returns an array containing a slice of the keys
 
 <Callout type="warn">
 This operation will copy the entire storage to memory, which can be quite expensive. This is designed
-</Callout>
 to mostly be used by view accessors that are queried without any gas fees. Developers should keep in mind that
 this function has an unbounded cost, and using it as part of a state-changing function may render the function
 uncallable if the map grows to a point where copying to memory consumes too much gas to fit in a block.
+</Callout>
 
 </div>
 </div>
@@ -13346,9 +13346,9 @@ Removes all the entries from a map. O(n).
 
 <Callout type="warn">
 This function has an unbounded cost that scales with map size. Developers should keep in mind that
-</Callout>
 using it may render the function uncallable if the map grows to the point where clearing it consumes too much
 gas to fit in a block.
+</Callout>
 
 </div>
 </div>
@@ -13465,10 +13465,10 @@ Returns an array containing all the keys
 
 <Callout type="warn">
 This operation will copy the entire storage to memory, which can be quite expensive. This is designed
-</Callout>
 to mostly be used by view accessors that are queried without any gas fees. Developers should keep in mind that
 this function has an unbounded cost, and using it as part of a state-changing function may render the function
 uncallable if the map grows to a point where copying to memory consumes too much gas to fit in a block.
+</Callout>
 
 </div>
 </div>
@@ -13489,10 +13489,10 @@ Returns an array containing a slice of the keys
 
 <Callout type="warn">
 This operation will copy the entire storage to memory, which can be quite expensive. This is designed
-</Callout>
 to mostly be used by view accessors that are queried without any gas fees. Developers should keep in mind that
 this function has an unbounded cost, and using it as part of a state-changing function may render the function
 uncallable if the map grows to a point where copying to memory consumes too much gas to fit in a block.
+</Callout>
 
 </div>
 </div>
@@ -13553,9 +13553,9 @@ Removes all the entries from a map. O(n).
 
 <Callout type="warn">
 This function has an unbounded cost that scales with map size. Developers should keep in mind that
-</Callout>
 using it may render the function uncallable if the map grows to the point where clearing it consumes too much
 gas to fit in a block.
+</Callout>
 
 </div>
 </div>
@@ -13672,10 +13672,10 @@ Returns an array containing all the keys
 
 <Callout type="warn">
 This operation will copy the entire storage to memory, which can be quite expensive. This is designed
-</Callout>
 to mostly be used by view accessors that are queried without any gas fees. Developers should keep in mind that
 this function has an unbounded cost, and using it as part of a state-changing function may render the function
 uncallable if the map grows to a point where copying to memory consumes too much gas to fit in a block.
+</Callout>
 
 </div>
 </div>
@@ -13696,10 +13696,10 @@ Returns an array containing a slice of the keys
 
 <Callout type="warn">
 This operation will copy the entire storage to memory, which can be quite expensive. This is designed
-</Callout>
 to mostly be used by view accessors that are queried without any gas fees. Developers should keep in mind that
 this function has an unbounded cost, and using it as part of a state-changing function may render the function
 uncallable if the map grows to a point where copying to memory consumes too much gas to fit in a block.
+</Callout>
 
 </div>
 </div>
@@ -13760,8 +13760,8 @@ Removes all the entries from a map. O(n).
 
 <Callout type="warn">
 Developers should keep in mind that this function has an unbounded cost and using it may render the
-</Callout>
 function uncallable if the map grows to the point where clearing it consumes too much gas to fit in a block.
+</Callout>
 
 </div>
 </div>
@@ -13879,10 +13879,10 @@ Returns an array containing all the keys
 
 <Callout type="warn">
 This operation will copy the entire storage to memory, which can be quite expensive. This is designed
-</Callout>
 to mostly be used by view accessors that are queried without any gas fees. Developers should keep in mind that
 this function has an unbounded cost, and using it as part of a state-changing function may render the function
 uncallable if the map grows to a point where copying to memory consumes too much gas to fit in a block.
+</Callout>
 
 </div>
 </div>
@@ -13903,10 +13903,10 @@ Returns an array containing a slice of the keys
 
 <Callout type="warn">
 This operation will copy the entire storage to memory, which can be quite expensive. This is designed
-</Callout>
 to mostly be used by view accessors that are queried without any gas fees. Developers should keep in mind that
 this function has an unbounded cost, and using it as part of a state-changing function may render the function
 uncallable if the map grows to a point where copying to memory consumes too much gas to fit in a block.
+</Callout>
 
 </div>
 </div>
@@ -14101,8 +14101,8 @@ Removes all the values from a set. O(n).
 
 <Callout type="warn">
 Developers should keep in mind that this function has an unbounded cost and using it may render the
-</Callout>
 function uncallable if the set grows to the point where clearing it consumes too much gas to fit in a block.
+</Callout>
 
 </div>
 </div>
@@ -14181,10 +14181,10 @@ Return the entire set in an array
 
 <Callout type="warn">
 This operation will copy the entire storage to memory, which can be quite expensive. This is designed
-</Callout>
 to mostly be used by view accessors that are queried without any gas fees. Developers should keep in mind that
 this function has an unbounded cost, and using it as part of a state-changing function may render the function
 uncallable if the set grows to a point where copying to memory consumes too much gas to fit in a block.
+</Callout>
 
 </div>
 </div>
@@ -14205,10 +14205,10 @@ Return a slice of the set in an array
 
 <Callout type="warn">
 This operation will copy the entire storage to memory, which can be quite expensive. This is designed
-</Callout>
 to mostly be used by view accessors that are queried without any gas fees. Developers should keep in mind that
 this function has an unbounded cost, and using it as part of a state-changing function may render the function
 uncallable if the set grows to a point where copying to memory consumes too much gas to fit in a block.
+</Callout>
 
 </div>
 </div>
@@ -14269,8 +14269,8 @@ Removes all the values from a set. O(n).
 
 <Callout type="warn">
 Developers should keep in mind that this function has an unbounded cost and using it may render the
-</Callout>
 function uncallable if the set grows to the point where clearing it consumes too much gas to fit in a block.
+</Callout>
 
 </div>
 </div>
@@ -14349,10 +14349,10 @@ Return the entire set in an array
 
 <Callout type="warn">
 This operation will copy the entire storage to memory, which can be quite expensive. This is designed
-</Callout>
 to mostly be used by view accessors that are queried without any gas fees. Developers should keep in mind that
 this function has an unbounded cost, and using it as part of a state-changing function may render the function
 uncallable if the set grows to a point where copying to memory consumes too much gas to fit in a block.
+</Callout>
 
 </div>
 </div>
@@ -14373,10 +14373,10 @@ Return a slice of the set in an array
 
 <Callout type="warn">
 This operation will copy the entire storage to memory, which can be quite expensive. This is designed
-</Callout>
 to mostly be used by view accessors that are queried without any gas fees. Developers should keep in mind that
 this function has an unbounded cost, and using it as part of a state-changing function may render the function
 uncallable if the set grows to a point where copying to memory consumes too much gas to fit in a block.
+</Callout>
 
 </div>
 </div>
@@ -14437,8 +14437,8 @@ Removes all the values from a set. O(n).
 
 <Callout type="warn">
 Developers should keep in mind that this function has an unbounded cost and using it may render the
-</Callout>
 function uncallable if the set grows to the point where clearing it consumes too much gas to fit in a block.
+</Callout>
 
 </div>
 </div>
@@ -14517,10 +14517,10 @@ Return the entire set in an array
 
 <Callout type="warn">
 This operation will copy the entire storage to memory, which can be quite expensive. This is designed
-</Callout>
 to mostly be used by view accessors that are queried without any gas fees. Developers should keep in mind that
 this function has an unbounded cost, and using it as part of a state-changing function may render the function
 uncallable if the set grows to a point where copying to memory consumes too much gas to fit in a block.
+</Callout>
 
 </div>
 </div>
@@ -14541,10 +14541,10 @@ Return a slice of the set in an array
 
 <Callout type="warn">
 This operation will copy the entire storage to memory, which can be quite expensive. This is designed
-</Callout>
 to mostly be used by view accessors that are queried without any gas fees. Developers should keep in mind that
 this function has an unbounded cost, and using it as part of a state-changing function may render the function
 uncallable if the set grows to a point where copying to memory consumes too much gas to fit in a block.
+</Callout>
 
 </div>
 </div>
@@ -14605,8 +14605,8 @@ Removes all the values from a set. O(n).
 
 <Callout type="warn">
 Developers should keep in mind that this function has an unbounded cost and using it may render the
-</Callout>
 function uncallable if the set grows to the point where clearing it consumes too much gas to fit in a block.
+</Callout>
 
 </div>
 </div>
@@ -14685,10 +14685,10 @@ Return the entire set in an array
 
 <Callout type="warn">
 This operation will copy the entire storage to memory, which can be quite expensive. This is designed
-</Callout>
 to mostly be used by view accessors that are queried without any gas fees. Developers should keep in mind that
 this function has an unbounded cost, and using it as part of a state-changing function may render the function
 uncallable if the set grows to a point where copying to memory consumes too much gas to fit in a block.
+</Callout>
 
 </div>
 </div>
@@ -14709,10 +14709,10 @@ Return a slice of the set in an array
 
 <Callout type="warn">
 This operation will copy the entire storage to memory, which can be quite expensive. This is designed
-</Callout>
 to mostly be used by view accessors that are queried without any gas fees. Developers should keep in mind that
 this function has an unbounded cost, and using it as part of a state-changing function may render the function
 uncallable if the set grows to a point where copying to memory consumes too much gas to fit in a block.
+</Callout>
 
 </div>
 </div>
@@ -14773,8 +14773,8 @@ Removes all the values from a set. O(n).
 
 <Callout type="warn">
 Developers should keep in mind that this function has an unbounded cost and using it may render the
-</Callout>
 function uncallable if the set grows to the point where clearing it consumes too much gas to fit in a block.
+</Callout>
 
 </div>
 </div>
@@ -14853,10 +14853,10 @@ Return the entire set in an array
 
 <Callout type="warn">
 This operation will copy the entire storage to memory, which can be quite expensive. This is designed
-</Callout>
 to mostly be used by view accessors that are queried without any gas fees. Developers should keep in mind that
 this function has an unbounded cost, and using it as part of a state-changing function may render the function
 uncallable if the set grows to a point where copying to memory consumes too much gas to fit in a block.
+</Callout>
 
 </div>
 </div>
@@ -14877,10 +14877,10 @@ Return a slice of the set in an array
 
 <Callout type="warn">
 This operation will copy the entire storage to memory, which can be quite expensive. This is designed
-</Callout>
 to mostly be used by view accessors that are queried without any gas fees. Developers should keep in mind that
 this function has an unbounded cost, and using it as part of a state-changing function may render the function
 uncallable if the set grows to a point where copying to memory consumes too much gas to fit in a block.
+</Callout>
 
 </div>
 </div>
@@ -14923,9 +14923,9 @@ The structure is designed to perform the following operations with the correspon
 
 <Callout type="warn">
 This library allows for the use of custom comparator functions. Given that manipulating
-</Callout>
 memory can lead to unexpected behavior. Consider verifying that the comparator does not manipulate
 the Heap's state directly and that it follows the Solidity memory safety rules.
+</Callout>
 
 _Available since v5.1._
 
@@ -14977,8 +14977,8 @@ Remove (and return) the root element for the heap using the default comparator.
 
 <Callout>
 All inserting and removal from a heap should always be done using the same comparator. Mixing comparator
-</Callout>
 during the lifecycle of a heap will result in undefined behavior.
+</Callout>
 
 </div>
 </div>
@@ -14999,8 +14999,8 @@ Remove (and return) the root element for the heap using the provided comparator.
 
 <Callout>
 All inserting and removal from a heap should always be done using the same comparator. Mixing comparator
-</Callout>
 during the lifecycle of a heap will result in undefined behavior.
+</Callout>
 
 </div>
 </div>
@@ -15021,8 +15021,8 @@ Insert a new element in the heap using the default comparator.
 
 <Callout>
 All inserting and removal from a heap should always be done using the same comparator. Mixing comparator
-</Callout>
 during the lifecycle of a heap will result in undefined behavior.
+</Callout>
 
 </div>
 </div>
@@ -15043,8 +15043,8 @@ Insert a new element in the heap using the provided comparator.
 
 <Callout>
 All inserting and removal from a heap should always be done using the same comparator. Mixing comparator
-</Callout>
 during the lifecycle of a heap will result in undefined behavior.
+</Callout>
 
 </div>
 </div>
@@ -15066,8 +15066,8 @@ This is equivalent to using [`Heap.pop`](#Heap-pop-struct-Heap-Uint256Heap-funct
 
 <Callout>
 All inserting and removal from a heap should always be done using the same comparator. Mixing comparator
-</Callout>
 during the lifecycle of a heap will result in undefined behavior.
+</Callout>
 
 </div>
 </div>
@@ -15089,8 +15089,8 @@ This is equivalent to using [`Heap.pop`](#Heap-pop-struct-Heap-Uint256Heap-funct
 
 <Callout>
 All inserting and removal from a heap should always be done using the same comparator. Mixing comparator
-</Callout>
 during the lifecycle of a heap will result in undefined behavior.
+</Callout>
 
 </div>
 </div>
@@ -15159,9 +15159,9 @@ A tree is defined by the following parameters:
 
 <Callout>
 Building trees using non-commutative hashing functions (i.e. `H(a, b) != H(b, a)`) is supported. However,
-</Callout>
 proving the inclusion of a leaf in such trees is not possible with the [`MerkleProof`](cryptography#MerkleProof) library since it only supports
 _commutative_ hashing functions.
+</Callout>
 
 _Available since v5.1._
 
@@ -15208,8 +15208,8 @@ should be pushed to it using the default [push](#MerkleTree-push-struct-MerkleTr
 
 <Callout type="warn">
 The zero value should be carefully chosen since it will be stored in the tree representing
-</Callout>
 empty leaves. It should be a value that is not expected to be part of the tree.
+</Callout>
 
 </div>
 </div>
@@ -15233,13 +15233,13 @@ should be pushed to it using the custom push function, which should be the same 
 
 <Callout type="warn">
 Providing a custom hashing function is a security-sensitive operation since it may
-</Callout>
 compromise the soundness of the tree.
+</Callout>
 
 <Callout>
 Consider verifying that the hashing function does not manipulate the memory state directly and that it
-</Callout>
 follows the Solidity memory safety rules. Otherwise, it may lead to unexpected behavior.
+</Callout>
 
 </div>
 </div>

--- a/content/contracts/5.x/api/utils/cryptography.mdx
+++ b/content/contracts/5.x/api/utils/cryptography.mdx
@@ -381,9 +381,9 @@ The meaning of `name` and `version` is specified in
 - `version`: the current major version of the signing domain.
 
 <Callout>
-These parameters cannot be changed except through a xref:learn::upgrading-smart-contracts.adoc[smart
+These parameters cannot be changed except through a [smart
+contract upgrade](../../learn/upgrading-smart-contracts).
 </Callout>
-contract upgrade].
 
 </div>
 </div>
@@ -1591,7 +1591,7 @@ Utilities to process [ERC-7739](https://ercs.ethereum.org/ERCS/erc-7739) typed d
 that are specific to an EIP-712 domain.
 
 This library provides methods to wrap, unwrap and operate over typed data signatures with a defensive
-rehashing mechanism that includes the app's xref:api:utils/cryptography#EIP712-_domainSeparatorV4[EIP-712]
+rehashing mechanism that includes the app's [EIP-712](#EIP712-_domainSeparatorV4--)
 and preserves readability of the signed content using an EIP-712 nested approach.
 
 A smart contract domain can validate a signature for a typed data structure in two ways:
@@ -1604,8 +1604,8 @@ A provider for a smart contract wallet would need to return this signature as th
 </Callout>
 result of a call to `personal_sign` or `eth_signTypedData`, and this may be unsupported by
 API clients that expect a return value of 129 bytes, or specifically the `r,s,v` parameters
-of an xref:api:utils/cryptography#ECDSA[ECDSA] signature, as is for example specified for
-xref:api:utils/cryptography#EIP712[EIP-712].
+of an [ECDSA](#ECDSA) signature, as is for example specified for
+[EIP-712](#EIP712).
 
 <div className="bg-secondary p-4 rounded-md mb-6">
 <h3 style={{ marginTop: "0"}}>Functions</h3>
@@ -1818,8 +1818,7 @@ Signature validation algorithm.
 Implementing a signature validation algorithm is a security-sensitive operation as it involves
 </Callout>
 cryptographic verification. It is important to review and test thoroughly before deployment. Consider
-using one of the signature verification libraries (xref:api:utils/cryptography#ECDSA[ECDSA],
-xref:api:utils/cryptography#P256[P256] or xref:api:utils/cryptography#RSA[RSA]).
+using one of the signature verification libraries ([ECDSA](#ECDSA), [P256](#P256), or [RSA](#RSA)).
 
 </div>
 </div>
@@ -2673,7 +2672,7 @@ Thrown when the arrays lengths don't match. See [`MultiSignerERC7913Weighted._se
 import "@openzeppelin/contracts/utils/cryptography/signers/SignerECDSA.sol";
 ```
 
-Implementation of [`AbstractSigner`](#AbstractSigner) using xref:api:utils/cryptography#ECDSA[ECDSA] signatures.
+Implementation of [`AbstractSigner`](#AbstractSigner) using [ECDSA](#ECDSA) signatures.
 
 For [`Account`](../account#Account) usage, a [`SignerECDSA._setSigner`](#SignerECDSA-_setSigner-address-) function is provided to set the [`SignerECDSA.signer`](#SignerECDSA-signer--) address.
 Doing so is easier for a factory, who is likely to use initializable clones of this contract.
@@ -2770,10 +2769,9 @@ Signature validation algorithm.
 
 <Callout type="warn">
 Implementing a signature validation algorithm is a security-sensitive operation as it involves
-</Callout>
 cryptographic verification. It is important to review and test thoroughly before deployment. Consider
-using one of the signature verification libraries (xref:api:utils/cryptography#ECDSA[ECDSA],
-xref:api:utils/cryptography#P256[P256] or xref:api:utils/cryptography#RSA[RSA]).
+using one of the signature verification libraries ([ECDSA](#ECDSA), [P256](#P256), or [RSA](#RSA)).
+</Callout>
 
 </div>
 </div>
@@ -2960,7 +2958,7 @@ with [`SignerECDSA.signer`](#SignerECDSA-signer--), `hash` and `signature`.
 import "@openzeppelin/contracts/utils/cryptography/signers/SignerP256.sol";
 ```
 
-Implementation of [`AbstractSigner`](#AbstractSigner) using xref:api:utils/cryptography#P256[P256] signatures.
+Implementation of [`AbstractSigner`](#AbstractSigner) using [P256](#P256) signatures.
 
 For [`Account`](../account#Account) usage, a [`SignerECDSA._setSigner`](#SignerECDSA-_setSigner-address-) function is provided to set the [`SignerECDSA.signer`](#SignerECDSA-signer--) public key.
 Doing so is easier for a factory, who is likely to use initializable clones of this contract.
@@ -3065,10 +3063,9 @@ Signature validation algorithm.
 
 <Callout type="warn">
 Implementing a signature validation algorithm is a security-sensitive operation as it involves
-</Callout>
 cryptographic verification. It is important to review and test thoroughly before deployment. Consider
-using one of the signature verification libraries (xref:api:utils/cryptography#ECDSA[ECDSA],
-xref:api:utils/cryptography#P256[P256] or xref:api:utils/cryptography#RSA[RSA]).
+using one of the signature verification libraries ([ECDSA](#ECDSA), [P256](#P256), or [RSA](#RSA)).
+</Callout>
 
 </div>
 </div>
@@ -3104,7 +3101,7 @@ xref:api:utils/cryptography#P256[P256] or xref:api:utils/cryptography#RSA[RSA]).
 import "@openzeppelin/contracts/utils/cryptography/signers/SignerRSA.sol";
 ```
 
-Implementation of [`AbstractSigner`](#AbstractSigner) using xref:api:utils/cryptography#RSA[RSA] signatures.
+Implementation of [`AbstractSigner`](#AbstractSigner) using [RSA](#RSA) signatures.
 
 For [`Account`](../account#Account) usage, a [`SignerECDSA._setSigner`](#SignerECDSA-_setSigner-address-) function is provided to set the [`SignerECDSA.signer`](#SignerECDSA-signer--) public key.
 Doing so is easier for a factory, who is likely to use initializable clones of this contract.
@@ -3198,7 +3195,7 @@ Return the signer's RSA public key.
 <div className="px-4">
 
 See [`AbstractSigner._rawSignatureValidation`](#AbstractSigner-_rawSignatureValidation-bytes32-bytes-). Verifies a PKCSv1.5 signature by calling
-xref:api:utils/cryptography.adoc#RSA-pkcs1Sha256-bytes-bytes-bytes-bytes-[RSA.pkcs1Sha256].
+[RSA.pkcs1Sha256](#RSA-pkcs1Sha256-bytes-bytes-bytes-bytes-).
 
 <Callout type="warn">
 Following the RSASSA-PKCS1-V1_5-VERIFY procedure outlined in RFC8017 (section 8.2.2), the
@@ -3234,11 +3231,11 @@ This contract requires implementing the [`AccountERC7579._rawSignatureValidation
 which may be either an typed data or a personal sign nested type.
 
 <Callout>
-xref:api:utils/cryptography#EIP712[EIP-712] uses xref:api:utils/cryptography#ShortStrings[ShortStrings] to
-</Callout>
+[EIP-712](#EIP712) uses [ShortStrings](../utils#ShortStrings) to
 optimize gas costs for short strings (up to 31 characters). Consider that strings longer than that will use storage,
 which may limit the ability of the signer to be used within the ERC-4337 validation phase (due to
 [ERC-7562 storage access rules](https://eips.ethereum.org/EIPS/eip-7562#storage-rules)).
+</Callout>
 
 <div className="bg-secondary p-4 rounded-md mb-6">
 <h3 style={{ marginTop: "0"}}>Functions</h3>

--- a/content/contracts/5.x/api/utils/cryptography.mdx
+++ b/content/contracts/5.x/api/utils/cryptography.mdx
@@ -132,11 +132,11 @@ half order, and the `v` value to be either 27 or 28.
 
 <Callout type="warn">
 `hash` _must_ be the result of a hash operation for the
-</Callout>
 verification to be secure: it is possible to craft signatures that
 recover to arbitrary addresses for non-hashed data. A safe way to ensure
 this is by receiving a hash of the original message (which may otherwise
 be too long), and then calling [`MessageHashUtils.toEthSignedMessageHash`](#MessageHashUtils-toEthSignedMessageHash-bytes-) on it.
+</Callout>
 
 Documentation for signature generation:
 - with [Web3.js](https://web3js.readthedocs.io/en/v1.3.4/web3-eth-accounts.html#sign)
@@ -166,11 +166,11 @@ half order, and the `v` value to be either 27 or 28.
 
 <Callout type="warn">
 `hash` _must_ be the result of a hash operation for the
-</Callout>
 verification to be secure: it is possible to craft signatures that
 recover to arbitrary addresses for non-hashed data. A safe way to ensure
 this is by receiving a hash of the original message (which may otherwise
 be too long), and then calling [`MessageHashUtils.toEthSignedMessageHash`](#MessageHashUtils-toEthSignedMessageHash-bytes-) on it.
+</Callout>
 
 </div>
 </div>
@@ -330,14 +330,14 @@ the chain id to protect against replay attacks on an eventual fork of the chain.
 
 <Callout>
 This contract implements the version of the encoding known as "v4", as implemented by the JSON RPC method
-</Callout>
 [`eth_signTypedDataV4` in MetaMask](https://docs.metamask.io/guide/signing-data.html).
+</Callout>
 
 <Callout>
 In the upgradeable version of this contract, the cached values will correspond to the address, and the domain
-</Callout>
 separator of the implementation contract. This will cause the [`EIP712._domainSeparatorV4`](#EIP712-_domainSeparatorV4--) function to always rebuild the
 separator from the immutable values, which is cheaper than accessing a cached version in cold storage.
+</Callout>
 
 <div className="bg-secondary p-4 rounded-md mb-6">
 <h3 style={{ marginTop: "0"}}>Functions</h3>
@@ -468,8 +468,8 @@ The name parameter for the EIP712 domain.
 
 <Callout>
 By default this function reads _name which is an immutable value.
-</Callout>
 It only reads from storage if necessary (in case the value is too large to fit in a ShortString).
+</Callout>
 
 </div>
 </div>
@@ -490,8 +490,8 @@ The version parameter for the EIP712 domain.
 
 <Callout>
 By default this function reads _version which is an immutable value.
-</Callout>
 It only reads from storage if necessary (in case the value is too large to fit in a ShortString).
+</Callout>
 
 </div>
 </div>
@@ -586,24 +586,24 @@ You will find a quickstart guide in the readme.
 
 <Callout type="warn">
 You should avoid using leaf values that are 64 bytes long prior to
-</Callout>
 hashing, or use a hash function other than keccak256 for hashing leaves.
 This is because the concatenation of a sorted pair of internal nodes in
 the Merkle tree could be reinterpreted as a leaf value.
 OpenZeppelin's JavaScript library generates Merkle trees that are safe
 against this attack out of the box.
+</Callout>
 
 <Callout type="warn">
 Consider memory side-effects when using custom hashing functions
-</Callout>
 that access memory in an unsafe way.
+</Callout>
 
 <Callout>
 This library supports proof verification for merkle trees built using
-</Callout>
 custom _commutative_ hashing functions (i.e. `H(a, b) == H(b, a)`). Proving
 leaf inclusion in trees built using non-commutative hashing functions requires
 additional logic that is not supported by this library.
+</Callout>
 
 <div className="bg-secondary p-4 rounded-md mb-6">
 <h3 style={{ marginTop: "0"}}>Functions</h3>
@@ -831,8 +831,8 @@ CAUTION: Not all Merkle trees admit multiproofs. See [`MerkleProof.processMultiP
 
 <Callout>
 Consider the case where `root == proof[0] && leaves.length == 0` as it will return `true`.
-</Callout>
 The `leaves` must be validated independently. See [`MerkleProof.processMultiProof`](#MerkleProof-processMultiProof-bytes32---bool---bytes32---function--bytes32-bytes32--view-returns--bytes32--).
+</Callout>
 
 </div>
 </div>
@@ -862,9 +862,9 @@ tree (i.e., as seen from right to left starting at the deepest layer and continu
 
 <Callout>
 The _empty set_ (i.e. the case where `proof.length == 1 && leaves.length == 0`) is considered a no-op,
-</Callout>
 and therefore a valid multiproof (i.e. it returns `proof[0]`). Consider disallowing this case if you're not
 validating the leaves elsewhere.
+</Callout>
 
 </div>
 </div>
@@ -890,8 +890,8 @@ CAUTION: Not all Merkle trees admit multiproofs. See [`MerkleProof.processMultiP
 
 <Callout>
 Consider the case where `root == proof[0] && leaves.length == 0` as it will return `true`.
-</Callout>
 The `leaves` must be validated independently. See [`MerkleProof.processMultiProof`](#MerkleProof-processMultiProof-bytes32---bool---bytes32---function--bytes32-bytes32--view-returns--bytes32--).
+</Callout>
 
 </div>
 </div>
@@ -921,9 +921,9 @@ tree (i.e., as seen from right to left starting at the deepest layer and continu
 
 <Callout>
 The _empty set_ (i.e. the case where `proof.length == 1 && leaves.length == 0`) is considered a no-op,
-</Callout>
 and therefore a valid multiproof (i.e. it returns `proof[0]`). Consider disallowing this case if you're not
 validating the leaves elsewhere.
+</Callout>
 
 </div>
 </div>
@@ -949,8 +949,8 @@ CAUTION: Not all Merkle trees admit multiproofs. See [`MerkleProof.processMultiP
 
 <Callout>
 Consider the case where `root == proof[0] && leaves.length == 0` as it will return `true`.
-</Callout>
 The `leaves` must be validated independently. See [`MerkleProof.processMultiProofCalldata`](#MerkleProof-processMultiProofCalldata-bytes32---bool---bytes32---function--bytes32-bytes32--view-returns--bytes32--).
+</Callout>
 
 </div>
 </div>
@@ -980,9 +980,9 @@ tree (i.e., as seen from right to left starting at the deepest layer and continu
 
 <Callout>
 The _empty set_ (i.e. the case where `proof.length == 1 && leaves.length == 0`) is considered a no-op,
-</Callout>
 and therefore a valid multiproof (i.e. it returns `proof[0]`). Consider disallowing this case if you're not
 validating the leaves elsewhere.
+</Callout>
 
 </div>
 </div>
@@ -1008,8 +1008,8 @@ CAUTION: Not all Merkle trees admit multiproofs. See [`MerkleProof.processMultiP
 
 <Callout>
 Consider the case where `root == proof[0] && leaves.length == 0` as it will return `true`.
-</Callout>
 The `leaves` must be validated independently. See [`MerkleProof.processMultiProofCalldata`](#MerkleProof-processMultiProofCalldata-bytes32---bool---bytes32---function--bytes32-bytes32--view-returns--bytes32--).
+</Callout>
 
 </div>
 </div>
@@ -1039,9 +1039,9 @@ tree (i.e., as seen from right to left starting at the deepest layer and continu
 
 <Callout>
 The _empty set_ (i.e. the case where `proof.length == 1 && leaves.length == 0`) is considered a no-op,
-</Callout>
 and therefore a valid multiproof (i.e. it returns `proof[0]`). Consider disallowing this case if you're not
 validating the leaves elsewhere.
+</Callout>
 
 </div>
 </div>
@@ -1117,9 +1117,9 @@ hash signed when using the [`eth_sign`](https://ethereum.org/en/developers/docs/
 
 <Callout>
 The `messageHash` parameter is intended to be the result of hashing a raw message with
-</Callout>
 keccak256, although any bytes32 value can be safely used because the final digest will
 be re-hashed.
+</Callout>
 
 See [`ECDSA.recover`](#ECDSA-recover-bytes32-uint8-bytes32-bytes32-).
 
@@ -1412,20 +1412,20 @@ support for explicit or implicit NULL parameters in the DigestInfo (no other opt
 
 <Callout type="warn">
 For security reason, this function requires the signature and modulus to have a length of at least
-</Callout>
 2048 bits. If you use a smaller key, consider replacing it with a larger, more secure, one.
+</Callout>
 
 <Callout type="warn">
 This verification algorithm doesn't prevent replayability. If called multiple times with the same
-</Callout>
 digest, public key and (valid signature), it will return true every time. Consider including an onchain nonce
 or unique identifier in the message to prevent replay attacks.
+</Callout>
 
 <Callout type="warn">
 This verification algorithm supports any exponent. NIST recommends using `65537` (or higher).
-</Callout>
 That is the default value many libraries use, such as OpenSSL. Developers may choose to reject public keys
 using a low exponent out of security concerns.
+</Callout>
 
 </div>
 </div>
@@ -1481,8 +1481,8 @@ signature is validated against it using ERC-1271, otherwise it's validated using
 
 <Callout>
 Unlike ECDSA signatures, contract signatures are revocable, and the outcome of this function can thus
-</Callout>
 change through time. It could return true at block N and false at block N+1 (or the opposite).
+</Callout>
 
 <Callout>
 For an extended version of this function that supports ERC-7913 signatures, see #SignatureChecker-isValidSignatureNow-bytes-bytes32-bytes-.
@@ -1508,8 +1508,8 @@ against the signer smart contract using ERC-1271.
 
 <Callout>
 Unlike ECDSA signatures, contract signatures are revocable, and the outcome of this function can thus
-</Callout>
 change through time. It could return true at block N and false at block N+1 (or the opposite).
+</Callout>
 
 </div>
 </div>
@@ -1539,8 +1539,8 @@ Verification is done as follows:
 
 <Callout>
 Unlike ECDSA signatures, contract signatures are revocable, and the outcome of this function can thus
-</Callout>
 change through time. It could return true at block N and false at block N+1 (or the opposite).
+</Callout>
 
 </div>
 </div>
@@ -1565,8 +1565,8 @@ signers are supported, but the uniqueness check will be more expensive.
 
 <Callout>
 Unlike ECDSA signatures, contract signatures are revocable, and the outcome of this function can thus
-</Callout>
 change through time. It could return true at block N and false at block N+1 (or the opposite).
+</Callout>
 
 </div>
 </div>
@@ -1601,11 +1601,11 @@ A smart contract domain can validate a signature for a typed data structure in t
 
 <Callout>
 A provider for a smart contract wallet would need to return this signature as the
-</Callout>
 result of a call to `personal_sign` or `eth_signTypedData`, and this may be unsupported by
 API clients that expect a return value of 129 bytes, or specifically the `r,s,v` parameters
 of an [ECDSA](#ECDSA) signature, as is for example specified for
 [EIP-712](#EIP712).
+</Callout>
 
 <div className="bg-secondary p-4 rounded-md mb-6">
 <h3 style={{ marginTop: "0"}}>Functions</h3>
@@ -1666,8 +1666,8 @@ Constructed as follows:
 
 <Callout>
 This function returns empty if the input format is invalid instead of reverting.
-</Callout>
 data instead.
+</Callout>
 
 </div>
 </div>
@@ -1816,9 +1816,9 @@ Signature validation algorithm.
 
 <Callout type="warn">
 Implementing a signature validation algorithm is a security-sensitive operation as it involves
-</Callout>
 cryptographic verification. It is important to review and test thoroughly before deployment. Consider
 using one of the signature verification libraries ([ECDSA](#ECDSA), [P256](#P256), or [RSA](#RSA)).
+</Callout>
 
 </div>
 </div>
@@ -1871,9 +1871,9 @@ contract MyMultiSignerAccount is Account, MultiSignerERC7913, Initializable {
 
 <Callout type="warn">
 Failing to properly initialize the signers and threshold either during construction
-</Callout>
 (if used standalone) or during initialization (if used as a clone) may leave the contract
 either front-runnable or unusable.
+</Callout>
 
 <div className="bg-secondary p-4 rounded-md mb-6">
 <h3 style={{ marginTop: "0"}}>Functions</h3>
@@ -1949,9 +1949,9 @@ Using `start = 0` and `end = type(uint64).max` will return the entire set of sig
 
 <Callout type="warn">
 Depending on the `start` and `end`, this operation can copy a large amount of data to memory, which
-</Callout>
 can be expensive. This is designed for view accessors queried without gas fees. Using it in state-changing
 functions may become uncallable if the slice grows too large.
+</Callout>
 
 </div>
 </div>
@@ -2160,8 +2160,8 @@ Returns whether the signers are authorized and the signatures are valid for the 
 
 <Callout type="warn">
 Sorting the signers by their `keccak256` hash will improve the gas efficiency of this function.
-</Callout>
 See [`SignatureChecker.areValidSignaturesNow`](#SignatureChecker-areValidSignaturesNow-bytes32-bytes---bytes---) for more details.
+</Callout>
 
 Requirements:
 
@@ -2377,9 +2377,9 @@ contract MyWeightedMultiSignerAccount is Account, MultiSignerERC7913Weighted, In
 
 <Callout type="warn">
 When setting a threshold value, ensure it matches the scale used for signer weights.
-</Callout>
 For example, if signers have weights like 1, 2, or 3, then a threshold of 4 would require at
 least two signers (e.g., one with weight 1 and one with weight 3). See [`MultiSignerERC7913Weighted.signerWeight`](#MultiSignerERC7913Weighted-signerWeight-bytes-).
+</Callout>
 
 <div className="bg-secondary p-4 rounded-md mb-6">
 <h3 style={{ marginTop: "0"}}>Functions</h3>
@@ -2567,10 +2567,10 @@ Requirements:
 
 <Callout>
 This function intentionally does not call `super._validateReachableThreshold` because the base implementation
-</Callout>
 assumes each signer has a weight of 1, which is a subset of this weighted implementation. Consider that multiple
 implementations of this function may exist in the contract, so important side effects may be missed
 depending on the linearization order.
+</Callout>
 
 </div>
 </div>
@@ -2591,10 +2591,10 @@ Validates that the total weight of signers meets the threshold requirement.
 
 <Callout>
 This function intentionally does not call `super._validateThreshold` because the base implementation
-</Callout>
 assumes each signer has a weight of 1, which is a subset of this weighted implementation. Consider that multiple
 implementations of this function may exist in the contract, so important side effects may be missed
 depending on the linearization order.
+</Callout>
 
 </div>
 </div>
@@ -2616,8 +2616,8 @@ Emitted when a signer's weight is changed.
 
 <Callout>
 Not emitted in [`MultiSignerERC7913._addSigners`](#MultiSignerERC7913-_addSigners-bytes---) or [`MultiSignerERC7913._removeSigners`](#MultiSignerERC7913-_removeSigners-bytes---). Indexers must rely on [`MultiSignerERC7913.ERC7913SignerAdded`](#MultiSignerERC7913-ERC7913SignerAdded-bytes-)
-</Callout>
 and [`MultiSignerERC7913.ERC7913SignerRemoved`](#MultiSignerERC7913-ERC7913SignerRemoved-bytes-) to index a default weight of 1. See [`MultiSignerERC7913Weighted.signerWeight`](#MultiSignerERC7913Weighted-signerWeight-bytes-).
+</Callout>
 
 </div>
 </div>
@@ -2689,8 +2689,8 @@ contract MyAccountECDSA is Account, SignerECDSA, Initializable {
 
 <Callout type="warn">
 Failing to call [`SignerECDSA._setSigner`](#SignerECDSA-_setSigner-address-) either during construction (if used standalone)
-</Callout>
 or during initialization (if used as a clone) may leave the signer either front-runnable or unusable.
+</Callout>
 
 <div className="bg-secondary p-4 rounded-md mb-6">
 <h3 style={{ marginTop: "0"}}>Functions</h3>
@@ -2861,8 +2861,8 @@ contract MyAccountERC7913 is Account, SignerERC7913, Initializable {
 
 <Callout type="warn">
 Failing to call [`SignerECDSA._setSigner`](#SignerECDSA-_setSigner-address-) either during construction (if used standalone)
-</Callout>
 or during initialization (if used as a clone) may leave the signer either front-runnable or unusable.
+</Callout>
 
 <div className="bg-secondary p-4 rounded-md mb-6">
 <h3 style={{ marginTop: "0"}}>Functions</h3>
@@ -2975,8 +2975,8 @@ contract MyAccountP256 is Account, SignerP256, Initializable {
 
 <Callout type="warn">
 Failing to call [`SignerECDSA._setSigner`](#SignerECDSA-_setSigner-address-) either during construction (if used standalone)
-</Callout>
 or during initialization (if used as a clone) may leave the signer either front-runnable or unusable.
+</Callout>
 
 <div className="bg-secondary p-4 rounded-md mb-6">
 <h3 style={{ marginTop: "0"}}>Functions</h3>
@@ -3118,8 +3118,8 @@ contract MyAccountRSA is Account, SignerRSA, Initializable {
 
 <Callout type="warn">
 Failing to call [`SignerECDSA._setSigner`](#SignerECDSA-_setSigner-address-) either during construction (if used standalone)
-</Callout>
 or during initialization (if used as a clone) may leave the signer either front-runnable or unusable.
+</Callout>
 
 <div className="bg-secondary p-4 rounded-md mb-6">
 <h3 style={{ marginTop: "0"}}>Functions</h3>
@@ -3199,9 +3199,9 @@ See [`AbstractSigner._rawSignatureValidation`](#AbstractSigner-_rawSignatureVali
 
 <Callout type="warn">
 Following the RSASSA-PKCS1-V1_5-VERIFY procedure outlined in RFC8017 (section 8.2.2), the
-</Callout>
 provided `hash` is used as the `M` (message) and rehashed using SHA256 according to EMSA-PKCS1-v1_5
 encoding as per section 9.2 (step 1) of the RFC.
+</Callout>
 
 </div>
 </div>

--- a/content/contracts/5.x/eoa-delegation.mdx
+++ b/content/contracts/5.x/eoa-delegation.mdx
@@ -54,8 +54,8 @@ const authorization = await eoaClient.signAuthorization({
 
 <Callout>
 When implementing delegate contracts, ensure they require signatures that avoid replayability (e.g. a domain separator, nonce).
-</Callout>
 A poorly implemented delegate can allow a malicious actor to take near complete control over a signer’s EOA.
+</Callout>
 
 ### Send a Set Code Transaction
 

--- a/content/contracts/5.x/learn/connecting-to-public-test-networks.mdx
+++ b/content/contracts/5.x/learn/connecting-to-public-test-networks.mdx
@@ -82,8 +82,8 @@ We need to update our configuration file with a new network connection to the te
 
 <Callout>
 See the Hardhat [networks configuration](https://hardhat.org/config/#json-rpc-based-networks) documentation for information on configuration options.
-</Callout>
 Note in the first line that we are loading the project id and mnemonic from a `secrets.json` file, which should look like the following, but using your own values. Make sure to `.gitignore` it to ensure you don’t commit secrets to version control!
+</Callout>
 
 ```json
 

--- a/content/defender/logs.mdx
+++ b/content/defender/logs.mdx
@@ -89,6 +89,6 @@ Datadog uses different sites around the world. For example, if you are relying o
 
 <Callout>
 `API Key` value can be obtained from Datadog site by opening `Logs` section from the left menu.
-</Callout>
 Go to `Cloud` section and select `AWS` provider.
 After following those steps, the `API Key` value is displayed in the bottom section of the page.
+</Callout>

--- a/content/stellar-contracts/0.2.0/utils/upgradeable.mdx
+++ b/content/stellar-contracts/0.2.0/utils/upgradeable.mdx
@@ -146,8 +146,8 @@ impl UpgradeableMigratableInternal for ExampleContract {
 
 <Callout>
 If a rollback is required, the contract can be upgraded to a newer version where the rollback-specific logic
-</Callout>
 is defined and performed as a migration.
+</Callout>
 
 #### Atomic upgrade and migration
 

--- a/content/stellar-contracts/0.3.0/utils/upgradeable.mdx
+++ b/content/stellar-contracts/0.3.0/utils/upgradeable.mdx
@@ -146,8 +146,8 @@ impl UpgradeableMigratableInternal for ExampleContract {
 
 <Callout>
 If a rollback is required, the contract can be upgraded to a newer version where the rollback-specific logic
-</Callout>
 is defined and performed as a migration.
+</Callout>
 
 #### Atomic upgrade and migration
 

--- a/content/substrate-runtimes/0.2.0/pallets/message-queue.mdx
+++ b/content/substrate-runtimes/0.2.0/pallets/message-queue.mdx
@@ -40,8 +40,8 @@ Execute an overweight message.
 
 <Callout>
 Temporary processing errors will be propagated whereas permanent errors are treated
-</Callout>
 as success condition.
+</Callout>
 
 <Callout type='warn'>
 The `weight_limit` passed to this function does not affect the `weight_limit` set in other parts of the pallet.
@@ -106,8 +106,8 @@ Remove a page which has no more messages remaining to be processed or is stale.
 
 <Callout type='warn'>
 The pallet utilizes the [`sp_weights::WeightMeter`] to manually track its consumption to always stay within
-</Callout>
 the required limit. This implies that the message processor hook can calculate the weight of a message without executing it.
+</Callout>
 
 #### How does this pallet work under the hood?
 

--- a/content/substrate-runtimes/0.2.0/pallets/treasury.mdx
+++ b/content/substrate-runtimes/0.2.0/pallets/treasury.mdx
@@ -52,8 +52,8 @@ For record-keeping purposes, the proposer is deemed to be equivalent to the bene
 
 <Callout>
 The behavior and API of the old `spend` call capable of spending local DOT tokens remain unchanged, and is now under the name `spend_local`. The revised
-</Callout>
 new `spend` call is able to spend any asset kind managed by the treasury.
+</Callout>
 
 ***Params:***
 

--- a/content/uniswap-hooks/api/base.mdx
+++ b/content/uniswap-hooks/api/base.mdx
@@ -32,19 +32,19 @@ underlying currency by using the `settle` function from the `CurrencySettler` li
 
 <Callout type="warn">
 If the hook is used for multiple pools, the ERC-6909 tokens must be separated and managed
-</Callout>
 independently for each pool in order to prevent draining of ERC-6909 tokens from one pool to another.
+</Callout>
 
 <Callout>
 The hook only supports async exact-input swaps. Exact-output swaps will be processed normally
-</Callout>
 by the `PoolManager`.
+</Callout>
 
 <Callout type="warn">
 This is experimental software and is provided on an "as is" and "as available" basis. We do
-</Callout>
 not give any warranties and will not be liable for any losses incurred through any use of this code
 base.
+</Callout>
 
 _Available since v0.1.0_
 
@@ -204,15 +204,15 @@ manage fees over liquidity shares accordingly.
 
 <Callout>
 This base hook is designed to work with a single pool key. If you want to use the same custom
-</Callout>
 accounting hook for multiple pools, you must have multiple storage instances of this contract and
 initialize them via the `PoolManager` with their respective pool keys.
+</Callout>
 
 <Callout type="warn">
 This is experimental software and is provided on an "as is" and "as available" basis. We do
-</Callout>
 not give any warranties and will not be liable for any losses incurred through any use of this code
 base.
+</Callout>
 
 _Available since v0.1.0_
 
@@ -369,8 +369,8 @@ according to the price when the transaction is executed.
 
 <Callout>
 The `amount0Min` and `amount1Min` parameters are relative to the principal delta, which excludes
-</Callout>
 fees accrued from the liquidity modification delta.
+</Callout>
 
 </div>
 </div>
@@ -709,14 +709,14 @@ created from this calculation is then consumed and applied by the `PoolManager`.
 
 <Callout>
 This hook by default does not include fee or salt mechanisms, which can be implemented by inheriting
-</Callout>
 contracts if needed.
+</Callout>
 
 <Callout type="warn">
 This is experimental software and is provided on an "as is" and "as available" basis. We do
-</Callout>
 not give any warranties and will not be liable for any losses incurred through any use of this code
 base.
+</Callout>
 
 _Available since v0.1.0_
 
@@ -875,8 +875,8 @@ to get the amount of tokens to be sent to the receiver.
 
 <Callout>
 In order to take and settle tokens from the pool, the hook must hold the liquidity added
-</Callout>
 via the [`BaseCustomAccounting.addLiquidity`](#BaseCustomAccounting-addLiquidity-struct-BaseCustomAccounting-AddLiquidityParams-) function.
+</Callout>
 
 </div>
 </div>
@@ -1026,14 +1026,14 @@ Based on the [Uniswap v4 periphery implementation](https://github.com/Uniswap/v4
 
 <Callout>
 Hook entry points must be overridden and implemented by the inheriting hook to be used. Their respective
-</Callout>
 flags must be set to true in the `getHookPermissions` function as well.
+</Callout>
 
 <Callout type="warn">
 This is experimental software and is provided on an "as is" and "as available" basis. We do
-</Callout>
 not give any warranties and will not be liable for any losses incurred through any use of this code
 base.
+</Callout>
 
 _Available since v0.1.0_
 

--- a/content/uniswap-hooks/api/fee.mdx
+++ b/content/uniswap-hooks/api/fee.mdx
@@ -27,14 +27,14 @@ as a hook fee, being posteriorily handled or distributed by the hook via [`BaseD
 
 <Callout>
 In order to use this hook, the inheriting contract must implement [`BaseDynamicAfterFee._getTargetUnspecified`](#BaseDynamicAfterFee-_getTargetUnspecified-address-struct-PoolKey-struct-SwapParams-bytes-) to determine the target,
-</Callout>
 and [`BaseDynamicAfterFee._afterSwapHandler`](#BaseDynamicAfterFee-_afterSwapHandler-struct-PoolKey-struct-SwapParams-BalanceDelta-uint256-uint256-) to handle accumulated fees.
+</Callout>
 
 <Callout type="warn">
 This is experimental software and is provided on an "as is" and "as available" basis. We do
-</Callout>
 not give any warranties and will not be liable for any losses incurred through any use of this code
 base.
+</Callout>
 
 _Available since v0.1.0_
 
@@ -308,9 +308,9 @@ Base implementation to apply a dynamic fee via the `PoolManager`'s `updateDynami
 
 <Callout type="warn">
 This is experimental software and is provided on an "as is" and "as available" basis. We do
-</Callout>
 not give any warranties and will not be liable for any losses incurred through any use of this code
 base.
+</Callout>
 
 _Available since v0.1.0_
 
@@ -429,12 +429,12 @@ that contains this hook's address.
 
 <Callout type="warn">
 This function can be called by anyone at any time. If `_getFee` implementation
-</Callout>
 depends on external conditions (e.g., oracle prices, other pool states, token balances),
 it may be vulnerable to manipulation. An attacker could potentially:
 1. Manipulate the external conditions that `_getFee` depends on
 2. Call `poke()` to update the fee to a more favorable rate
 3. Execute trades at the manipulated fee rate
+</Callout>
 
 Inheriting contracts should consider implementing access controls on this function,
 make the logic in `_getFee` resistant to short-term manipulation, or accept the risk
@@ -497,9 +497,9 @@ Base implementation for automatic dynamic fees applied before swaps.
 
 <Callout type="warn">
 This is experimental software and is provided on an "as is" and "as available" basis. We do
-</Callout>
 not give any warranties and will not be liable for any losses incurred through any use of this code
 base.
+</Callout>
 
 _Available since v0.1.0_
 

--- a/content/uniswap-hooks/api/general.mdx
+++ b/content/uniswap-hooks/api/general.mdx
@@ -35,25 +35,25 @@ to determine how to handle the collected fees from the anti-sandwich mechanism.
 
 <Callout>
 The Anti-sandwich mechanism only protects swaps in the zeroForOne swap direction.
-</Callout>
 Swaps in the !zeroForOne direction are not protected by this hook design.
+</Callout>
 
 <Callout type="warn">
 Since this hook makes MEV not profitable, there's not as much arbitrage in
-</Callout>
 the pool, making prices at beginning of the block not necessarily close to market price.
+</Callout>
 
 <Callout type="warn">
 In `_beforeSwap`, the hook iterates over all ticks between last tick and current tick.
-</Callout>
 Developers must be aware that for large price changes in pools with small tick spacing, the `for`
 loop will iterate over a large number of ticks, which could lead to `MemoryOOG` error.
+</Callout>
 
 <Callout type="warn">
 This is experimental software and is provided on an "as is" and "as available" basis. We do
-</Callout>
 not give any warranties and will not be liable for any losses incurred through any use of this code
 base.
+</Callout>
 
 _Available since v1.1.0_
 
@@ -314,15 +314,15 @@ Once completely filled, the resulting liquidity can be withdrawn from the pool.
 
 <Callout type="warn">
 When cancelling or adding more liquidity into an existing order, it's possible that fees
-</Callout>
 have been accrued. In those cases, the accrued fees are added to the order info, benefitting the remaining
 limit order placers.
+</Callout>
 
 <Callout type="warn">
 This is experimental software and is provided on an "as is" and "as available" basis. We do
-</Callout>
 not give any warranties and will not be liable for any losses incurred through any use of this code
 base.
+</Callout>
 
 _Available since v1.1.0_
 
@@ -942,28 +942,28 @@ See [`LiquidityPenaltyHook._calculateLiquidityPenalty`](#LiquidityPenaltyHook-_c
 
 <Callout>
 If a long term liquidity provider adds liquidity continuously, a pause of `blockNumberOffset`
-</Callout>
 before removing will be needed if `feesAccrued` collection is intended, in order to avoid getting
 penalized by the JIT protection mechanism.
+</Callout>
 
 <Callout type="warn">
 Altrough this hook achieves it's objective of protecting long term LP's in most scenarios,
-</Callout>
 low liquidity pools and long-tail assets may still be vulnerable depending on the configured `blockNumberOffset`.
 Larger values of such are recommended in those cases in order to decrease the profitability of the attack.
+</Callout>
 
 <Callout type="warn">
 In low liquidity pools, this hook may be vulnerable to multi-account strategies: attackers may bypass JIT protection
-</Callout>
 by using a secondary account to add minimal liquidity at a target tick with no other liquidity, then moving the price there after a JIT attack.
 This allows penalty fees to be redirected to the attacker's secondary account. While technically feasible, this attack is rarely profitable in practice,
 due to the cost associated with moving the price to the target tick.
+</Callout>
 
 <Callout type="warn">
 This is experimental software and is provided on an "as is" and "as available" basis. We do
-</Callout>
 not give any warranties and will not be liable for any losses incurred through any use of this code
 base.
+</Callout>
 
 _Available since v0.1.1_
 
@@ -1076,15 +1076,15 @@ liquidity was recently added to the position.
 
 <Callout>
 The penalty is applied on both `withheldFees` and `feeDelta` equally.
-</Callout>
 Therefore, regardless of how many times liquidity was added to the position within the `blockNumberOffset` period,
 all accrued fees are penalized as if the liquidity was added only once during that period. This ensures that
 splitting liquidity additions within the `blockNumberOffset` period does not reduce or increase the penalty.
+</Callout>
 
 <Callout type="warn">
 The penalty is donated to the pool's liquidity providers in range at the time of liquidity removal,
-</Callout>
 which may be different from the liquidity providers in range at the time of liquidity addition.
+</Callout>
 
 </div>
 </div>

--- a/content/upgrades-plugins/foundry/api/Defender.mdx
+++ b/content/upgrades-plugins/foundry/api/Defender.mdx
@@ -154,8 +154,8 @@ Requires that either the `referenceContract` option is set, or the contract has 
 
 <Callout type="warn">
 Ensure that the reference contract is the same as the current implementation contract that the proxy is pointing to.
-</Callout>
 This function does not validate that the reference contract is the current implementation.
+</Callout>
 
 NOTE: If using an EOA or Safe to deploy, go to [Defender deploy](https://defender.openzeppelin.com/v2/#/deploy) to submit the pending deployment of the new implementation contract while the script is running.
 The script waits for the deployment to complete before it continues.

--- a/content/upgrades-plugins/foundry/api/LegacyUpgrades.mdx
+++ b/content/upgrades-plugins/foundry/api/LegacyUpgrades.mdx
@@ -324,9 +324,9 @@ Not supported for OpenZeppelin Defender deployments.
 
 <Callout type="warn">
 Not recommended for use in Forge scripts.
-</Callout>
 `UnsafeUpgrades` does not validate whether your contracts are upgrade safe or whether new implementations are compatible with previous ones.
 Use `Upgrades` if you want validations to be run.
+</Callout>
 
 NOTE: Only for upgrading existing deployments using OpenZeppelin Contracts v4.
 For new deployments, use OpenZeppelin Contracts v5 and Upgrades.sol.

--- a/content/upgrades-plugins/foundry/api/Upgrades.mdx
+++ b/content/upgrades-plugins/foundry/api/Upgrades.mdx
@@ -503,9 +503,9 @@ Not supported for OpenZeppelin Defender deployments.
 
 <Callout type="warn">
 Not recommended for use in Forge scripts.
-</Callout>
 `UnsafeUpgrades` does not validate whether your contracts are upgrade safe or whether new implementations are compatible with previous ones.
 Use `Upgrades` if you want validations to be run.
+</Callout>
 
 NOTE: Requires OpenZeppelin Contracts v5 or higher.
 

--- a/content/upgrades-plugins/foundry/foundry-defender.mdx
+++ b/content/upgrades-plugins/foundry/foundry-defender.mdx
@@ -6,8 +6,8 @@ OpenZeppelin Foundry Upgrades can be used for performing deployments through [Op
 
 <Callout type='warn'>
 Defender deployments are ***always*** broadcast to a live network, regardless of whether you are using the `broadcast` cheatcode.
-</Callout>
 The recommended pattern is to separate Defender scripts from scripts that rely on network forking and simulations, to avoid mixing simulation and live network data.
+</Callout>
 
 ## Installation
 

--- a/content/upgrades-plugins/foundry/foundry-upgrades.mdx
+++ b/content/upgrades-plugins/foundry/foundry-upgrades.mdx
@@ -216,17 +216,16 @@ Upgrades.upgradeBeacon(beacon, "MyContractV2.sol");
 
 <Callout type='warn'>
 When upgrading a proxy or beacon, ensure that the new contract either has its `@custom:oz-upgrades-from <reference>` annotation set to the name of the old implementation contract used by the proxy or beacon, or set it with the `referenceContract` option, for example:
-</Callout>
 ```solidity
 Options memory opts;
 opts.referenceContract = "MyContractV1.sol";
 Upgrades.upgradeProxy(proxy, "MyContractV2.sol", "", opts);
 // or Upgrades.upgradeBeacon(beacon, "MyContractV2.sol", opts);
 ```
+</Callout>
 
 <Callout>
 If possible, keep the old version of the implementation contract’s source code somewhere in your project to use as a reference as above. This requires the new version to be in a different directory, Solidity file, or using a different contract name. Otherwise, if you want to use the same directory and name for the new version, keep the build info directory from the previous deployment (or build it from an older branch of your project repository) and reference it as follows:
-</Callout>
 ```solidity
 Options memory opts;
 opts.referenceBuildInfoDir = "/old-builds/build-info-v1";
@@ -234,6 +233,7 @@ opts.referenceContract = "build-info-v1:MyContract";
 Upgrades.upgradeProxy(proxy, "MyContract.sol", "", opts);
 // or Upgrades.upgradeBeacon(beacon, "MyContract.sol", opts);
 ```
+</Callout>
 
 ## Coverage Testing
 


### PR DESCRIPTION
This PR fixes the following, but these also need to be addressed in the source repo (for the first item) and in the adoc-markdown conversion (for both the first and second items).  The changes listed here can be used as reference when we make the source repo/conversion changes.

- Fixes 5.x API links which contained `::`, `ROOT`, or `xref`
- Fixes an issue where `</Callout>` end tags were inserted after the first line in a paragraph, even though there is follow-on text. Moved it to after the text at the end of the paragraph.
  - This was done with a regex search and replace:
    - Find: `(<Callout[^>]*>\n[^<]+)\n</Callout>\n([^<\n]+(?:\n[^<\n]+)*)`
    - Replace: `$1\n$2\n</Callout> `