### PR TITLE
chore: fixed broken links

### DIFF
--- a/content/community-contracts/api/access.mdx
+++ b/content/community-contracts/api/access.mdx
@@ -15,7 +15,7 @@ This directory contains utility contracts to restrict access control in smart co
 
 <div style={{marginTop: "4em"}} className="w-full flex flex-row items-center justify-between">
 
-## `AccessManagerLight` 
+## `AccessManagerLight`
 
 <a target="_blank" style={{marginTop: "1.5em"}} href="https://github.com/OpenZeppelin/openzeppelin-contracts/blob/v0.0.1/contracts/access/manager/AccessManagerLight.sol">
 <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-github-icon lucide-github"><path d="M15 22v-4a4.8 4.8 0 0 0-1-3.5c3 0 6-2 6-5.5.08-1.25-.27-2.48-1-3.5.28-1.15.28-2.35 0-3.5 0 0-1 0-3 1.5-2.64-.5-5.36-.5-8 0C6 2 5 2 5 2c-.3 1.15-.3 2.35 0 3.5A5.403 5.403 0 0 0 4 9c0 3.5 3 5.5 6 5.5-.39.49-.68 1.05-.85 1.65-.17.6-.22 1.23-.15 1.85v4"/><path d="M9 18c-4.51 2-5-2-7-2"/></svg>
@@ -24,7 +24,7 @@ This directory contains utility contracts to restrict access control in smart co
 </div>
 
 ```solidity
-import "@openzeppelin/contracts/access/manager/AccessManagerLight.sol";
+import "@openzeppelin/community-contracts/access/manager/AccessManagerLight.sol";
 ```
 
 Light version of an AccessManager contract that defines `bytes8` roles
@@ -461,4 +461,3 @@ Internal version of [`AccessManagerLight._setRequirements`](#AccessManagerLight-
 
 </div>
 </div>
-

--- a/content/community-contracts/api/access.mdx
+++ b/content/community-contracts/api/access.mdx
@@ -17,7 +17,7 @@ This directory contains utility contracts to restrict access control in smart co
 
 ## `AccessManagerLight`
 
-<a target="_blank" style={{marginTop: "1.5em"}} href="https://github.com/OpenZeppelin/openzeppelin-contracts/blob/v0.0.1/contracts/access/manager/AccessManagerLight.sol">
+<a target="_blank" style={{marginTop: "1.5em"}} href="https://github.com/OpenZeppelin/openzeppelin-community-contracts/blob/master/contracts/access/manager/AccessManagerLight.sol">
 <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-github-icon lucide-github"><path d="M15 22v-4a4.8 4.8 0 0 0-1-3.5c3 0 6-2 6-5.5.08-1.25-.27-2.48-1-3.5.28-1.15.28-2.35 0-3.5 0 0-1 0-3 1.5-2.64-.5-5.36-.5-8 0C6 2 5 2 5 2c-.3 1.15-.3 2.35 0 3.5A5.403 5.403 0 0 0 4 9c0 3.5 3 5.5 6 5.5-.39.49-.68 1.05-.85 1.65-.17.6-.22 1.23-.15 1.85v4"/><path d="M9 18c-4.51 2-5-2-7-2"/></svg>
 </a>
 

--- a/content/community-contracts/api/account.mdx
+++ b/content/community-contracts/api/account.mdx
@@ -62,7 +62,7 @@ This directory includes contracts to build accounts for ERC-4337. These include:
 
 ## `ERC7579DelayedExecutor`
 
-<a target="_blank" style={{marginTop: "1.5em"}} href="https://github.com/OpenZeppelin/openzeppelin-contracts/blob/v0.0.1/contracts/account/modules/ERC7579DelayedExecutor.sol">
+<a target="_blank" style={{marginTop: "1.5em"}} href="https://github.com/OpenZeppelin/openzeppelin-community-contracts/blob/master/contracts/account/modules/ERC7579DelayedExecutor.sol">
 <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-github-icon lucide-github"><path d="M15 22v-4a4.8 4.8 0 0 0-1-3.5c3 0 6-2 6-5.5.08-1.25-.27-2.48-1-3.5.28-1.15.28-2.35 0-3.5 0 0-1 0-3 1.5-2.64-.5-5.36-.5-8 0C6 2 5 2 5 2c-.3 1.15-.3 2.35 0 3.5A5.403 5.403 0 0 0 4 9c0 3.5 3 5.5 6 5.5-.39.49-.68 1.05-.85 1.65-.17.6-.22 1.23-.15 1.85v4"/><path d="M9 18c-4.51 2-5-2-7-2"/></svg>
 </a>
 
@@ -797,7 +797,7 @@ The module is not installed on the account.
 
 ## `ERC7579Executor`
 
-<a target="_blank" style={{marginTop: "1.5em"}} href="https://github.com/OpenZeppelin/openzeppelin-contracts/blob/v0.0.1/contracts/account/modules/ERC7579Executor.sol">
+<a target="_blank" style={{marginTop: "1.5em"}} href="https://github.com/OpenZeppelin/openzeppelin-community-contracts/blob/master/contracts/account/modules/ERC7579Executor.sol">
 <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-github-icon lucide-github"><path d="M15 22v-4a4.8 4.8 0 0 0-1-3.5c3 0 6-2 6-5.5.08-1.25-.27-2.48-1-3.5.28-1.15.28-2.35 0-3.5 0 0-1 0-3 1.5-2.64-.5-5.36-.5-8 0C6 2 5 2 5 2c-.3 1.15-.3 2.35 0 3.5A5.403 5.403 0 0 0 4 9c0 3.5 3 5.5 6 5.5-.39.49-.68 1.05-.85 1.65-.17.6-.22 1.23-.15 1.85v4"/><path d="M9 18c-4.51 2-5-2-7-2"/></svg>
 </a>
 
@@ -960,7 +960,7 @@ Emitted when an operation is executed.
 
 ## `ERC7579Multisig`
 
-<a target="_blank" style={{marginTop: "1.5em"}} href="https://github.com/OpenZeppelin/openzeppelin-contracts/blob/v0.0.1/contracts/account/modules/ERC7579Multisig.sol">
+<a target="_blank" style={{marginTop: "1.5em"}} href="https://github.com/OpenZeppelin/openzeppelin-community-contracts/blob/master/contracts/account/modules/ERC7579Multisig.sol">
 <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-github-icon lucide-github"><path d="M15 22v-4a4.8 4.8 0 0 0-1-3.5c3 0 6-2 6-5.5.08-1.25-.27-2.48-1-3.5.28-1.15.28-2.35 0-3.5 0 0-1 0-3 1.5-2.64-.5-5.36-.5-8 0C6 2 5 2 5 2c-.3 1.15-.3 2.35 0 3.5A5.403 5.403 0 0 0 4 9c0 3.5 3 5.5 6 5.5-.39.49-.68 1.05-.85 1.65-.17.6-.22 1.23-.15 1.85v4"/><path d="M9 18c-4.51 2-5-2-7-2"/></svg>
 </a>
 
@@ -1534,7 +1534,7 @@ The `threshold` is unreachable given the number of `signers`.
 
 ## `ERC7579MultisigConfirmation`
 
-<a target="_blank" style={{marginTop: "1.5em"}} href="https://github.com/OpenZeppelin/openzeppelin-contracts/blob/v0.0.1/contracts/account/modules/ERC7579MultisigConfirmation.sol">
+<a target="_blank" style={{marginTop: "1.5em"}} href="https://github.com/OpenZeppelin/openzeppelin-community-contracts/blob/master/contracts/account/modules/ERC7579MultisigConfirmation.sol">
 <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-github-icon lucide-github"><path d="M15 22v-4a4.8 4.8 0 0 0-1-3.5c3 0 6-2 6-5.5.08-1.25-.27-2.48-1-3.5.28-1.15.28-2.35 0-3.5 0 0-1 0-3 1.5-2.64-.5-5.36-.5-8 0C6 2 5 2 5 2c-.3 1.15-.3 2.35 0 3.5A5.403 5.403 0 0 0 4 9c0 3.5 3 5.5 6 5.5-.39.49-.68 1.05-.85 1.65-.17.6-.22 1.23-.15 1.85v4"/><path d="M9 18c-4.51 2-5-2-7-2"/></svg>
 </a>
 
@@ -1713,7 +1713,7 @@ Error thrown when a confirmation signature has expired
 
 ## `ERC7579MultisigStorage`
 
-<a target="_blank" style={{marginTop: "1.5em"}} href="https://github.com/OpenZeppelin/openzeppelin-contracts/blob/v0.0.1/contracts/account/modules/ERC7579MultisigStorage.sol">
+<a target="_blank" style={{marginTop: "1.5em"}} href="https://github.com/OpenZeppelin/openzeppelin-community-contracts/blob/master/contracts/account/modules/ERC7579MultisigStorage.sol">
 <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-github-icon lucide-github"><path d="M15 22v-4a4.8 4.8 0 0 0-1-3.5c3 0 6-2 6-5.5.08-1.25-.27-2.48-1-3.5.28-1.15.28-2.35 0-3.5 0 0-1 0-3 1.5-2.64-.5-5.36-.5-8 0C6 2 5 2 5 2c-.3 1.15-.3 2.35 0 3.5A5.403 5.403 0 0 0 4 9c0 3.5 3 5.5 6 5.5-.39.49-.68 1.05-.85 1.65-.17.6-.22 1.23-.15 1.85v4"/><path d="M9 18c-4.51 2-5-2-7-2"/></svg>
 </a>
 
@@ -1880,7 +1880,7 @@ Emitted when a signer signs a hash
 
 ## `ERC7579MultisigWeighted`
 
-<a target="_blank" style={{marginTop: "1.5em"}} href="https://github.com/OpenZeppelin/openzeppelin-contracts/blob/v0.0.1/contracts/account/modules/ERC7579MultisigWeighted.sol">
+<a target="_blank" style={{marginTop: "1.5em"}} href="https://github.com/OpenZeppelin/openzeppelin-community-contracts/blob/master/contracts/account/modules/ERC7579MultisigWeighted.sol">
 <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-github-icon lucide-github"><path d="M15 22v-4a4.8 4.8 0 0 0-1-3.5c3 0 6-2 6-5.5.08-1.25-.27-2.48-1-3.5.28-1.15.28-2.35 0-3.5 0 0-1 0-3 1.5-2.64-.5-5.36-.5-8 0C6 2 5 2 5 2c-.3 1.15-.3 2.35 0 3.5A5.403 5.403 0 0 0 4 9c0 3.5 3 5.5 6 5.5-.39.49-.68 1.05-.85 1.65-.17.6-.22 1.23-.15 1.85v4"/><path d="M9 18c-4.51 2-5-2-7-2"/></svg>
 </a>
 
@@ -2252,7 +2252,7 @@ Thrown when the arrays lengths don't match.
 
 ## `ERC7579SelectorExecutor`
 
-<a target="_blank" style={{marginTop: "1.5em"}} href="https://github.com/OpenZeppelin/openzeppelin-contracts/blob/v0.0.1/contracts/account/modules/ERC7579SelectorExecutor.sol">
+<a target="_blank" style={{marginTop: "1.5em"}} href="https://github.com/OpenZeppelin/openzeppelin-community-contracts/blob/master/contracts/account/modules/ERC7579SelectorExecutor.sol">
 <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-github-icon lucide-github"><path d="M15 22v-4a4.8 4.8 0 0 0-1-3.5c3 0 6-2 6-5.5.08-1.25-.27-2.48-1-3.5.28-1.15.28-2.35 0-3.5 0 0-1 0-3 1.5-2.64-.5-5.36-.5-8 0C6 2 5 2 5 2c-.3 1.15-.3 2.35 0 3.5A5.403 5.403 0 0 0 4 9c0 3.5 3 5.5 6 5.5-.39.49-.68 1.05-.85 1.65-.17.6-.22 1.23-.15 1.85v4"/><path d="M9 18c-4.51 2-5-2-7-2"/></svg>
 </a>
 
@@ -2531,7 +2531,7 @@ Error thrown when attempting to execute a non-authorized selector
 
 ## `ERC7579Signature`
 
-<a target="_blank" style={{marginTop: "1.5em"}} href="https://github.com/OpenZeppelin/openzeppelin-contracts/blob/v0.0.1/contracts/account/modules/ERC7579Signature.sol">
+<a target="_blank" style={{marginTop: "1.5em"}} href="https://github.com/OpenZeppelin/openzeppelin-community-contracts/blob/master/contracts/account/modules/ERC7579Signature.sol">
 <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-github-icon lucide-github"><path d="M15 22v-4a4.8 4.8 0 0 0-1-3.5c3 0 6-2 6-5.5.08-1.25-.27-2.48-1-3.5.28-1.15.28-2.35 0-3.5 0 0-1 0-3 1.5-2.64-.5-5.36-.5-8 0C6 2 5 2 5 2c-.3 1.15-.3 2.35 0 3.5A5.403 5.403 0 0 0 4 9c0 3.5 3 5.5 6 5.5-.39.49-.68 1.05-.85 1.65-.17.6-.22 1.23-.15 1.85v4"/><path d="M9 18c-4.51 2-5-2-7-2"/></svg>
 </a>
 
@@ -2750,7 +2750,7 @@ Thrown when the signer length is less than 20 bytes.
 
 ## `ERC7579Validator`
 
-<a target="_blank" style={{marginTop: "1.5em"}} href="https://github.com/OpenZeppelin/openzeppelin-contracts/blob/v0.0.1/contracts/account/modules/ERC7579Validator.sol">
+<a target="_blank" style={{marginTop: "1.5em"}} href="https://github.com/OpenZeppelin/openzeppelin-community-contracts/blob/master/contracts/account/modules/ERC7579Validator.sol">
 <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-github-icon lucide-github"><path d="M15 22v-4a4.8 4.8 0 0 0-1-3.5c3 0 6-2 6-5.5.08-1.25-.27-2.48-1-3.5.28-1.15.28-2.35 0-3.5 0 0-1 0-3 1.5-2.64-.5-5.36-.5-8 0C6 2 5 2 5 2c-.3 1.15-.3 2.35 0 3.5A5.403 5.403 0 0 0 4 9c0 3.5 3 5.5 6 5.5-.39.49-.68 1.05-.85 1.65-.17.6-.22 1.23-.15 1.85v4"/><path d="M9 18c-4.51 2-5-2-7-2"/></svg>
 </a>
 
@@ -2901,7 +2901,7 @@ handle cryptographic verification to prevent unauthorized access.
 
 ## `PaymasterCore`
 
-<a target="_blank" style={{marginTop: "1.5em"}} href="https://github.com/OpenZeppelin/openzeppelin-contracts/blob/v0.0.1/contracts/account/paymaster/PaymasterCore.sol">
+<a target="_blank" style={{marginTop: "1.5em"}} href="https://github.com/OpenZeppelin/openzeppelin-community-contracts/blob/master/contracts/account/paymaster/PaymasterCore.sol">
 <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-github-icon lucide-github"><path d="M15 22v-4a4.8 4.8 0 0 0-1-3.5c3 0 6-2 6-5.5.08-1.25-.27-2.48-1-3.5.28-1.15.28-2.35 0-3.5 0 0-1 0-3 1.5-2.64-.5-5.36-.5-8 0C6 2 5 2 5 2c-.3 1.15-.3 2.35 0 3.5A5.403 5.403 0 0 0 4 9c0 3.5 3 5.5 6 5.5-.39.49-.68 1.05-.85 1.65-.17.6-.22 1.23-.15 1.85v4"/><path d="M9 18c-4.51 2-5-2-7-2"/></svg>
 </a>
 
@@ -3249,7 +3249,7 @@ Unauthorized call to the paymaster.
 
 ## `PaymasterERC20`
 
-<a target="_blank" style={{marginTop: "1.5em"}} href="https://github.com/OpenZeppelin/openzeppelin-contracts/blob/v0.0.1/contracts/account/paymaster/PaymasterERC20.sol">
+<a target="_blank" style={{marginTop: "1.5em"}} href="https://github.com/OpenZeppelin/openzeppelin-community-contracts/blob/master/contracts/account/paymaster/PaymasterERC20.sol">
 <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-github-icon lucide-github"><path d="M15 22v-4a4.8 4.8 0 0 0-1-3.5c3 0 6-2 6-5.5.08-1.25-.27-2.48-1-3.5.28-1.15.28-2.35 0-3.5 0 0-1 0-3 1.5-2.64-.5-5.36-.5-8 0C6 2 5 2 5 2c-.3 1.15-.3 2.35 0 3.5A5.403 5.403 0 0 0 4 9c0 3.5 3 5.5 6 5.5-.39.49-.68 1.05-.85 1.65-.17.6-.22 1.23-.15 1.85v4"/><path d="M9 18c-4.51 2-5-2-7-2"/></svg>
 </a>
 
@@ -3565,7 +3565,7 @@ and the `actualAmount` of `token`.
 
 ## `PaymasterERC20Guarantor`
 
-<a target="_blank" style={{marginTop: "1.5em"}} href="https://github.com/OpenZeppelin/openzeppelin-contracts/blob/v0.0.1/contracts/account/paymaster/PaymasterERC20Guarantor.sol">
+<a target="_blank" style={{marginTop: "1.5em"}} href="https://github.com/OpenZeppelin/openzeppelin-community-contracts/blob/master/contracts/account/paymaster/PaymasterERC20Guarantor.sol">
 <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-github-icon lucide-github"><path d="M15 22v-4a4.8 4.8 0 0 0-1-3.5c3 0 6-2 6-5.5.08-1.25-.27-2.48-1-3.5.28-1.15.28-2.35 0-3.5 0 0-1 0-3 1.5-2.64-.5-5.36-.5-8 0C6 2 5 2 5 2c-.3 1.15-.3 2.35 0 3.5A5.403 5.403 0 0 0 4 9c0 3.5 3 5.5 6 5.5-.39.49-.68 1.05-.85 1.65-.17.6-.22 1.23-.15 1.85v4"/><path d="M9 18c-4.51 2-5-2-7-2"/></svg>
 </a>
 
@@ -3754,7 +3754,7 @@ Emitted when a user operation identified by `userOpHash` is guaranteed by a `gua
 
 ## `PaymasterERC721Owner`
 
-<a target="_blank" style={{marginTop: "1.5em"}} href="https://github.com/OpenZeppelin/openzeppelin-contracts/blob/v0.0.1/contracts/account/paymaster/PaymasterERC721Owner.sol">
+<a target="_blank" style={{marginTop: "1.5em"}} href="https://github.com/OpenZeppelin/openzeppelin-community-contracts/blob/master/contracts/account/paymaster/PaymasterERC721Owner.sol">
 <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-github-icon lucide-github"><path d="M15 22v-4a4.8 4.8 0 0 0-1-3.5c3 0 6-2 6-5.5.08-1.25-.27-2.48-1-3.5.28-1.15.28-2.35 0-3.5 0 0-1 0-3 1.5-2.64-.5-5.36-.5-8 0C6 2 5 2 5 2c-.3 1.15-.3 2.35 0 3.5A5.403 5.403 0 0 0 4 9c0 3.5 3 5.5 6 5.5-.39.49-.68 1.05-.85 1.65-.17.6-.22 1.23-.15 1.85v4"/><path d="M9 18c-4.51 2-5-2-7-2"/></svg>
 </a>
 
@@ -3906,7 +3906,7 @@ Emitted when the paymaster token is set.
 
 ## `PaymasterSigner`
 
-<a target="_blank" style={{marginTop: "1.5em"}} href="https://github.com/OpenZeppelin/openzeppelin-contracts/blob/v0.0.1/contracts/account/paymaster/PaymasterSigner.sol">
+<a target="_blank" style={{marginTop: "1.5em"}} href="https://github.com/OpenZeppelin/openzeppelin-community-contracts/blob/master/contracts/account/paymaster/PaymasterSigner.sol">
 <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-github-icon lucide-github"><path d="M15 22v-4a4.8 4.8 0 0 0-1-3.5c3 0 6-2 6-5.5.08-1.25-.27-2.48-1-3.5.28-1.15.28-2.35 0-3.5 0 0-1 0-3 1.5-2.64-.5-5.36-.5-8 0C6 2 5 2 5 2c-.3 1.15-.3 2.35 0 3.5A5.403 5.403 0 0 0 4 9c0 3.5 3 5.5 6 5.5-.39.49-.68 1.05-.85 1.65-.17.6-.22 1.23-.15 1.85v4"/><path d="M9 18c-4.51 2-5-2-7-2"/></svg>
 </a>
 

--- a/content/community-contracts/api/account.mdx
+++ b/content/community-contracts/api/account.mdx
@@ -60,7 +60,7 @@ This directory includes contracts to build accounts for ERC-4337. These include:
 
 <div style={{marginTop: "4em"}} className="w-full flex flex-row items-center justify-between">
 
-## `ERC7579DelayedExecutor` 
+## `ERC7579DelayedExecutor`
 
 <a target="_blank" style={{marginTop: "1.5em"}} href="https://github.com/OpenZeppelin/openzeppelin-contracts/blob/v0.0.1/contracts/account/modules/ERC7579DelayedExecutor.sol">
 <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-github-icon lucide-github"><path d="M15 22v-4a4.8 4.8 0 0 0-1-3.5c3 0 6-2 6-5.5.08-1.25-.27-2.48-1-3.5.28-1.15.28-2.35 0-3.5 0 0-1 0-3 1.5-2.64-.5-5.36-.5-8 0C6 2 5 2 5 2c-.3 1.15-.3 2.35 0 3.5A5.403 5.403 0 0 0 4 9c0 3.5 3 5.5 6 5.5-.39.49-.68 1.05-.85 1.65-.17.6-.22 1.23-.15 1.85v4"/><path d="M9 18c-4.51 2-5-2-7-2"/></svg>
@@ -69,7 +69,7 @@ This directory includes contracts to build accounts for ERC-4337. These include:
 </div>
 
 ```solidity
-import "@openzeppelin/contracts/account/modules/ERC7579DelayedExecutor.sol";
+import "@openzeppelin/community-contracts/account/modules/ERC7579DelayedExecutor.sol";
 ```
 
 Extension of [`ERC7579Executor`](#ERC7579Executor) that allows scheduling and executing delayed operations
@@ -795,7 +795,7 @@ The module is not installed on the account.
 
 <div style={{marginTop: "4em"}} className="w-full flex flex-row items-center justify-between">
 
-## `ERC7579Executor` 
+## `ERC7579Executor`
 
 <a target="_blank" style={{marginTop: "1.5em"}} href="https://github.com/OpenZeppelin/openzeppelin-contracts/blob/v0.0.1/contracts/account/modules/ERC7579Executor.sol">
 <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-github-icon lucide-github"><path d="M15 22v-4a4.8 4.8 0 0 0-1-3.5c3 0 6-2 6-5.5.08-1.25-.27-2.48-1-3.5.28-1.15.28-2.35 0-3.5 0 0-1 0-3 1.5-2.64-.5-5.36-.5-8 0C6 2 5 2 5 2c-.3 1.15-.3 2.35 0 3.5A5.403 5.403 0 0 0 4 9c0 3.5 3 5.5 6 5.5-.39.49-.68 1.05-.85 1.65-.17.6-.22 1.23-.15 1.85v4"/><path d="M9 18c-4.51 2-5-2-7-2"/></svg>
@@ -804,7 +804,7 @@ The module is not installed on the account.
 </div>
 
 ```solidity
-import "@openzeppelin/contracts/account/modules/ERC7579Executor.sol";
+import "@openzeppelin/community-contracts/account/modules/ERC7579Executor.sol";
 ```
 
 Basic implementation for ERC-7579 executor modules that provides execution functionality
@@ -958,7 +958,7 @@ Emitted when an operation is executed.
 
 <div style={{marginTop: "4em"}} className="w-full flex flex-row items-center justify-between">
 
-## `ERC7579Multisig` 
+## `ERC7579Multisig`
 
 <a target="_blank" style={{marginTop: "1.5em"}} href="https://github.com/OpenZeppelin/openzeppelin-contracts/blob/v0.0.1/contracts/account/modules/ERC7579Multisig.sol">
 <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-github-icon lucide-github"><path d="M15 22v-4a4.8 4.8 0 0 0-1-3.5c3 0 6-2 6-5.5.08-1.25-.27-2.48-1-3.5.28-1.15.28-2.35 0-3.5 0 0-1 0-3 1.5-2.64-.5-5.36-.5-8 0C6 2 5 2 5 2c-.3 1.15-.3 2.35 0 3.5A5.403 5.403 0 0 0 4 9c0 3.5 3 5.5 6 5.5-.39.49-.68 1.05-.85 1.65-.17.6-.22 1.23-.15 1.85v4"/><path d="M9 18c-4.51 2-5-2-7-2"/></svg>
@@ -967,7 +967,7 @@ Emitted when an operation is executed.
 </div>
 
 ```solidity
-import "@openzeppelin/contracts/account/modules/ERC7579Multisig.sol";
+import "@openzeppelin/community-contracts/account/modules/ERC7579Multisig.sol";
 ```
 
 Implementation of an [`ERC7579Validator`](#ERC7579Validator) that uses ERC-7913 signers for multisignature
@@ -1532,7 +1532,7 @@ The `threshold` is unreachable given the number of `signers`.
 
 <div style={{marginTop: "4em"}} className="w-full flex flex-row items-center justify-between">
 
-## `ERC7579MultisigConfirmation` 
+## `ERC7579MultisigConfirmation`
 
 <a target="_blank" style={{marginTop: "1.5em"}} href="https://github.com/OpenZeppelin/openzeppelin-contracts/blob/v0.0.1/contracts/account/modules/ERC7579MultisigConfirmation.sol">
 <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-github-icon lucide-github"><path d="M15 22v-4a4.8 4.8 0 0 0-1-3.5c3 0 6-2 6-5.5.08-1.25-.27-2.48-1-3.5.28-1.15.28-2.35 0-3.5 0 0-1 0-3 1.5-2.64-.5-5.36-.5-8 0C6 2 5 2 5 2c-.3 1.15-.3 2.35 0 3.5A5.403 5.403 0 0 0 4 9c0 3.5 3 5.5 6 5.5-.39.49-.68 1.05-.85 1.65-.17.6-.22 1.23-.15 1.85v4"/><path d="M9 18c-4.51 2-5-2-7-2"/></svg>
@@ -1541,7 +1541,7 @@ The `threshold` is unreachable given the number of `signers`.
 </div>
 
 ```solidity
-import "@openzeppelin/contracts/account/modules/ERC7579MultisigConfirmation.sol";
+import "@openzeppelin/community-contracts/account/modules/ERC7579MultisigConfirmation.sol";
 ```
 
 Extension of [`ERC7579Multisig`](#ERC7579Multisig) that requires explicit confirmation signatures
@@ -1711,7 +1711,7 @@ Error thrown when a confirmation signature has expired
 
 <div style={{marginTop: "4em"}} className="w-full flex flex-row items-center justify-between">
 
-## `ERC7579MultisigStorage` 
+## `ERC7579MultisigStorage`
 
 <a target="_blank" style={{marginTop: "1.5em"}} href="https://github.com/OpenZeppelin/openzeppelin-contracts/blob/v0.0.1/contracts/account/modules/ERC7579MultisigStorage.sol">
 <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-github-icon lucide-github"><path d="M15 22v-4a4.8 4.8 0 0 0-1-3.5c3 0 6-2 6-5.5.08-1.25-.27-2.48-1-3.5.28-1.15.28-2.35 0-3.5 0 0-1 0-3 1.5-2.64-.5-5.36-.5-8 0C6 2 5 2 5 2c-.3 1.15-.3 2.35 0 3.5A5.403 5.403 0 0 0 4 9c0 3.5 3 5.5 6 5.5-.39.49-.68 1.05-.85 1.65-.17.6-.22 1.23-.15 1.85v4"/><path d="M9 18c-4.51 2-5-2-7-2"/></svg>
@@ -1720,7 +1720,7 @@ Error thrown when a confirmation signature has expired
 </div>
 
 ```solidity
-import "@openzeppelin/contracts/account/modules/ERC7579MultisigStorage.sol";
+import "@openzeppelin/community-contracts/account/modules/ERC7579MultisigStorage.sol";
 ```
 
 Extension of [`ERC7579Multisig`](#ERC7579Multisig) that allows storing presigned approvals in storage.
@@ -1878,7 +1878,7 @@ Emitted when a signer signs a hash
 
 <div style={{marginTop: "4em"}} className="w-full flex flex-row items-center justify-between">
 
-## `ERC7579MultisigWeighted` 
+## `ERC7579MultisigWeighted`
 
 <a target="_blank" style={{marginTop: "1.5em"}} href="https://github.com/OpenZeppelin/openzeppelin-contracts/blob/v0.0.1/contracts/account/modules/ERC7579MultisigWeighted.sol">
 <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-github-icon lucide-github"><path d="M15 22v-4a4.8 4.8 0 0 0-1-3.5c3 0 6-2 6-5.5.08-1.25-.27-2.48-1-3.5.28-1.15.28-2.35 0-3.5 0 0-1 0-3 1.5-2.64-.5-5.36-.5-8 0C6 2 5 2 5 2c-.3 1.15-.3 2.35 0 3.5A5.403 5.403 0 0 0 4 9c0 3.5 3 5.5 6 5.5-.39.49-.68 1.05-.85 1.65-.17.6-.22 1.23-.15 1.85v4"/><path d="M9 18c-4.51 2-5-2-7-2"/></svg>
@@ -1887,7 +1887,7 @@ Emitted when a signer signs a hash
 </div>
 
 ```solidity
-import "@openzeppelin/contracts/account/modules/ERC7579MultisigWeighted.sol";
+import "@openzeppelin/community-contracts/account/modules/ERC7579MultisigWeighted.sol";
 ```
 
 Extension of [`ERC7579Multisig`](#ERC7579Multisig) that supports weighted signatures.
@@ -2250,7 +2250,7 @@ Thrown when the arrays lengths don't match.
 
 <div style={{marginTop: "4em"}} className="w-full flex flex-row items-center justify-between">
 
-## `ERC7579SelectorExecutor` 
+## `ERC7579SelectorExecutor`
 
 <a target="_blank" style={{marginTop: "1.5em"}} href="https://github.com/OpenZeppelin/openzeppelin-contracts/blob/v0.0.1/contracts/account/modules/ERC7579SelectorExecutor.sol">
 <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-github-icon lucide-github"><path d="M15 22v-4a4.8 4.8 0 0 0-1-3.5c3 0 6-2 6-5.5.08-1.25-.27-2.48-1-3.5.28-1.15.28-2.35 0-3.5 0 0-1 0-3 1.5-2.64-.5-5.36-.5-8 0C6 2 5 2 5 2c-.3 1.15-.3 2.35 0 3.5A5.403 5.403 0 0 0 4 9c0 3.5 3 5.5 6 5.5-.39.49-.68 1.05-.85 1.65-.17.6-.22 1.23-.15 1.85v4"/><path d="M9 18c-4.51 2-5-2-7-2"/></svg>
@@ -2259,7 +2259,7 @@ Thrown when the arrays lengths don't match.
 </div>
 
 ```solidity
-import "@openzeppelin/contracts/account/modules/ERC7579SelectorExecutor.sol";
+import "@openzeppelin/community-contracts/account/modules/ERC7579SelectorExecutor.sol";
 ```
 
 Implementation of an [`ERC7579Executor`](#ERC7579Executor) that allows authorizing specific function selectors
@@ -2529,7 +2529,7 @@ Error thrown when attempting to execute a non-authorized selector
 
 <div style={{marginTop: "4em"}} className="w-full flex flex-row items-center justify-between">
 
-## `ERC7579Signature` 
+## `ERC7579Signature`
 
 <a target="_blank" style={{marginTop: "1.5em"}} href="https://github.com/OpenZeppelin/openzeppelin-contracts/blob/v0.0.1/contracts/account/modules/ERC7579Signature.sol">
 <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-github-icon lucide-github"><path d="M15 22v-4a4.8 4.8 0 0 0-1-3.5c3 0 6-2 6-5.5.08-1.25-.27-2.48-1-3.5.28-1.15.28-2.35 0-3.5 0 0-1 0-3 1.5-2.64-.5-5.36-.5-8 0C6 2 5 2 5 2c-.3 1.15-.3 2.35 0 3.5A5.403 5.403 0 0 0 4 9c0 3.5 3 5.5 6 5.5-.39.49-.68 1.05-.85 1.65-.17.6-.22 1.23-.15 1.85v4"/><path d="M9 18c-4.51 2-5-2-7-2"/></svg>
@@ -2538,7 +2538,7 @@ Error thrown when attempting to execute a non-authorized selector
 </div>
 
 ```solidity
-import "@openzeppelin/contracts/account/modules/ERC7579Signature.sol";
+import "@openzeppelin/community-contracts/account/modules/ERC7579Signature.sol";
 ```
 
 Implementation of [`ERC7579Validator`](#ERC7579Validator) module using ERC-7913 signature verification.
@@ -2748,7 +2748,7 @@ Thrown when the signer length is less than 20 bytes.
 
 <div style={{marginTop: "4em"}} className="w-full flex flex-row items-center justify-between">
 
-## `ERC7579Validator` 
+## `ERC7579Validator`
 
 <a target="_blank" style={{marginTop: "1.5em"}} href="https://github.com/OpenZeppelin/openzeppelin-contracts/blob/v0.0.1/contracts/account/modules/ERC7579Validator.sol">
 <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-github-icon lucide-github"><path d="M15 22v-4a4.8 4.8 0 0 0-1-3.5c3 0 6-2 6-5.5.08-1.25-.27-2.48-1-3.5.28-1.15.28-2.35 0-3.5 0 0-1 0-3 1.5-2.64-.5-5.36-.5-8 0C6 2 5 2 5 2c-.3 1.15-.3 2.35 0 3.5A5.403 5.403 0 0 0 4 9c0 3.5 3 5.5 6 5.5-.39.49-.68 1.05-.85 1.65-.17.6-.22 1.23-.15 1.85v4"/><path d="M9 18c-4.51 2-5-2-7-2"/></svg>
@@ -2757,7 +2757,7 @@ Thrown when the signer length is less than 20 bytes.
 </div>
 
 ```solidity
-import "@openzeppelin/contracts/account/modules/ERC7579Validator.sol";
+import "@openzeppelin/community-contracts/account/modules/ERC7579Validator.sol";
 ```
 
 Abstract validator module for ERC-7579 accounts.
@@ -2899,7 +2899,7 @@ handle cryptographic verification to prevent unauthorized access.
 
 <div style={{marginTop: "4em"}} className="w-full flex flex-row items-center justify-between">
 
-## `PaymasterCore` 
+## `PaymasterCore`
 
 <a target="_blank" style={{marginTop: "1.5em"}} href="https://github.com/OpenZeppelin/openzeppelin-contracts/blob/v0.0.1/contracts/account/paymaster/PaymasterCore.sol">
 <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-github-icon lucide-github"><path d="M15 22v-4a4.8 4.8 0 0 0-1-3.5c3 0 6-2 6-5.5.08-1.25-.27-2.48-1-3.5.28-1.15.28-2.35 0-3.5 0 0-1 0-3 1.5-2.64-.5-5.36-.5-8 0C6 2 5 2 5 2c-.3 1.15-.3 2.35 0 3.5A5.403 5.403 0 0 0 4 9c0 3.5 3 5.5 6 5.5-.39.49-.68 1.05-.85 1.65-.17.6-.22 1.23-.15 1.85v4"/><path d="M9 18c-4.51 2-5-2-7-2"/></svg>
@@ -2908,7 +2908,7 @@ handle cryptographic verification to prevent unauthorized access.
 </div>
 
 ```solidity
-import "@openzeppelin/contracts/account/paymaster/PaymasterCore.sol";
+import "@openzeppelin/community-contracts/account/paymaster/PaymasterCore.sol";
 ```
 
 A simple ERC4337 paymaster implementation. This base implementation only includes the minimal logic to validate
@@ -3247,7 +3247,7 @@ Unauthorized call to the paymaster.
 
 <div style={{marginTop: "4em"}} className="w-full flex flex-row items-center justify-between">
 
-## `PaymasterERC20` 
+## `PaymasterERC20`
 
 <a target="_blank" style={{marginTop: "1.5em"}} href="https://github.com/OpenZeppelin/openzeppelin-contracts/blob/v0.0.1/contracts/account/paymaster/PaymasterERC20.sol">
 <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-github-icon lucide-github"><path d="M15 22v-4a4.8 4.8 0 0 0-1-3.5c3 0 6-2 6-5.5.08-1.25-.27-2.48-1-3.5.28-1.15.28-2.35 0-3.5 0 0-1 0-3 1.5-2.64-.5-5.36-.5-8 0C6 2 5 2 5 2c-.3 1.15-.3 2.35 0 3.5A5.403 5.403 0 0 0 4 9c0 3.5 3 5.5 6 5.5-.39.49-.68 1.05-.85 1.65-.17.6-.22 1.23-.15 1.85v4"/><path d="M9 18c-4.51 2-5-2-7-2"/></svg>
@@ -3256,7 +3256,7 @@ Unauthorized call to the paymaster.
 </div>
 
 ```solidity
-import "@openzeppelin/contracts/account/paymaster/PaymasterERC20.sol";
+import "@openzeppelin/community-contracts/account/paymaster/PaymasterERC20.sol";
 ```
 
 Extension of [`PaymasterCore`](#PaymasterCore) that enables users to pay gas with ERC-20 tokens.
@@ -3563,7 +3563,7 @@ and the `actualAmount` of `token`.
 
 <div style={{marginTop: "4em"}} className="w-full flex flex-row items-center justify-between">
 
-## `PaymasterERC20Guarantor` 
+## `PaymasterERC20Guarantor`
 
 <a target="_blank" style={{marginTop: "1.5em"}} href="https://github.com/OpenZeppelin/openzeppelin-contracts/blob/v0.0.1/contracts/account/paymaster/PaymasterERC20Guarantor.sol">
 <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-github-icon lucide-github"><path d="M15 22v-4a4.8 4.8 0 0 0-1-3.5c3 0 6-2 6-5.5.08-1.25-.27-2.48-1-3.5.28-1.15.28-2.35 0-3.5 0 0-1 0-3 1.5-2.64-.5-5.36-.5-8 0C6 2 5 2 5 2c-.3 1.15-.3 2.35 0 3.5A5.403 5.403 0 0 0 4 9c0 3.5 3 5.5 6 5.5-.39.49-.68 1.05-.85 1.65-.17.6-.22 1.23-.15 1.85v4"/><path d="M9 18c-4.51 2-5-2-7-2"/></svg>
@@ -3572,7 +3572,7 @@ and the `actualAmount` of `token`.
 </div>
 
 ```solidity
-import "@openzeppelin/contracts/account/paymaster/PaymasterERC20Guarantor.sol";
+import "@openzeppelin/community-contracts/account/paymaster/PaymasterERC20Guarantor.sol";
 ```
 
 Extension of [`PaymasterERC20`](#PaymasterERC20) that enables third parties to guarantee user operations.
@@ -3752,7 +3752,7 @@ Emitted when a user operation identified by `userOpHash` is guaranteed by a `gua
 
 <div style={{marginTop: "4em"}} className="w-full flex flex-row items-center justify-between">
 
-## `PaymasterERC721Owner` 
+## `PaymasterERC721Owner`
 
 <a target="_blank" style={{marginTop: "1.5em"}} href="https://github.com/OpenZeppelin/openzeppelin-contracts/blob/v0.0.1/contracts/account/paymaster/PaymasterERC721Owner.sol">
 <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-github-icon lucide-github"><path d="M15 22v-4a4.8 4.8 0 0 0-1-3.5c3 0 6-2 6-5.5.08-1.25-.27-2.48-1-3.5.28-1.15.28-2.35 0-3.5 0 0-1 0-3 1.5-2.64-.5-5.36-.5-8 0C6 2 5 2 5 2c-.3 1.15-.3 2.35 0 3.5A5.403 5.403 0 0 0 4 9c0 3.5 3 5.5 6 5.5-.39.49-.68 1.05-.85 1.65-.17.6-.22 1.23-.15 1.85v4"/><path d="M9 18c-4.51 2-5-2-7-2"/></svg>
@@ -3761,7 +3761,7 @@ Emitted when a user operation identified by `userOpHash` is guaranteed by a `gua
 </div>
 
 ```solidity
-import "@openzeppelin/contracts/account/paymaster/PaymasterERC721Owner.sol";
+import "@openzeppelin/community-contracts/account/paymaster/PaymasterERC721Owner.sol";
 ```
 
 Extension of [`PaymasterCore`](#PaymasterCore) that supports account based on ownership of an ERC-721 token.
@@ -3904,7 +3904,7 @@ Emitted when the paymaster token is set.
 
 <div style={{marginTop: "4em"}} className="w-full flex flex-row items-center justify-between">
 
-## `PaymasterSigner` 
+## `PaymasterSigner`
 
 <a target="_blank" style={{marginTop: "1.5em"}} href="https://github.com/OpenZeppelin/openzeppelin-contracts/blob/v0.0.1/contracts/account/paymaster/PaymasterSigner.sol">
 <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-github-icon lucide-github"><path d="M15 22v-4a4.8 4.8 0 0 0-1-3.5c3 0 6-2 6-5.5.08-1.25-.27-2.48-1-3.5.28-1.15.28-2.35 0-3.5 0 0-1 0-3 1.5-2.64-.5-5.36-.5-8 0C6 2 5 2 5 2c-.3 1.15-.3 2.35 0 3.5A5.403 5.403 0 0 0 4 9c0 3.5 3 5.5 6 5.5-.39.49-.68 1.05-.85 1.65-.17.6-.22 1.23-.15 1.85v4"/><path d="M9 18c-4.51 2-5-2-7-2"/></svg>
@@ -3913,7 +3913,7 @@ Emitted when the paymaster token is set.
 </div>
 
 ```solidity
-import "@openzeppelin/contracts/account/paymaster/PaymasterSigner.sol";
+import "@openzeppelin/community-contracts/account/paymaster/PaymasterSigner.sol";
 ```
 
 Extension of [`PaymasterCore`](#PaymasterCore) that adds signature validation. See `SignerECDSA`, `SignerP256` or `SignerRSA`.
@@ -4039,4 +4039,3 @@ Decodes the user operation's data from `paymasterAndData`.
 
 </div>
 </div>
-

--- a/content/community-contracts/api/crosschain.mdx
+++ b/content/community-contracts/api/crosschain.mdx
@@ -32,7 +32,7 @@ Developers can access interoperability protocols through gateway adapters. The l
 
 ## `ERC7786OpenBridge`
 
-<a target="_blank" style={{marginTop: "1.5em"}} href="https://github.com/OpenZeppelin/openzeppelin-contracts/blob/v0.0.1/contracts/crosschain/ERC7786OpenBridge.sol">
+<a target="_blank" style={{marginTop: "1.5em"}} href="https://github.com/OpenZeppelin/openzeppelin-community-contracts/blob/master/contracts/crosschain/ERC7786OpenBridge.sol">
 <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-github-icon lucide-github"><path d="M15 22v-4a4.8 4.8 0 0 0-1-3.5c3 0 6-2 6-5.5.08-1.25-.27-2.48-1-3.5.28-1.15.28-2.35 0-3.5 0 0-1 0-3 1.5-2.64-.5-5.36-.5-8 0C6 2 5 2 5 2c-.3 1.15-.3 2.35 0 3.5A5.403 5.403 0 0 0 4 9c0 3.5 3 5.5 6 5.5-.39.49-.68 1.05-.85 1.65-.17.6-.22 1.23-.15 1.85v4"/><path d="M9 18c-4.51 2-5-2-7-2"/></svg>
 </a>
 
@@ -724,7 +724,7 @@ Recovery method in case value is ever received through [`ERC7786OpenBridge.recei
 
 ## `AxelarGatewayAdapter`
 
-<a target="_blank" style={{marginTop: "1.5em"}} href="https://github.com/OpenZeppelin/openzeppelin-contracts/blob/v0.0.1/contracts/crosschain/axelar/AxelarGatewayAdapter.sol">
+<a target="_blank" style={{marginTop: "1.5em"}} href="https://github.com/OpenZeppelin/openzeppelin-community-contracts/blob/master/contracts/crosschain/axelar/AxelarGatewayAdapter.sol">
 <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-github-icon lucide-github"><path d="M15 22v-4a4.8 4.8 0 0 0-1-3.5c3 0 6-2 6-5.5.08-1.25-.27-2.48-1-3.5.28-1.15.28-2.35 0-3.5 0 0-1 0-3 1.5-2.64-.5-5.36-.5-8 0C6 2 5 2 5 2c-.3 1.15-.3 2.35 0 3.5A5.403 5.403 0 0 0 4 9c0 3.5 3 5.5 6 5.5-.39.49-.68 1.05-.85 1.65-.17.6-.22 1.23-.15 1.85v4"/><path d="M9 18c-4.51 2-5-2-7-2"/></svg>
 </a>
 
@@ -1191,7 +1191,7 @@ A chain equivalence has been registered.
 
 ## `ERC7786Attributes`
 
-<a target="_blank" style={{marginTop: "1.5em"}} href="https://github.com/OpenZeppelin/openzeppelin-contracts/blob/v0.0.1/contracts/crosschain/utils/ERC7786Attributes.sol">
+<a target="_blank" style={{marginTop: "1.5em"}} href="https://github.com/OpenZeppelin/openzeppelin-community-contracts/blob/master/contracts/crosschain/utils/ERC7786Attributes.sol">
 <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-github-icon lucide-github"><path d="M15 22v-4a4.8 4.8 0 0 0-1-3.5c3 0 6-2 6-5.5.08-1.25-.27-2.48-1-3.5.28-1.15.28-2.35 0-3.5 0 0-1 0-3 1.5-2.64-.5-5.36-.5-8 0C6 2 5 2 5 2c-.3 1.15-.3 2.35 0 3.5A5.403 5.403 0 0 0 4 9c0 3.5 3 5.5 6 5.5-.39.49-.68 1.05-.85 1.65-.17.6-.22 1.23-.15 1.85v4"/><path d="M9 18c-4.51 2-5-2-7-2"/></svg>
 </a>
 
@@ -1233,7 +1233,7 @@ Parse the `requestRelay(uint256,uint256,address)` (0x4cbb573a) attribute into it
 
 ## `ERC7786Receiver`
 
-<a target="_blank" style={{marginTop: "1.5em"}} href="https://github.com/OpenZeppelin/openzeppelin-contracts/blob/v0.0.1/contracts/crosschain/utils/ERC7786Receiver.sol">
+<a target="_blank" style={{marginTop: "1.5em"}} href="https://github.com/OpenZeppelin/openzeppelin-community-contracts/blob/master/contracts/crosschain/utils/ERC7786Receiver.sol">
 <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-github-icon lucide-github"><path d="M15 22v-4a4.8 4.8 0 0 0-1-3.5c3 0 6-2 6-5.5.08-1.25-.27-2.48-1-3.5.28-1.15.28-2.35 0-3.5 0 0-1 0-3 1.5-2.64-.5-5.36-.5-8 0C6 2 5 2 5 2c-.3 1.15-.3 2.35 0 3.5A5.403 5.403 0 0 0 4 9c0 3.5 3 5.5 6 5.5-.39.49-.68 1.05-.85 1.65-.17.6-.22 1.23-.15 1.85v4"/><path d="M9 18c-4.51 2-5-2-7-2"/></svg>
 </a>
 
@@ -1362,7 +1362,7 @@ Virtual function that should contain the logic to execute when a cross-chain mes
 
 ## `WormholeGatewayAdapter`
 
-<a target="_blank" style={{marginTop: "1.5em"}} href="https://github.com/OpenZeppelin/openzeppelin-contracts/blob/v0.0.1/contracts/crosschain/wormhole/WormholeGatewayAdapter.sol">
+<a target="_blank" style={{marginTop: "1.5em"}} href="https://github.com/OpenZeppelin/openzeppelin-community-contracts/blob/master/contracts/crosschain/wormhole/WormholeGatewayAdapter.sol">
 <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-github-icon lucide-github"><path d="M15 22v-4a4.8 4.8 0 0 0-1-3.5c3 0 6-2 6-5.5.08-1.25-.27-2.48-1-3.5.28-1.15.28-2.35 0-3.5 0 0-1 0-3 1.5-2.64-.5-5.36-.5-8 0C6 2 5 2 5 2c-.3 1.15-.3 2.35 0 3.5A5.403 5.403 0 0 0 4 9c0 3.5 3 5.5 6 5.5-.39.49-.68 1.05-.85 1.65-.17.6-.22 1.23-.15 1.85v4"/><path d="M9 18c-4.51 2-5-2-7-2"/></svg>
 </a>
 

--- a/content/community-contracts/api/crosschain.mdx
+++ b/content/community-contracts/api/crosschain.mdx
@@ -30,7 +30,7 @@ Developers can access interoperability protocols through gateway adapters. The l
 
 <div style={{marginTop: "4em"}} className="w-full flex flex-row items-center justify-between">
 
-## `ERC7786OpenBridge` 
+## `ERC7786OpenBridge`
 
 <a target="_blank" style={{marginTop: "1.5em"}} href="https://github.com/OpenZeppelin/openzeppelin-contracts/blob/v0.0.1/contracts/crosschain/ERC7786OpenBridge.sol">
 <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-github-icon lucide-github"><path d="M15 22v-4a4.8 4.8 0 0 0-1-3.5c3 0 6-2 6-5.5.08-1.25-.27-2.48-1-3.5.28-1.15.28-2.35 0-3.5 0 0-1 0-3 1.5-2.64-.5-5.36-.5-8 0C6 2 5 2 5 2c-.3 1.15-.3 2.35 0 3.5A5.403 5.403 0 0 0 4 9c0 3.5 3 5.5 6 5.5-.39.49-.68 1.05-.85 1.65-.17.6-.22 1.23-.15 1.85v4"/><path d="M9 18c-4.51 2-5-2-7-2"/></svg>
@@ -39,7 +39,7 @@ Developers can access interoperability protocols through gateway adapters. The l
 </div>
 
 ```solidity
-import "@openzeppelin/contracts/crosschain/ERC7786OpenBridge.sol";
+import "@openzeppelin/community-contracts/crosschain/ERC7786OpenBridge.sol";
 ```
 
 N of M gateway: Sends your message through M independent gateways. It will be delivered to the receiver by an
@@ -722,7 +722,7 @@ Recovery method in case value is ever received through [`ERC7786OpenBridge.recei
 
 <div style={{marginTop: "4em"}} className="w-full flex flex-row items-center justify-between">
 
-## `AxelarGatewayAdapter` 
+## `AxelarGatewayAdapter`
 
 <a target="_blank" style={{marginTop: "1.5em"}} href="https://github.com/OpenZeppelin/openzeppelin-contracts/blob/v0.0.1/contracts/crosschain/axelar/AxelarGatewayAdapter.sol">
 <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-github-icon lucide-github"><path d="M15 22v-4a4.8 4.8 0 0 0-1-3.5c3 0 6-2 6-5.5.08-1.25-.27-2.48-1-3.5.28-1.15.28-2.35 0-3.5 0 0-1 0-3 1.5-2.64-.5-5.36-.5-8 0C6 2 5 2 5 2c-.3 1.15-.3 2.35 0 3.5A5.403 5.403 0 0 0 4 9c0 3.5 3 5.5 6 5.5-.39.49-.68 1.05-.85 1.65-.17.6-.22 1.23-.15 1.85v4"/><path d="M9 18c-4.51 2-5-2-7-2"/></svg>
@@ -731,7 +731,7 @@ Recovery method in case value is ever received through [`ERC7786OpenBridge.recei
 </div>
 
 ```solidity
-import "@openzeppelin/contracts/crosschain/axelar/AxelarGatewayAdapter.sol";
+import "@openzeppelin/community-contracts/crosschain/axelar/AxelarGatewayAdapter.sol";
 ```
 
 Implementation of an ERC-7786 gateway destination adapter for the Axelar Network in dual mode.
@@ -1189,7 +1189,7 @@ A chain equivalence has been registered.
 
 <div style={{marginTop: "4em"}} className="w-full flex flex-row items-center justify-between">
 
-## `ERC7786Attributes` 
+## `ERC7786Attributes`
 
 <a target="_blank" style={{marginTop: "1.5em"}} href="https://github.com/OpenZeppelin/openzeppelin-contracts/blob/v0.0.1/contracts/crosschain/utils/ERC7786Attributes.sol">
 <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-github-icon lucide-github"><path d="M15 22v-4a4.8 4.8 0 0 0-1-3.5c3 0 6-2 6-5.5.08-1.25-.27-2.48-1-3.5.28-1.15.28-2.35 0-3.5 0 0-1 0-3 1.5-2.64-.5-5.36-.5-8 0C6 2 5 2 5 2c-.3 1.15-.3 2.35 0 3.5A5.403 5.403 0 0 0 4 9c0 3.5 3 5.5 6 5.5-.39.49-.68 1.05-.85 1.65-.17.6-.22 1.23-.15 1.85v4"/><path d="M9 18c-4.51 2-5-2-7-2"/></svg>
@@ -1198,7 +1198,7 @@ A chain equivalence has been registered.
 </div>
 
 ```solidity
-import "@openzeppelin/contracts/crosschain/utils/ERC7786Attributes.sol";
+import "@openzeppelin/community-contracts/crosschain/utils/ERC7786Attributes.sol";
 ```
 
 Library of helper to parse/process ERC-7786 attributes
@@ -1231,7 +1231,7 @@ Parse the `requestRelay(uint256,uint256,address)` (0x4cbb573a) attribute into it
 
 <div style={{marginTop: "4em"}} className="w-full flex flex-row items-center justify-between">
 
-## `ERC7786Receiver` 
+## `ERC7786Receiver`
 
 <a target="_blank" style={{marginTop: "1.5em"}} href="https://github.com/OpenZeppelin/openzeppelin-contracts/blob/v0.0.1/contracts/crosschain/utils/ERC7786Receiver.sol">
 <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-github-icon lucide-github"><path d="M15 22v-4a4.8 4.8 0 0 0-1-3.5c3 0 6-2 6-5.5.08-1.25-.27-2.48-1-3.5.28-1.15.28-2.35 0-3.5 0 0-1 0-3 1.5-2.64-.5-5.36-.5-8 0C6 2 5 2 5 2c-.3 1.15-.3 2.35 0 3.5A5.403 5.403 0 0 0 4 9c0 3.5 3 5.5 6 5.5-.39.49-.68 1.05-.85 1.65-.17.6-.22 1.23-.15 1.85v4"/><path d="M9 18c-4.51 2-5-2-7-2"/></svg>
@@ -1240,7 +1240,7 @@ Parse the `requestRelay(uint256,uint256,address)` (0x4cbb573a) attribute into it
 </div>
 
 ```solidity
-import "@openzeppelin/contracts/crosschain/utils/ERC7786Receiver.sol";
+import "@openzeppelin/community-contracts/crosschain/utils/ERC7786Receiver.sol";
 ```
 
 Base implementation of an ERC-7786 compliant cross-chain message receiver.
@@ -1360,7 +1360,7 @@ Virtual function that should contain the logic to execute when a cross-chain mes
 
 <div style={{marginTop: "4em"}} className="w-full flex flex-row items-center justify-between">
 
-## `WormholeGatewayAdapter` 
+## `WormholeGatewayAdapter`
 
 <a target="_blank" style={{marginTop: "1.5em"}} href="https://github.com/OpenZeppelin/openzeppelin-contracts/blob/v0.0.1/contracts/crosschain/wormhole/WormholeGatewayAdapter.sol">
 <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-github-icon lucide-github"><path d="M15 22v-4a4.8 4.8 0 0 0-1-3.5c3 0 6-2 6-5.5.08-1.25-.27-2.48-1-3.5.28-1.15.28-2.35 0-3.5 0 0-1 0-3 1.5-2.64-.5-5.36-.5-8 0C6 2 5 2 5 2c-.3 1.15-.3 2.35 0 3.5A5.403 5.403 0 0 0 4 9c0 3.5 3 5.5 6 5.5-.39.49-.68 1.05-.85 1.65-.17.6-.22 1.23-.15 1.85v4"/><path d="M9 18c-4.51 2-5-2-7-2"/></svg>
@@ -1369,7 +1369,7 @@ Virtual function that should contain the logic to execute when a cross-chain mes
 </div>
 
 ```solidity
-import "@openzeppelin/contracts/crosschain/wormhole/WormholeGatewayAdapter.sol";
+import "@openzeppelin/community-contracts/crosschain/wormhole/WormholeGatewayAdapter.sol";
 ```
 
 An ERC-7786 compliant adapter to send and receive messages via Wormhole.
@@ -2011,4 +2011,3 @@ A chain equivalence has been registered.
 
 </div>
 </div>
-

--- a/content/community-contracts/api/interfaces.mdx
+++ b/content/community-contracts/api/interfaces.mdx
@@ -31,7 +31,7 @@ These interfaces are available as `.sol` files. These are useful to interact wit
 
 <div style={{marginTop: "4em"}} className="w-full flex flex-row items-center justify-between">
 
-## `IERC7786GatewaySource` 
+## `IERC7786GatewaySource`
 
 <a target="_blank" style={{marginTop: "1.5em"}} href="https://github.com/OpenZeppelin/openzeppelin-contracts/blob/v0.0.1/contracts/interfaces/IERC7786.sol">
 <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-github-icon lucide-github"><path d="M15 22v-4a4.8 4.8 0 0 0-1-3.5c3 0 6-2 6-5.5.08-1.25-.27-2.48-1-3.5.28-1.15.28-2.35 0-3.5 0 0-1 0-3 1.5-2.64-.5-5.36-.5-8 0C6 2 5 2 5 2c-.3 1.15-.3 2.35 0 3.5A5.403 5.403 0 0 0 4 9c0 3.5 3 5.5 6 5.5-.39.49-.68 1.05-.85 1.65-.17.6-.22 1.23-.15 1.85v4"/><path d="M9 18c-4.51 2-5-2-7-2"/></svg>
@@ -40,7 +40,7 @@ These interfaces are available as `.sol` files. These are useful to interact wit
 </div>
 
 ```solidity
-import "@openzeppelin/contracts/interfaces/IERC7786.sol";
+import "@openzeppelin/community-contracts/interfaces/IERC7786.sol";
 ```
 
 Interface for ERC-7786 source gateways.
@@ -150,7 +150,7 @@ This error is thrown when a message creation fails because of an unsupported att
 
 <div style={{marginTop: "4em"}} className="w-full flex flex-row items-center justify-between">
 
-## `IERC7786Receiver` 
+## `IERC7786Receiver`
 
 <a target="_blank" style={{marginTop: "1.5em"}} href="https://github.com/OpenZeppelin/openzeppelin-contracts/blob/v0.0.1/contracts/interfaces/IERC7786.sol">
 <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-github-icon lucide-github"><path d="M15 22v-4a4.8 4.8 0 0 0-1-3.5c3 0 6-2 6-5.5.08-1.25-.27-2.48-1-3.5.28-1.15.28-2.35 0-3.5 0 0-1 0-3 1.5-2.64-.5-5.36-.5-8 0C6 2 5 2 5 2c-.3 1.15-.3 2.35 0 3.5A5.403 5.403 0 0 0 4 9c0 3.5 3 5.5 6 5.5-.39.49-.68 1.05-.85 1.65-.17.6-.22 1.23-.15 1.85v4"/><path d="M9 18c-4.51 2-5-2-7-2"/></svg>
@@ -159,7 +159,7 @@ This error is thrown when a message creation fails because of an unsupported att
 </div>
 
 ```solidity
-import "@openzeppelin/contracts/interfaces/IERC7786.sol";
+import "@openzeppelin/community-contracts/interfaces/IERC7786.sol";
 ```
 
 Interface for the ERC-7786 client contract (receiver).
@@ -196,7 +196,7 @@ This function may be called directly by the gateway.
 
 <div style={{marginTop: "4em"}} className="w-full flex flex-row items-center justify-between">
 
-## `IERC7786Attributes` 
+## `IERC7786Attributes`
 
 <a target="_blank" style={{marginTop: "1.5em"}} href="https://github.com/OpenZeppelin/openzeppelin-contracts/blob/v0.0.1/contracts/interfaces/IERC7786Attributes.sol">
 <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-github-icon lucide-github"><path d="M15 22v-4a4.8 4.8 0 0 0-1-3.5c3 0 6-2 6-5.5.08-1.25-.27-2.48-1-3.5.28-1.15.28-2.35 0-3.5 0 0-1 0-3 1.5-2.64-.5-5.36-.5-8 0C6 2 5 2 5 2c-.3 1.15-.3 2.35 0 3.5A5.403 5.403 0 0 0 4 9c0 3.5 3 5.5 6 5.5-.39.49-.68 1.05-.85 1.65-.17.6-.22 1.23-.15 1.85v4"/><path d="M9 18c-4.51 2-5-2-7-2"/></svg>
@@ -205,7 +205,7 @@ This function may be called directly by the gateway.
 </div>
 
 ```solidity
-import "@openzeppelin/contracts/interfaces/IERC7786Attributes.sol";
+import "@openzeppelin/community-contracts/interfaces/IERC7786Attributes.sol";
 ```
 
 Standard attributes for ERC-7786. These attributes may be standardized in different ERCs.
@@ -236,7 +236,7 @@ Standard attributes for ERC-7786. These attributes may be standardized in differ
 
 <div style={{marginTop: "4em"}} className="w-full flex flex-row items-center justify-between">
 
-## `IERC7802` 
+## `IERC7802`
 
 <a target="_blank" style={{marginTop: "1.5em"}} href="https://github.com/OpenZeppelin/openzeppelin-contracts/blob/v0.0.1/contracts/interfaces/IERC7802.sol">
 <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-github-icon lucide-github"><path d="M15 22v-4a4.8 4.8 0 0 0-1-3.5c3 0 6-2 6-5.5.08-1.25-.27-2.48-1-3.5.28-1.15.28-2.35 0-3.5 0 0-1 0-3 1.5-2.64-.5-5.36-.5-8 0C6 2 5 2 5 2c-.3 1.15-.3 2.35 0 3.5A5.403 5.403 0 0 0 4 9c0 3.5 3 5.5 6 5.5-.39.49-.68 1.05-.85 1.65-.17.6-.22 1.23-.15 1.85v4"/><path d="M9 18c-4.51 2-5-2-7-2"/></svg>
@@ -245,7 +245,7 @@ Standard attributes for ERC-7786. These attributes may be standardized in differ
 </div>
 
 ```solidity
-import "@openzeppelin/contracts/interfaces/IERC7802.sol";
+import "@openzeppelin/community-contracts/interfaces/IERC7802.sol";
 ```
 
 <div className="bg-secondary p-4 rounded-md mb-6">
@@ -332,7 +332,7 @@ import "@openzeppelin/contracts/interfaces/IERC7802.sol";
 
 <div style={{marginTop: "4em"}} className="w-full flex flex-row items-center justify-between">
 
-## `IERC7821` 
+## `IERC7821`
 
 <a target="_blank" style={{marginTop: "1.5em"}} href="https://github.com/OpenZeppelin/openzeppelin-contracts/blob/v0.0.1/contracts/interfaces/IERC7821.sol">
 <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-github-icon lucide-github"><path d="M15 22v-4a4.8 4.8 0 0 0-1-3.5c3 0 6-2 6-5.5.08-1.25-.27-2.48-1-3.5.28-1.15.28-2.35 0-3.5 0 0-1 0-3 1.5-2.64-.5-5.36-.5-8 0C6 2 5 2 5 2c-.3 1.15-.3 2.35 0 3.5A5.403 5.403 0 0 0 4 9c0 3.5 3 5.5 6 5.5-.39.49-.68 1.05-.85 1.65-.17.6-.22 1.23-.15 1.85v4"/><path d="M9 18c-4.51 2-5-2-7-2"/></svg>
@@ -341,7 +341,7 @@ import "@openzeppelin/contracts/interfaces/IERC7802.sol";
 </div>
 
 ```solidity
-import "@openzeppelin/contracts/interfaces/IERC7821.sol";
+import "@openzeppelin/community-contracts/interfaces/IERC7821.sol";
 ```
 
 Interface for minimal batch executor.
@@ -418,7 +418,7 @@ Only returns true for:
 
 <div style={{marginTop: "4em"}} className="w-full flex flex-row items-center justify-between">
 
-## `IERC7943` 
+## `IERC7943`
 
 <a target="_blank" style={{marginTop: "1.5em"}} href="https://github.com/OpenZeppelin/openzeppelin-contracts/blob/v0.0.1/contracts/interfaces/IERC7943.sol">
 <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-github-icon lucide-github"><path d="M15 22v-4a4.8 4.8 0 0 0-1-3.5c3 0 6-2 6-5.5.08-1.25-.27-2.48-1-3.5.28-1.15.28-2.35 0-3.5 0 0-1 0-3 1.5-2.64-.5-5.36-.5-8 0C6 2 5 2 5 2c-.3 1.15-.3 2.35 0 3.5A5.403 5.403 0 0 0 4 9c0 3.5 3 5.5 6 5.5-.39.49-.68 1.05-.85 1.65-.17.6-.22 1.23-.15 1.85v4"/><path d="M9 18c-4.51 2-5-2-7-2"/></svg>
@@ -427,7 +427,7 @@ Only returns true for:
 </div>
 
 ```solidity
-import "@openzeppelin/contracts/interfaces/IERC7943.sol";
+import "@openzeppelin/community-contracts/interfaces/IERC7943.sol";
 ```
 
 <div className="bg-secondary p-4 rounded-md mb-6">
@@ -625,7 +625,7 @@ This is often used for allowlist/KYC/KYB/AML checks.
 
 <div style={{marginTop: "4em"}} className="w-full flex flex-row items-center justify-between">
 
-## `IDKIMRegistry` 
+## `IDKIMRegistry`
 
 <a target="_blank" style={{marginTop: "1.5em"}} href="https://github.com/OpenZeppelin/openzeppelin-contracts/blob/v0.0.1/contracts/interfaces/IERC7969.sol">
 <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-github-icon lucide-github"><path d="M15 22v-4a4.8 4.8 0 0 0-1-3.5c3 0 6-2 6-5.5.08-1.25-.27-2.48-1-3.5.28-1.15.28-2.35 0-3.5 0 0-1 0-3 1.5-2.64-.5-5.36-.5-8 0C6 2 5 2 5 2c-.3 1.15-.3 2.35 0 3.5A5.403 5.403 0 0 0 4 9c0 3.5 3 5.5 6 5.5-.39.49-.68 1.05-.85 1.65-.17.6-.22 1.23-.15 1.85v4"/><path d="M9 18c-4.51 2-5-2-7-2"/></svg>
@@ -634,7 +634,7 @@ This is often used for allowlist/KYC/KYB/AML checks.
 </div>
 
 ```solidity
-import "@openzeppelin/contracts/interfaces/IERC7969.sol";
+import "@openzeppelin/community-contracts/interfaces/IERC7969.sol";
 ```
 
 This interface provides a standard way to register and validate DKIM public key hashes onchain
@@ -711,4 +711,3 @@ Emitted when a DKIM public key hash is revoked for a domain
 
 </div>
 </div>
-

--- a/content/community-contracts/api/interfaces.mdx
+++ b/content/community-contracts/api/interfaces.mdx
@@ -33,7 +33,7 @@ These interfaces are available as `.sol` files. These are useful to interact wit
 
 ## `IERC7786GatewaySource`
 
-<a target="_blank" style={{marginTop: "1.5em"}} href="https://github.com/OpenZeppelin/openzeppelin-contracts/blob/v0.0.1/contracts/interfaces/IERC7786.sol">
+<a target="_blank" style={{marginTop: "1.5em"}} href="https://github.com/OpenZeppelin/openzeppelin-community-contracts/blob/master/contracts/interfaces/IERC7786.sol">
 <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-github-icon lucide-github"><path d="M15 22v-4a4.8 4.8 0 0 0-1-3.5c3 0 6-2 6-5.5.08-1.25-.27-2.48-1-3.5.28-1.15.28-2.35 0-3.5 0 0-1 0-3 1.5-2.64-.5-5.36-.5-8 0C6 2 5 2 5 2c-.3 1.15-.3 2.35 0 3.5A5.403 5.403 0 0 0 4 9c0 3.5 3 5.5 6 5.5-.39.49-.68 1.05-.85 1.65-.17.6-.22 1.23-.15 1.85v4"/><path d="M9 18c-4.51 2-5-2-7-2"/></svg>
 </a>
 
@@ -152,7 +152,7 @@ This error is thrown when a message creation fails because of an unsupported att
 
 ## `IERC7786Receiver`
 
-<a target="_blank" style={{marginTop: "1.5em"}} href="https://github.com/OpenZeppelin/openzeppelin-contracts/blob/v0.0.1/contracts/interfaces/IERC7786.sol">
+<a target="_blank" style={{marginTop: "1.5em"}} href="https://github.com/OpenZeppelin/openzeppelin-community-contracts/blob/master/contracts/interfaces/IERC7786.sol">
 <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-github-icon lucide-github"><path d="M15 22v-4a4.8 4.8 0 0 0-1-3.5c3 0 6-2 6-5.5.08-1.25-.27-2.48-1-3.5.28-1.15.28-2.35 0-3.5 0 0-1 0-3 1.5-2.64-.5-5.36-.5-8 0C6 2 5 2 5 2c-.3 1.15-.3 2.35 0 3.5A5.403 5.403 0 0 0 4 9c0 3.5 3 5.5 6 5.5-.39.49-.68 1.05-.85 1.65-.17.6-.22 1.23-.15 1.85v4"/><path d="M9 18c-4.51 2-5-2-7-2"/></svg>
 </a>
 
@@ -198,7 +198,7 @@ This function may be called directly by the gateway.
 
 ## `IERC7786Attributes`
 
-<a target="_blank" style={{marginTop: "1.5em"}} href="https://github.com/OpenZeppelin/openzeppelin-contracts/blob/v0.0.1/contracts/interfaces/IERC7786Attributes.sol">
+<a target="_blank" style={{marginTop: "1.5em"}} href="https://github.com/OpenZeppelin/openzeppelin-community-contracts/blob/master/contracts/interfaces/IERC7786Attributes.sol">
 <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-github-icon lucide-github"><path d="M15 22v-4a4.8 4.8 0 0 0-1-3.5c3 0 6-2 6-5.5.08-1.25-.27-2.48-1-3.5.28-1.15.28-2.35 0-3.5 0 0-1 0-3 1.5-2.64-.5-5.36-.5-8 0C6 2 5 2 5 2c-.3 1.15-.3 2.35 0 3.5A5.403 5.403 0 0 0 4 9c0 3.5 3 5.5 6 5.5-.39.49-.68 1.05-.85 1.65-.17.6-.22 1.23-.15 1.85v4"/><path d="M9 18c-4.51 2-5-2-7-2"/></svg>
 </a>
 
@@ -238,7 +238,7 @@ Standard attributes for ERC-7786. These attributes may be standardized in differ
 
 ## `IERC7802`
 
-<a target="_blank" style={{marginTop: "1.5em"}} href="https://github.com/OpenZeppelin/openzeppelin-contracts/blob/v0.0.1/contracts/interfaces/IERC7802.sol">
+<a target="_blank" style={{marginTop: "1.5em"}} href="https://github.com/OpenZeppelin/openzeppelin-community-contracts/blob/master/contracts/interfaces/IERC7802.sol">
 <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-github-icon lucide-github"><path d="M15 22v-4a4.8 4.8 0 0 0-1-3.5c3 0 6-2 6-5.5.08-1.25-.27-2.48-1-3.5.28-1.15.28-2.35 0-3.5 0 0-1 0-3 1.5-2.64-.5-5.36-.5-8 0C6 2 5 2 5 2c-.3 1.15-.3 2.35 0 3.5A5.403 5.403 0 0 0 4 9c0 3.5 3 5.5 6 5.5-.39.49-.68 1.05-.85 1.65-.17.6-.22 1.23-.15 1.85v4"/><path d="M9 18c-4.51 2-5-2-7-2"/></svg>
 </a>
 
@@ -334,7 +334,7 @@ import "@openzeppelin/community-contracts/interfaces/IERC7802.sol";
 
 ## `IERC7821`
 
-<a target="_blank" style={{marginTop: "1.5em"}} href="https://github.com/OpenZeppelin/openzeppelin-contracts/blob/v0.0.1/contracts/interfaces/IERC7821.sol">
+<a target="_blank" style={{marginTop: "1.5em"}} href="https://github.com/OpenZeppelin/openzeppelin-community-contracts/blob/master/contracts/interfaces/IERC7821.sol">
 <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-github-icon lucide-github"><path d="M15 22v-4a4.8 4.8 0 0 0-1-3.5c3 0 6-2 6-5.5.08-1.25-.27-2.48-1-3.5.28-1.15.28-2.35 0-3.5 0 0-1 0-3 1.5-2.64-.5-5.36-.5-8 0C6 2 5 2 5 2c-.3 1.15-.3 2.35 0 3.5A5.403 5.403 0 0 0 4 9c0 3.5 3 5.5 6 5.5-.39.49-.68 1.05-.85 1.65-.17.6-.22 1.23-.15 1.85v4"/><path d="M9 18c-4.51 2-5-2-7-2"/></svg>
 </a>
 
@@ -420,7 +420,7 @@ Only returns true for:
 
 ## `IERC7943`
 
-<a target="_blank" style={{marginTop: "1.5em"}} href="https://github.com/OpenZeppelin/openzeppelin-contracts/blob/v0.0.1/contracts/interfaces/IERC7943.sol">
+<a target="_blank" style={{marginTop: "1.5em"}} href="https://github.com/OpenZeppelin/openzeppelin-community-contracts/blob/master/contracts/interfaces/IERC7943.sol">
 <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-github-icon lucide-github"><path d="M15 22v-4a4.8 4.8 0 0 0-1-3.5c3 0 6-2 6-5.5.08-1.25-.27-2.48-1-3.5.28-1.15.28-2.35 0-3.5 0 0-1 0-3 1.5-2.64-.5-5.36-.5-8 0C6 2 5 2 5 2c-.3 1.15-.3 2.35 0 3.5A5.403 5.403 0 0 0 4 9c0 3.5 3 5.5 6 5.5-.39.49-.68 1.05-.85 1.65-.17.6-.22 1.23-.15 1.85v4"/><path d="M9 18c-4.51 2-5-2-7-2"/></svg>
 </a>
 
@@ -627,7 +627,7 @@ This is often used for allowlist/KYC/KYB/AML checks.
 
 ## `IDKIMRegistry`
 
-<a target="_blank" style={{marginTop: "1.5em"}} href="https://github.com/OpenZeppelin/openzeppelin-contracts/blob/v0.0.1/contracts/interfaces/IERC7969.sol">
+<a target="_blank" style={{marginTop: "1.5em"}} href="https://github.com/OpenZeppelin/openzeppelin-community-contracts/blob/master/contracts/interfaces/IERC7969.sol">
 <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-github-icon lucide-github"><path d="M15 22v-4a4.8 4.8 0 0 0-1-3.5c3 0 6-2 6-5.5.08-1.25-.27-2.48-1-3.5.28-1.15.28-2.35 0-3.5 0 0-1 0-3 1.5-2.64-.5-5.36-.5-8 0C6 2 5 2 5 2c-.3 1.15-.3 2.35 0 3.5A5.403 5.403 0 0 0 4 9c0 3.5 3 5.5 6 5.5-.39.49-.68 1.05-.85 1.65-.17.6-.22 1.23-.15 1.85v4"/><path d="M9 18c-4.51 2-5-2-7-2"/></svg>
 </a>
 

--- a/content/community-contracts/api/proxy.mdx
+++ b/content/community-contracts/api/proxy.mdx
@@ -17,7 +17,7 @@ Variants of proxy patterns, which are contracts that allow to forward a call to 
 
 ## `HybridProxy`
 
-<a target="_blank" style={{marginTop: "1.5em"}} href="https://github.com/OpenZeppelin/openzeppelin-contracts/blob/v0.0.1/contracts/proxy/HybridProxy.sol">
+<a target="_blank" style={{marginTop: "1.5em"}} href="https://github.com/OpenZeppelin/openzeppelin-community-contracts/blob/master/contracts/proxy/HybridProxy.sol">
 <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-github-icon lucide-github"><path d="M15 22v-4a4.8 4.8 0 0 0-1-3.5c3 0 6-2 6-5.5.08-1.25-.27-2.48-1-3.5.28-1.15.28-2.35 0-3.5 0 0-1 0-3 1.5-2.64-.5-5.36-.5-8 0C6 2 5 2 5 2c-.3 1.15-.3 2.35 0 3.5A5.403 5.403 0 0 0 4 9c0 3.5 3 5.5 6 5.5-.39.49-.68 1.05-.85 1.65-.17.6-.22 1.23-.15 1.85v4"/><path d="M9 18c-4.51 2-5-2-7-2"/></svg>
 </a>
 

--- a/content/community-contracts/api/proxy.mdx
+++ b/content/community-contracts/api/proxy.mdx
@@ -15,7 +15,7 @@ Variants of proxy patterns, which are contracts that allow to forward a call to 
 
 <div style={{marginTop: "4em"}} className="w-full flex flex-row items-center justify-between">
 
-## `HybridProxy` 
+## `HybridProxy`
 
 <a target="_blank" style={{marginTop: "1.5em"}} href="https://github.com/OpenZeppelin/openzeppelin-contracts/blob/v0.0.1/contracts/proxy/HybridProxy.sol">
 <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-github-icon lucide-github"><path d="M15 22v-4a4.8 4.8 0 0 0-1-3.5c3 0 6-2 6-5.5.08-1.25-.27-2.48-1-3.5.28-1.15.28-2.35 0-3.5 0 0-1 0-3 1.5-2.64-.5-5.36-.5-8 0C6 2 5 2 5 2c-.3 1.15-.3 2.35 0 3.5A5.403 5.403 0 0 0 4 9c0 3.5 3 5.5 6 5.5-.39.49-.68 1.05-.85 1.65-.17.6-.22 1.23-.15 1.85v4"/><path d="M9 18c-4.51 2-5-2-7-2"/></svg>
@@ -24,7 +24,7 @@ Variants of proxy patterns, which are contracts that allow to forward a call to 
 </div>
 
 ```solidity
-import "@openzeppelin/contracts/proxy/HybridProxy.sol";
+import "@openzeppelin/community-contracts/proxy/HybridProxy.sol";
 ```
 
 A version of an ERC-1967 proxy that uses the address stored in the implementation slot as a beacon.
@@ -92,4 +92,3 @@ define this function, mistakenly identifying it as a beacon.
 
 </div>
 </div>
-

--- a/content/community-contracts/api/token.mdx
+++ b/content/community-contracts/api/token.mdx
@@ -34,7 +34,7 @@ Set of extensions and utilities for tokens (e.g ERC-20, ERC-721, ERC-1155) and d
 
 ## `ERC20Allowlist`
 
-<a target="_blank" style={{marginTop: "1.5em"}} href="https://github.com/OpenZeppelin/openzeppelin-contracts/blob/v0.0.1/contracts/token/ERC20/extensions/ERC20Allowlist.sol">
+<a target="_blank" style={{marginTop: "1.5em"}} href="https://github.com/OpenZeppelin/openzeppelin-community-contracts/blob/master/contracts/token/ERC20/extensions/ERC20Allowlist.sol">
 <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-github-icon lucide-github"><path d="M15 22v-4a4.8 4.8 0 0 0-1-3.5c3 0 6-2 6-5.5.08-1.25-.27-2.48-1-3.5.28-1.15.28-2.35 0-3.5 0 0-1 0-3 1.5-2.64-.5-5.36-.5-8 0C6 2 5 2 5 2c-.3 1.15-.3 2.35 0 3.5A5.403 5.403 0 0 0 4 9c0 3.5 3 5.5 6 5.5-.39.49-.68 1.05-.85 1.65-.17.6-.22 1.23-.15 1.85v4"/><path d="M9 18c-4.51 2-5-2-7-2"/></svg>
 </a>
 
@@ -262,7 +262,7 @@ The operation failed because the user is not allowed.
 
 ## `ERC20Blocklist`
 
-<a target="_blank" style={{marginTop: "1.5em"}} href="https://github.com/OpenZeppelin/openzeppelin-contracts/blob/v0.0.1/contracts/token/ERC20/extensions/ERC20Blocklist.sol">
+<a target="_blank" style={{marginTop: "1.5em"}} href="https://github.com/OpenZeppelin/openzeppelin-community-contracts/blob/master/contracts/token/ERC20/extensions/ERC20Blocklist.sol">
 <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-github-icon lucide-github"><path d="M15 22v-4a4.8 4.8 0 0 0-1-3.5c3 0 6-2 6-5.5.08-1.25-.27-2.48-1-3.5.28-1.15.28-2.35 0-3.5 0 0-1 0-3 1.5-2.64-.5-5.36-.5-8 0C6 2 5 2 5 2c-.3 1.15-.3 2.35 0 3.5A5.403 5.403 0 0 0 4 9c0 3.5 3 5.5 6 5.5-.39.49-.68 1.05-.85 1.65-.17.6-.22 1.23-.15 1.85v4"/><path d="M9 18c-4.51 2-5-2-7-2"/></svg>
 </a>
 
@@ -490,7 +490,7 @@ The operation failed because the user is blocked.
 
 ## `ERC20Collateral`
 
-<a target="_blank" style={{marginTop: "1.5em"}} href="https://github.com/OpenZeppelin/openzeppelin-contracts/blob/v0.0.1/contracts/token/ERC20/extensions/ERC20Collateral.sol">
+<a target="_blank" style={{marginTop: "1.5em"}} href="https://github.com/OpenZeppelin/openzeppelin-community-contracts/blob/master/contracts/token/ERC20/extensions/ERC20Collateral.sol">
 <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-github-icon lucide-github"><path d="M15 22v-4a4.8 4.8 0 0 0-1-3.5c3 0 6-2 6-5.5.08-1.25-.27-2.48-1-3.5.28-1.15.28-2.35 0-3.5 0 0-1 0-3 1.5-2.64-.5-5.36-.5-8 0C6 2 5 2 5 2c-.3 1.15-.3 2.35 0 3.5A5.403 5.403 0 0 0 4 9c0 3.5 3 5.5 6 5.5-.39.49-.68 1.05-.85 1.65-.17.6-.22 1.23-.15 1.85v4"/><path d="M9 18c-4.51 2-5-2-7-2"/></svg>
 </a>
 
@@ -713,7 +713,7 @@ Collateral amount has expired.
 
 ## `ERC20Custodian`
 
-<a target="_blank" style={{marginTop: "1.5em"}} href="https://github.com/OpenZeppelin/openzeppelin-contracts/blob/v0.0.1/contracts/token/ERC20/extensions/ERC20Custodian.sol">
+<a target="_blank" style={{marginTop: "1.5em"}} href="https://github.com/OpenZeppelin/openzeppelin-community-contracts/blob/master/contracts/token/ERC20/extensions/ERC20Custodian.sol">
 <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-github-icon lucide-github"><path d="M15 22v-4a4.8 4.8 0 0 0-1-3.5c3 0 6-2 6-5.5.08-1.25-.27-2.48-1-3.5.28-1.15.28-2.35 0-3.5 0 0-1 0-3 1.5-2.64-.5-5.36-.5-8 0C6 2 5 2 5 2c-.3 1.15-.3 2.35 0 3.5A5.403 5.403 0 0 0 4 9c0 3.5 3 5.5 6 5.5-.39.49-.68 1.05-.85 1.65-.17.6-.22 1.23-.15 1.85v4"/><path d="M9 18c-4.51 2-5-2-7-2"/></svg>
 </a>
 
@@ -1008,7 +1008,7 @@ Error thrown when a non-custodian account attempts to perform a custodian-only o
 
 ## `ERC20Freezable`
 
-<a target="_blank" style={{marginTop: "1.5em"}} href="https://github.com/OpenZeppelin/openzeppelin-contracts/blob/v0.0.1/contracts/token/ERC20/extensions/ERC20Freezable.sol">
+<a target="_blank" style={{marginTop: "1.5em"}} href="https://github.com/OpenZeppelin/openzeppelin-community-contracts/blob/master/contracts/token/ERC20/extensions/ERC20Freezable.sol">
 <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-github-icon lucide-github"><path d="M15 22v-4a4.8 4.8 0 0 0-1-3.5c3 0 6-2 6-5.5.08-1.25-.27-2.48-1-3.5.28-1.15.28-2.35 0-3.5 0 0-1 0-3 1.5-2.64-.5-5.36-.5-8 0C6 2 5 2 5 2c-.3 1.15-.3 2.35 0 3.5A5.403 5.403 0 0 0 4 9c0 3.5 3 5.5 6 5.5-.39.49-.68 1.05-.85 1.65-.17.6-.22 1.23-.15 1.85v4"/><path d="M9 18c-4.51 2-5-2-7-2"/></svg>
 </a>
 
@@ -1180,7 +1180,7 @@ The operation failed because the user has insufficient unfrozen balance.
 
 ## `ERC20Restricted`
 
-<a target="_blank" style={{marginTop: "1.5em"}} href="https://github.com/OpenZeppelin/openzeppelin-contracts/blob/v0.0.1/contracts/token/ERC20/extensions/ERC20Restricted.sol">
+<a target="_blank" style={{marginTop: "1.5em"}} href="https://github.com/OpenZeppelin/openzeppelin-community-contracts/blob/master/contracts/token/ERC20/extensions/ERC20Restricted.sol">
 <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-github-icon lucide-github"><path d="M15 22v-4a4.8 4.8 0 0 0-1-3.5c3 0 6-2 6-5.5.08-1.25-.27-2.48-1-3.5.28-1.15.28-2.35 0-3.5 0 0-1 0-3 1.5-2.64-.5-5.36-.5-8 0C6 2 5 2 5 2c-.3 1.15-.3 2.35 0 3.5A5.403 5.403 0 0 0 4 9c0 3.5 3 5.5 6 5.5-.39.49-.68 1.05-.85 1.65-.17.6-.22 1.23-.15 1.85v4"/><path d="M9 18c-4.51 2-5-2-7-2"/></svg>
 </a>
 
@@ -1452,7 +1452,7 @@ The operation failed because the user account is restricted.
 
 ## `ERC20uRWA`
 
-<a target="_blank" style={{marginTop: "1.5em"}} href="https://github.com/OpenZeppelin/openzeppelin-contracts/blob/v0.0.1/contracts/token/ERC20/extensions/ERC20uRWA.sol">
+<a target="_blank" style={{marginTop: "1.5em"}} href="https://github.com/OpenZeppelin/openzeppelin-community-contracts/blob/master/contracts/token/ERC20/extensions/ERC20uRWA.sol">
 <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-github-icon lucide-github"><path d="M15 22v-4a4.8 4.8 0 0 0-1-3.5c3 0 6-2 6-5.5.08-1.25-.27-2.48-1-3.5.28-1.15.28-2.35 0-3.5 0 0-1 0-3 1.5-2.64-.5-5.36-.5-8 0C6 2 5 2 5 2c-.3 1.15-.3 2.35 0 3.5A5.403 5.403 0 0 0 4 9c0 3.5 3 5.5 6 5.5-.39.49-.68 1.05-.85 1.65-.17.6-.22 1.23-.15 1.85v4"/><path d="M9 18c-4.51 2-5-2-7-2"/></svg>
 </a>
 
@@ -1767,7 +1767,7 @@ function _checkFreezer(address user, uint256 amount) internal view override only
 
 ## `ERC4626Fees`
 
-<a target="_blank" style={{marginTop: "1.5em"}} href="https://github.com/OpenZeppelin/openzeppelin-contracts/blob/v0.0.1/contracts/token/ERC20/extensions/ERC4626Fees.sol">
+<a target="_blank" style={{marginTop: "1.5em"}} href="https://github.com/OpenZeppelin/openzeppelin-community-contracts/blob/master/contracts/token/ERC20/extensions/ERC4626Fees.sol">
 <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-github-icon lucide-github"><path d="M15 22v-4a4.8 4.8 0 0 0-1-3.5c3 0 6-2 6-5.5.08-1.25-.27-2.48-1-3.5.28-1.15.28-2.35 0-3.5 0 0-1 0-3 1.5-2.64-.5-5.36-.5-8 0C6 2 5 2 5 2c-.3 1.15-.3 2.35 0 3.5A5.403 5.403 0 0 0 4 9c0 3.5 3 5.5 6 5.5-.39.49-.68 1.05-.85 1.65-.17.6-.22 1.23-.15 1.85v4"/><path d="M9 18c-4.51 2-5-2-7-2"/></svg>
 </a>
 
@@ -2038,7 +2038,7 @@ Send exit fee to [`ERC4626Fees._exitFeeRecipient`](#ERC4626Fees-_exitFeeRecipien
 
 ## `OnTokenTransferAdapter`
 
-<a target="_blank" style={{marginTop: "1.5em"}} href="https://github.com/OpenZeppelin/openzeppelin-contracts/blob/v0.0.1/contracts/token/OnTokenTransferAdapter.sol">
+<a target="_blank" style={{marginTop: "1.5em"}} href="https://github.com/OpenZeppelin/openzeppelin-community-contracts/blob/master/contracts/token/OnTokenTransferAdapter.sol">
 <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-github-icon lucide-github"><path d="M15 22v-4a4.8 4.8 0 0 0-1-3.5c3 0 6-2 6-5.5.08-1.25-.27-2.48-1-3.5.28-1.15.28-2.35 0-3.5 0 0-1 0-3 1.5-2.64-.5-5.36-.5-8 0C6 2 5 2 5 2c-.3 1.15-.3 2.35 0 3.5A5.403 5.403 0 0 0 4 9c0 3.5 3 5.5 6 5.5-.39.49-.68 1.05-.85 1.65-.17.6-.22 1.23-.15 1.85v4"/><path d="M9 18c-4.51 2-5-2-7-2"/></svg>
 </a>
 

--- a/content/community-contracts/api/token.mdx
+++ b/content/community-contracts/api/token.mdx
@@ -32,7 +32,7 @@ Set of extensions and utilities for tokens (e.g ERC-20, ERC-721, ERC-1155) and d
 
 <div style={{marginTop: "4em"}} className="w-full flex flex-row items-center justify-between">
 
-## `ERC20Allowlist` 
+## `ERC20Allowlist`
 
 <a target="_blank" style={{marginTop: "1.5em"}} href="https://github.com/OpenZeppelin/openzeppelin-contracts/blob/v0.0.1/contracts/token/ERC20/extensions/ERC20Allowlist.sol">
 <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-github-icon lucide-github"><path d="M15 22v-4a4.8 4.8 0 0 0-1-3.5c3 0 6-2 6-5.5.08-1.25-.27-2.48-1-3.5.28-1.15.28-2.35 0-3.5 0 0-1 0-3 1.5-2.64-.5-5.36-.5-8 0C6 2 5 2 5 2c-.3 1.15-.3 2.35 0 3.5A5.403 5.403 0 0 0 4 9c0 3.5 3 5.5 6 5.5-.39.49-.68 1.05-.85 1.65-.17.6-.22 1.23-.15 1.85v4"/><path d="M9 18c-4.51 2-5-2-7-2"/></svg>
@@ -41,7 +41,7 @@ Set of extensions and utilities for tokens (e.g ERC-20, ERC-721, ERC-1155) and d
 </div>
 
 ```solidity
-import "@openzeppelin/contracts/token/ERC20/extensions/ERC20Allowlist.sol";
+import "@openzeppelin/community-contracts/token/ERC20/extensions/ERC20Allowlist.sol";
 ```
 
 Extension of [`PaymasterERC20`](account#PaymasterERC20) that allows to implement an allowlist
@@ -260,7 +260,7 @@ The operation failed because the user is not allowed.
 
 <div style={{marginTop: "4em"}} className="w-full flex flex-row items-center justify-between">
 
-## `ERC20Blocklist` 
+## `ERC20Blocklist`
 
 <a target="_blank" style={{marginTop: "1.5em"}} href="https://github.com/OpenZeppelin/openzeppelin-contracts/blob/v0.0.1/contracts/token/ERC20/extensions/ERC20Blocklist.sol">
 <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-github-icon lucide-github"><path d="M15 22v-4a4.8 4.8 0 0 0-1-3.5c3 0 6-2 6-5.5.08-1.25-.27-2.48-1-3.5.28-1.15.28-2.35 0-3.5 0 0-1 0-3 1.5-2.64-.5-5.36-.5-8 0C6 2 5 2 5 2c-.3 1.15-.3 2.35 0 3.5A5.403 5.403 0 0 0 4 9c0 3.5 3 5.5 6 5.5-.39.49-.68 1.05-.85 1.65-.17.6-.22 1.23-.15 1.85v4"/><path d="M9 18c-4.51 2-5-2-7-2"/></svg>
@@ -269,7 +269,7 @@ The operation failed because the user is not allowed.
 </div>
 
 ```solidity
-import "@openzeppelin/contracts/token/ERC20/extensions/ERC20Blocklist.sol";
+import "@openzeppelin/community-contracts/token/ERC20/extensions/ERC20Blocklist.sol";
 ```
 
 Extension of [`PaymasterERC20`](account#PaymasterERC20) that allows to implement a blocklist
@@ -488,7 +488,7 @@ The operation failed because the user is blocked.
 
 <div style={{marginTop: "4em"}} className="w-full flex flex-row items-center justify-between">
 
-## `ERC20Collateral` 
+## `ERC20Collateral`
 
 <a target="_blank" style={{marginTop: "1.5em"}} href="https://github.com/OpenZeppelin/openzeppelin-contracts/blob/v0.0.1/contracts/token/ERC20/extensions/ERC20Collateral.sol">
 <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-github-icon lucide-github"><path d="M15 22v-4a4.8 4.8 0 0 0-1-3.5c3 0 6-2 6-5.5.08-1.25-.27-2.48-1-3.5.28-1.15.28-2.35 0-3.5 0 0-1 0-3 1.5-2.64-.5-5.36-.5-8 0C6 2 5 2 5 2c-.3 1.15-.3 2.35 0 3.5A5.403 5.403 0 0 0 4 9c0 3.5 3 5.5 6 5.5-.39.49-.68 1.05-.85 1.65-.17.6-.22 1.23-.15 1.85v4"/><path d="M9 18c-4.51 2-5-2-7-2"/></svg>
@@ -497,7 +497,7 @@ The operation failed because the user is blocked.
 </div>
 
 ```solidity
-import "@openzeppelin/contracts/token/ERC20/extensions/ERC20Collateral.sol";
+import "@openzeppelin/community-contracts/token/ERC20/extensions/ERC20Collateral.sol";
 ```
 
 Extension of [`PaymasterERC20`](account#PaymasterERC20) that limits the supply of tokens based
@@ -711,7 +711,7 @@ Collateral amount has expired.
 
 <div style={{marginTop: "4em"}} className="w-full flex flex-row items-center justify-between">
 
-## `ERC20Custodian` 
+## `ERC20Custodian`
 
 <a target="_blank" style={{marginTop: "1.5em"}} href="https://github.com/OpenZeppelin/openzeppelin-contracts/blob/v0.0.1/contracts/token/ERC20/extensions/ERC20Custodian.sol">
 <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-github-icon lucide-github"><path d="M15 22v-4a4.8 4.8 0 0 0-1-3.5c3 0 6-2 6-5.5.08-1.25-.27-2.48-1-3.5.28-1.15.28-2.35 0-3.5 0 0-1 0-3 1.5-2.64-.5-5.36-.5-8 0C6 2 5 2 5 2c-.3 1.15-.3 2.35 0 3.5A5.403 5.403 0 0 0 4 9c0 3.5 3 5.5 6 5.5-.39.49-.68 1.05-.85 1.65-.17.6-.22 1.23-.15 1.85v4"/><path d="M9 18c-4.51 2-5-2-7-2"/></svg>
@@ -720,7 +720,7 @@ Collateral amount has expired.
 </div>
 
 ```solidity
-import "@openzeppelin/contracts/token/ERC20/extensions/ERC20Custodian.sol";
+import "@openzeppelin/community-contracts/token/ERC20/extensions/ERC20Custodian.sol";
 ```
 
 Extension of [`PaymasterERC20`](account#PaymasterERC20) that allows to implement a custodian
@@ -1006,7 +1006,7 @@ Error thrown when a non-custodian account attempts to perform a custodian-only o
 
 <div style={{marginTop: "4em"}} className="w-full flex flex-row items-center justify-between">
 
-## `ERC20Freezable` 
+## `ERC20Freezable`
 
 <a target="_blank" style={{marginTop: "1.5em"}} href="https://github.com/OpenZeppelin/openzeppelin-contracts/blob/v0.0.1/contracts/token/ERC20/extensions/ERC20Freezable.sol">
 <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-github-icon lucide-github"><path d="M15 22v-4a4.8 4.8 0 0 0-1-3.5c3 0 6-2 6-5.5.08-1.25-.27-2.48-1-3.5.28-1.15.28-2.35 0-3.5 0 0-1 0-3 1.5-2.64-.5-5.36-.5-8 0C6 2 5 2 5 2c-.3 1.15-.3 2.35 0 3.5A5.403 5.403 0 0 0 4 9c0 3.5 3 5.5 6 5.5-.39.49-.68 1.05-.85 1.65-.17.6-.22 1.23-.15 1.85v4"/><path d="M9 18c-4.51 2-5-2-7-2"/></svg>
@@ -1015,7 +1015,7 @@ Error thrown when a non-custodian account attempts to perform a custodian-only o
 </div>
 
 ```solidity
-import "@openzeppelin/contracts/token/ERC20/extensions/ERC20Freezable.sol";
+import "@openzeppelin/community-contracts/token/ERC20/extensions/ERC20Freezable.sol";
 ```
 
 Extension of [`PaymasterERC20`](account#PaymasterERC20) that allows to implement a freezing
@@ -1178,7 +1178,7 @@ The operation failed because the user has insufficient unfrozen balance.
 
 <div style={{marginTop: "4em"}} className="w-full flex flex-row items-center justify-between">
 
-## `ERC20Restricted` 
+## `ERC20Restricted`
 
 <a target="_blank" style={{marginTop: "1.5em"}} href="https://github.com/OpenZeppelin/openzeppelin-contracts/blob/v0.0.1/contracts/token/ERC20/extensions/ERC20Restricted.sol">
 <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-github-icon lucide-github"><path d="M15 22v-4a4.8 4.8 0 0 0-1-3.5c3 0 6-2 6-5.5.08-1.25-.27-2.48-1-3.5.28-1.15.28-2.35 0-3.5 0 0-1 0-3 1.5-2.64-.5-5.36-.5-8 0C6 2 5 2 5 2c-.3 1.15-.3 2.35 0 3.5A5.403 5.403 0 0 0 4 9c0 3.5 3 5.5 6 5.5-.39.49-.68 1.05-.85 1.65-.17.6-.22 1.23-.15 1.85v4"/><path d="M9 18c-4.51 2-5-2-7-2"/></svg>
@@ -1187,7 +1187,7 @@ The operation failed because the user has insufficient unfrozen balance.
 </div>
 
 ```solidity
-import "@openzeppelin/contracts/token/ERC20/extensions/ERC20Restricted.sol";
+import "@openzeppelin/community-contracts/token/ERC20/extensions/ERC20Restricted.sol";
 ```
 
 Extension of [`PaymasterERC20`](account#PaymasterERC20) that allows to implement user account transfer restrictions
@@ -1450,7 +1450,7 @@ The operation failed because the user account is restricted.
 
 <div style={{marginTop: "4em"}} className="w-full flex flex-row items-center justify-between">
 
-## `ERC20uRWA` 
+## `ERC20uRWA`
 
 <a target="_blank" style={{marginTop: "1.5em"}} href="https://github.com/OpenZeppelin/openzeppelin-contracts/blob/v0.0.1/contracts/token/ERC20/extensions/ERC20uRWA.sol">
 <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-github-icon lucide-github"><path d="M15 22v-4a4.8 4.8 0 0 0-1-3.5c3 0 6-2 6-5.5.08-1.25-.27-2.48-1-3.5.28-1.15.28-2.35 0-3.5 0 0-1 0-3 1.5-2.64-.5-5.36-.5-8 0C6 2 5 2 5 2c-.3 1.15-.3 2.35 0 3.5A5.403 5.403 0 0 0 4 9c0 3.5 3 5.5 6 5.5-.39.49-.68 1.05-.85 1.65-.17.6-.22 1.23-.15 1.85v4"/><path d="M9 18c-4.51 2-5-2-7-2"/></svg>
@@ -1459,7 +1459,7 @@ The operation failed because the user account is restricted.
 </div>
 
 ```solidity
-import "@openzeppelin/contracts/token/ERC20/extensions/ERC20uRWA.sol";
+import "@openzeppelin/community-contracts/token/ERC20/extensions/ERC20uRWA.sol";
 ```
 
 Extension of [`PaymasterERC20`](account#PaymasterERC20) according to [EIP-7943](https://eips.ethereum.org/EIPS/eip-7943).
@@ -1765,7 +1765,7 @@ function _checkFreezer(address user, uint256 amount) internal view override only
 
 <div style={{marginTop: "4em"}} className="w-full flex flex-row items-center justify-between">
 
-## `ERC4626Fees` 
+## `ERC4626Fees`
 
 <a target="_blank" style={{marginTop: "1.5em"}} href="https://github.com/OpenZeppelin/openzeppelin-contracts/blob/v0.0.1/contracts/token/ERC20/extensions/ERC4626Fees.sol">
 <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-github-icon lucide-github"><path d="M15 22v-4a4.8 4.8 0 0 0-1-3.5c3 0 6-2 6-5.5.08-1.25-.27-2.48-1-3.5.28-1.15.28-2.35 0-3.5 0 0-1 0-3 1.5-2.64-.5-5.36-.5-8 0C6 2 5 2 5 2c-.3 1.15-.3 2.35 0 3.5A5.403 5.403 0 0 0 4 9c0 3.5 3 5.5 6 5.5-.39.49-.68 1.05-.85 1.65-.17.6-.22 1.23-.15 1.85v4"/><path d="M9 18c-4.51 2-5-2-7-2"/></svg>
@@ -1774,7 +1774,7 @@ function _checkFreezer(address user, uint256 amount) internal view override only
 </div>
 
 ```solidity
-import "@openzeppelin/contracts/token/ERC20/extensions/ERC4626Fees.sol";
+import "@openzeppelin/community-contracts/token/ERC20/extensions/ERC4626Fees.sol";
 ```
 
 ERC-4626 vault with entry/exit fees expressed in [basis point (bp)](https://en.wikipedia.org/wiki/Basis_point).
@@ -2036,7 +2036,7 @@ Send exit fee to [`ERC4626Fees._exitFeeRecipient`](#ERC4626Fees-_exitFeeRecipien
 
 <div style={{marginTop: "4em"}} className="w-full flex flex-row items-center justify-between">
 
-## `OnTokenTransferAdapter` 
+## `OnTokenTransferAdapter`
 
 <a target="_blank" style={{marginTop: "1.5em"}} href="https://github.com/OpenZeppelin/openzeppelin-contracts/blob/v0.0.1/contracts/token/OnTokenTransferAdapter.sol">
 <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-github-icon lucide-github"><path d="M15 22v-4a4.8 4.8 0 0 0-1-3.5c3 0 6-2 6-5.5.08-1.25-.27-2.48-1-3.5.28-1.15.28-2.35 0-3.5 0 0-1 0-3 1.5-2.64-.5-5.36-.5-8 0C6 2 5 2 5 2c-.3 1.15-.3 2.35 0 3.5A5.403 5.403 0 0 0 4 9c0 3.5 3 5.5 6 5.5-.39.49-.68 1.05-.85 1.65-.17.6-.22 1.23-.15 1.85v4"/><path d="M9 18c-4.51 2-5-2-7-2"/></svg>
@@ -2045,7 +2045,7 @@ Send exit fee to [`ERC4626Fees._exitFeeRecipient`](#ERC4626Fees-_exitFeeRecipien
 </div>
 
 ```solidity
-import "@openzeppelin/contracts/token/OnTokenTransferAdapter.sol";
+import "@openzeppelin/community-contracts/token/OnTokenTransferAdapter.sol";
 ```
 
 This contract exposes the 667 `onTokenTransfer` hook on top of `IERC1363Receiver-onTransferReceived`.
@@ -2076,4 +2076,3 @@ Chainlink's Link, that implement the 667 interface for transferAndCall.
 
 </div>
 </div>
-

--- a/content/community-contracts/api/utils.mdx
+++ b/content/community-contracts/api/utils.mdx
@@ -22,7 +22,7 @@ Miscellaneous contracts and libraries containing utility functions you can use t
 
 <div style={{marginTop: "4em"}} className="w-full flex flex-row items-center justify-between">
 
-## `Masks` 
+## `Masks`
 
 <a target="_blank" style={{marginTop: "1.5em"}} href="https://github.com/OpenZeppelin/openzeppelin-contracts/blob/v0.0.1/contracts/utils/Masks.sol">
 <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-github-icon lucide-github"><path d="M15 22v-4a4.8 4.8 0 0 0-1-3.5c3 0 6-2 6-5.5.08-1.25-.27-2.48-1-3.5.28-1.15.28-2.35 0-3.5 0 0-1 0-3 1.5-2.64-.5-5.36-.5-8 0C6 2 5 2 5 2c-.3 1.15-.3 2.35 0 3.5A5.403 5.403 0 0 0 4 9c0 3.5 3 5.5 6 5.5-.39.49-.68 1.05-.85 1.65-.17.6-.22 1.23-.15 1.85v4"/><path d="M9 18c-4.51 2-5-2-7-2"/></svg>
@@ -31,7 +31,7 @@ Miscellaneous contracts and libraries containing utility functions you can use t
 </div>
 
 ```solidity
-import "@openzeppelin/contracts/utils/Masks.sol";
+import "@openzeppelin/community-contracts/utils/Masks.sol";
 ```
 
 Library for handling bit masks
@@ -208,7 +208,7 @@ Returns the symmetric difference (∆) of two masks, also known as disjunctive u
 
 <div style={{marginTop: "4em"}} className="w-full flex flex-row items-center justify-between">
 
-## `EnumerableMapExtended` 
+## `EnumerableMapExtended`
 
 <a target="_blank" style={{marginTop: "1.5em"}} href="https://github.com/OpenZeppelin/openzeppelin-contracts/blob/v0.0.1/contracts/utils/structs/EnumerableMapExtended.sol">
 <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-github-icon lucide-github"><path d="M15 22v-4a4.8 4.8 0 0 0-1-3.5c3 0 6-2 6-5.5.08-1.25-.27-2.48-1-3.5.28-1.15.28-2.35 0-3.5 0 0-1 0-3 1.5-2.64-.5-5.36-.5-8 0C6 2 5 2 5 2c-.3 1.15-.3 2.35 0 3.5A5.403 5.403 0 0 0 4 9c0 3.5 3 5.5 6 5.5-.39.49-.68 1.05-.85 1.65-.17.6-.22 1.23-.15 1.85v4"/><path d="M9 18c-4.51 2-5-2-7-2"/></svg>
@@ -217,7 +217,7 @@ Returns the symmetric difference (∆) of two masks, also known as disjunctive u
 </div>
 
 ```solidity
-import "@openzeppelin/contracts/utils/structs/EnumerableMapExtended.sol";
+import "@openzeppelin/community-contracts/utils/structs/EnumerableMapExtended.sol";
 ```
 
 Library for managing an enumerable variant of Solidity's
@@ -744,7 +744,7 @@ Query for a nonexistent map key.
 
 <div style={{marginTop: "4em"}} className="w-full flex flex-row items-center justify-between">
 
-## `EnumerableSetExtended` 
+## `EnumerableSetExtended`
 
 <a target="_blank" style={{marginTop: "1.5em"}} href="https://github.com/OpenZeppelin/openzeppelin-contracts/blob/v0.0.1/contracts/utils/structs/EnumerableSetExtended.sol">
 <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-github-icon lucide-github"><path d="M15 22v-4a4.8 4.8 0 0 0-1-3.5c3 0 6-2 6-5.5.08-1.25-.27-2.48-1-3.5.28-1.15.28-2.35 0-3.5 0 0-1 0-3 1.5-2.64-.5-5.36-.5-8 0C6 2 5 2 5 2c-.3 1.15-.3 2.35 0 3.5A5.403 5.403 0 0 0 4 9c0 3.5 3 5.5 6 5.5-.39.49-.68 1.05-.85 1.65-.17.6-.22 1.23-.15 1.85v4"/><path d="M9 18c-4.51 2-5-2-7-2"/></svg>
@@ -753,7 +753,7 @@ Query for a nonexistent map key.
 </div>
 
 ```solidity
-import "@openzeppelin/contracts/utils/structs/EnumerableSetExtended.sol";
+import "@openzeppelin/community-contracts/utils/structs/EnumerableSetExtended.sol";
 ```
 
 Library for managing
@@ -973,4 +973,3 @@ uncallable if the set grows to a point where copying to memory consumes too much
 
 </div>
 </div>
-

--- a/content/community-contracts/api/utils.mdx
+++ b/content/community-contracts/api/utils.mdx
@@ -24,7 +24,7 @@ Miscellaneous contracts and libraries containing utility functions you can use t
 
 ## `Masks`
 
-<a target="_blank" style={{marginTop: "1.5em"}} href="https://github.com/OpenZeppelin/openzeppelin-contracts/blob/v0.0.1/contracts/utils/Masks.sol">
+<a target="_blank" style={{marginTop: "1.5em"}} href="https://github.com/OpenZeppelin/openzeppelin-community-contracts/blob/master/contracts/utils/Masks.sol">
 <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-github-icon lucide-github"><path d="M15 22v-4a4.8 4.8 0 0 0-1-3.5c3 0 6-2 6-5.5.08-1.25-.27-2.48-1-3.5.28-1.15.28-2.35 0-3.5 0 0-1 0-3 1.5-2.64-.5-5.36-.5-8 0C6 2 5 2 5 2c-.3 1.15-.3 2.35 0 3.5A5.403 5.403 0 0 0 4 9c0 3.5 3 5.5 6 5.5-.39.49-.68 1.05-.85 1.65-.17.6-.22 1.23-.15 1.85v4"/><path d="M9 18c-4.51 2-5-2-7-2"/></svg>
 </a>
 
@@ -210,7 +210,7 @@ Returns the symmetric difference (∆) of two masks, also known as disjunctive u
 
 ## `EnumerableMapExtended`
 
-<a target="_blank" style={{marginTop: "1.5em"}} href="https://github.com/OpenZeppelin/openzeppelin-contracts/blob/v0.0.1/contracts/utils/structs/EnumerableMapExtended.sol">
+<a target="_blank" style={{marginTop: "1.5em"}} href="https://github.com/OpenZeppelin/openzeppelin-community-contracts/blob/master/contracts/utils/structs/EnumerableMapExtended.sol">
 <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-github-icon lucide-github"><path d="M15 22v-4a4.8 4.8 0 0 0-1-3.5c3 0 6-2 6-5.5.08-1.25-.27-2.48-1-3.5.28-1.15.28-2.35 0-3.5 0 0-1 0-3 1.5-2.64-.5-5.36-.5-8 0C6 2 5 2 5 2c-.3 1.15-.3 2.35 0 3.5A5.403 5.403 0 0 0 4 9c0 3.5 3 5.5 6 5.5-.39.49-.68 1.05-.85 1.65-.17.6-.22 1.23-.15 1.85v4"/><path d="M9 18c-4.51 2-5-2-7-2"/></svg>
 </a>
 
@@ -746,7 +746,7 @@ Query for a nonexistent map key.
 
 ## `EnumerableSetExtended`
 
-<a target="_blank" style={{marginTop: "1.5em"}} href="https://github.com/OpenZeppelin/openzeppelin-contracts/blob/v0.0.1/contracts/utils/structs/EnumerableSetExtended.sol">
+<a target="_blank" style={{marginTop: "1.5em"}} href="https://github.com/OpenZeppelin/openzeppelin-community-contracts/blob/master/contracts/utils/structs/EnumerableSetExtended.sol">
 <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-github-icon lucide-github"><path d="M15 22v-4a4.8 4.8 0 0 0-1-3.5c3 0 6-2 6-5.5.08-1.25-.27-2.48-1-3.5.28-1.15.28-2.35 0-3.5 0 0-1 0-3 1.5-2.64-.5-5.36-.5-8 0C6 2 5 2 5 2c-.3 1.15-.3 2.35 0 3.5A5.403 5.403 0 0 0 4 9c0 3.5 3 5.5 6 5.5-.39.49-.68 1.05-.85 1.65-.17.6-.22 1.23-.15 1.85v4"/><path d="M9 18c-4.51 2-5-2-7-2"/></svg>
 </a>
 

--- a/content/community-contracts/api/utils/cryptography.mdx
+++ b/content/community-contracts/api/utils/cryptography.mdx
@@ -36,7 +36,7 @@ A collection of contracts and libraries that implement various signature validat
 
 <div style={{marginTop: "4em"}} className="w-full flex flex-row items-center justify-between">
 
-## `DKIMRegistry` 
+## `DKIMRegistry`
 
 <a target="_blank" style={{marginTop: "1.5em"}} href="https://github.com/OpenZeppelin/openzeppelin-contracts/blob/v0.0.1/contracts/utils/cryptography/DKIMRegistry.sol">
 <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-github-icon lucide-github"><path d="M15 22v-4a4.8 4.8 0 0 0-1-3.5c3 0 6-2 6-5.5.08-1.25-.27-2.48-1-3.5.28-1.15.28-2.35 0-3.5 0 0-1 0-3 1.5-2.64-.5-5.36-.5-8 0C6 2 5 2 5 2c-.3 1.15-.3 2.35 0 3.5A5.403 5.403 0 0 0 4 9c0 3.5 3 5.5 6 5.5-.39.49-.68 1.05-.85 1.65-.17.6-.22 1.23-.15 1.85v4"/><path d="M9 18c-4.51 2-5-2-7-2"/></svg>
@@ -45,7 +45,7 @@ A collection of contracts and libraries that implement various signature validat
 </div>
 
 ```solidity
-import "@openzeppelin/contracts/utils/cryptography/DKIMRegistry.sol";
+import "@openzeppelin/community-contracts/utils/cryptography/DKIMRegistry.sol";
 ```
 
 Implementation of the [ERC-7969](https://eips.ethereum.org/EIPS/eip-7969) interface for registering
@@ -188,7 +188,7 @@ Emits a [`IDKIMRegistry.KeyHashRevoked`](../interfaces#IDKIMRegistry-KeyHashRevo
 
 <div style={{marginTop: "4em"}} className="w-full flex flex-row items-center justify-between">
 
-## `WebAuthn` 
+## `WebAuthn`
 
 <a target="_blank" style={{marginTop: "1.5em"}} href="https://github.com/OpenZeppelin/openzeppelin-contracts/blob/v0.0.1/contracts/utils/cryptography/WebAuthn.sol">
 <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-github-icon lucide-github"><path d="M15 22v-4a4.8 4.8 0 0 0-1-3.5c3 0 6-2 6-5.5.08-1.25-.27-2.48-1-3.5.28-1.15.28-2.35 0-3.5 0 0-1 0-3 1.5-2.64-.5-5.36-.5-8 0C6 2 5 2 5 2c-.3 1.15-.3 2.35 0 3.5A5.403 5.403 0 0 0 4 9c0 3.5 3 5.5 6 5.5-.39.49-.68 1.05-.85 1.65-.17.6-.22 1.23-.15 1.85v4"/><path d="M9 18c-4.51 2-5-2-7-2"/></svg>
@@ -197,7 +197,7 @@ Emits a [`IDKIMRegistry.KeyHashRevoked`](../interfaces#IDKIMRegistry-KeyHashRevo
 </div>
 
 ```solidity
-import "@openzeppelin/contracts/utils/cryptography/WebAuthn.sol";
+import "@openzeppelin/community-contracts/utils/cryptography/WebAuthn.sol";
 ```
 
 Library for verifying WebAuthn Authentication Assertions.
@@ -309,7 +309,7 @@ cause revert/panic.
 
 <div style={{marginTop: "4em"}} className="w-full flex flex-row items-center justify-between">
 
-## `ZKEmailUtils` 
+## `ZKEmailUtils`
 
 <a target="_blank" style={{marginTop: "1.5em"}} href="https://github.com/OpenZeppelin/openzeppelin-contracts/blob/v0.0.1/contracts/utils/cryptography/ZKEmailUtils.sol">
 <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-github-icon lucide-github"><path d="M15 22v-4a4.8 4.8 0 0 0-1-3.5c3 0 6-2 6-5.5.08-1.25-.27-2.48-1-3.5.28-1.15.28-2.35 0-3.5 0 0-1 0-3 1.5-2.64-.5-5.36-.5-8 0C6 2 5 2 5 2c-.3 1.15-.3 2.35 0 3.5A5.403 5.403 0 0 0 4 9c0 3.5 3 5.5 6 5.5-.39.49-.68 1.05-.85 1.65-.17.6-.22 1.23-.15 1.85v4"/><path d="M9 18c-4.51 2-5-2-7-2"/></svg>
@@ -318,7 +318,7 @@ cause revert/panic.
 </div>
 
 ```solidity
-import "@openzeppelin/contracts/utils/cryptography/ZKEmailUtils.sol";
+import "@openzeppelin/community-contracts/utils/cryptography/ZKEmailUtils.sol";
 ```
 
 Library for [ZKEmail](https://docs.zk.email) Groth16 proof validation utilities.
@@ -456,7 +456,7 @@ into a uint256 array in the order expected by the verifier circuit.
 
 <div style={{marginTop: "4em"}} className="w-full flex flex-row items-center justify-between">
 
-## `SignerWebAuthn` 
+## `SignerWebAuthn`
 
 <a target="_blank" style={{marginTop: "1.5em"}} href="https://github.com/OpenZeppelin/openzeppelin-contracts/blob/v0.0.1/contracts/utils/cryptography/signers/SignerWebAuthn.sol">
 <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-github-icon lucide-github"><path d="M15 22v-4a4.8 4.8 0 0 0-1-3.5c3 0 6-2 6-5.5.08-1.25-.27-2.48-1-3.5.28-1.15.28-2.35 0-3.5 0 0-1 0-3 1.5-2.64-.5-5.36-.5-8 0C6 2 5 2 5 2c-.3 1.15-.3 2.35 0 3.5A5.403 5.403 0 0 0 4 9c0 3.5 3 5.5 6 5.5-.39.49-.68 1.05-.85 1.65-.17.6-.22 1.23-.15 1.85v4"/><path d="M9 18c-4.51 2-5-2-7-2"/></svg>
@@ -465,7 +465,7 @@ into a uint256 array in the order expected by the verifier circuit.
 </div>
 
 ```solidity
-import "@openzeppelin/contracts/utils/cryptography/signers/SignerWebAuthn.sol";
+import "@openzeppelin/community-contracts/utils/cryptography/signers/SignerWebAuthn.sol";
 ```
 
 Implementation of `SignerP256` that supports WebAuthn authentication assertions.
@@ -536,7 +536,7 @@ the raw `r` and `s` values from the signature.
 
 <div style={{marginTop: "4em"}} className="w-full flex flex-row items-center justify-between">
 
-## `SignerZKEmail` 
+## `SignerZKEmail`
 
 <a target="_blank" style={{marginTop: "1.5em"}} href="https://github.com/OpenZeppelin/openzeppelin-contracts/blob/v0.0.1/contracts/utils/cryptography/signers/SignerZKEmail.sol">
 <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-github-icon lucide-github"><path d="M15 22v-4a4.8 4.8 0 0 0-1-3.5c3 0 6-2 6-5.5.08-1.25-.27-2.48-1-3.5.28-1.15.28-2.35 0-3.5 0 0-1 0-3 1.5-2.64-.5-5.36-.5-8 0C6 2 5 2 5 2c-.3 1.15-.3 2.35 0 3.5A5.403 5.403 0 0 0 4 9c0 3.5 3 5.5 6 5.5-.39.49-.68 1.05-.85 1.65-.17.6-.22 1.23-.15 1.85v4"/><path d="M9 18c-4.51 2-5-2-7-2"/></svg>
@@ -545,7 +545,7 @@ the raw `r` and `s` values from the signature.
 </div>
 
 ```solidity
-import "@openzeppelin/contracts/utils/cryptography/signers/SignerZKEmail.sol";
+import "@openzeppelin/community-contracts/utils/cryptography/signers/SignerZKEmail.sol";
 ```
 
 Implementation of `AbstractSigner` using [ZKEmail](https://docs.zk.email) signatures.
@@ -767,7 +767,7 @@ Proof verification error.
 
 <div style={{marginTop: "4em"}} className="w-full flex flex-row items-center justify-between">
 
-## `ERC7913WebAuthnVerifier` 
+## `ERC7913WebAuthnVerifier`
 
 <a target="_blank" style={{marginTop: "1.5em"}} href="https://github.com/OpenZeppelin/openzeppelin-contracts/blob/v0.0.1/contracts/utils/cryptography/verifiers/ERC7913WebAuthnVerifier.sol">
 <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-github-icon lucide-github"><path d="M15 22v-4a4.8 4.8 0 0 0-1-3.5c3 0 6-2 6-5.5.08-1.25-.27-2.48-1-3.5.28-1.15.28-2.35 0-3.5 0 0-1 0-3 1.5-2.64-.5-5.36-.5-8 0C6 2 5 2 5 2c-.3 1.15-.3 2.35 0 3.5A5.403 5.403 0 0 0 4 9c0 3.5 3 5.5 6 5.5-.39.49-.68 1.05-.85 1.65-.17.6-.22 1.23-.15 1.85v4"/><path d="M9 18c-4.51 2-5-2-7-2"/></svg>
@@ -776,7 +776,7 @@ Proof verification error.
 </div>
 
 ```solidity
-import "@openzeppelin/contracts/utils/cryptography/verifiers/ERC7913WebAuthnVerifier.sol";
+import "@openzeppelin/community-contracts/utils/cryptography/verifiers/ERC7913WebAuthnVerifier.sol";
 ```
 
 ERC-7913 signature verifier that supports WebAuthn authentication assertions.
@@ -825,7 +825,7 @@ SHOULD return 0xffffffff or revert if the key is empty
 
 <div style={{marginTop: "4em"}} className="w-full flex flex-row items-center justify-between">
 
-## `ERC7913ZKEmailVerifier` 
+## `ERC7913ZKEmailVerifier`
 
 <a target="_blank" style={{marginTop: "1.5em"}} href="https://github.com/OpenZeppelin/openzeppelin-contracts/blob/v0.0.1/contracts/utils/cryptography/verifiers/ERC7913ZKEmailVerifier.sol">
 <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-github-icon lucide-github"><path d="M15 22v-4a4.8 4.8 0 0 0-1-3.5c3 0 6-2 6-5.5.08-1.25-.27-2.48-1-3.5.28-1.15.28-2.35 0-3.5 0 0-1 0-3 1.5-2.64-.5-5.36-.5-8 0C6 2 5 2 5 2c-.3 1.15-.3 2.35 0 3.5A5.403 5.403 0 0 0 4 9c0 3.5 3 5.5 6 5.5-.39.49-.68 1.05-.85 1.65-.17.6-.22 1.23-.15 1.85v4"/><path d="M9 18c-4.51 2-5-2-7-2"/></svg>
@@ -834,7 +834,7 @@ SHOULD return 0xffffffff or revert if the key is empty
 </div>
 
 ```solidity
-import "@openzeppelin/contracts/utils/cryptography/verifiers/ERC7913ZKEmailVerifier.sol";
+import "@openzeppelin/community-contracts/utils/cryptography/verifiers/ERC7913ZKEmailVerifier.sol";
 ```
 
 ERC-7913 signature verifier that supports ZKEmail accounts.
@@ -934,4 +934,3 @@ bytes memory key = abi.encode(registry, accountSalt, verifier);
 
 </div>
 </div>
-

--- a/content/community-contracts/api/utils/cryptography.mdx
+++ b/content/community-contracts/api/utils/cryptography.mdx
@@ -38,7 +38,7 @@ A collection of contracts and libraries that implement various signature validat
 
 ## `DKIMRegistry`
 
-<a target="_blank" style={{marginTop: "1.5em"}} href="https://github.com/OpenZeppelin/openzeppelin-contracts/blob/v0.0.1/contracts/utils/cryptography/DKIMRegistry.sol">
+<a target="_blank" style={{marginTop: "1.5em"}} href="https://github.com/OpenZeppelin/openzeppelin-community-contracts/blob/master/contracts/utils/cryptography/DKIMRegistry.sol">
 <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-github-icon lucide-github"><path d="M15 22v-4a4.8 4.8 0 0 0-1-3.5c3 0 6-2 6-5.5.08-1.25-.27-2.48-1-3.5.28-1.15.28-2.35 0-3.5 0 0-1 0-3 1.5-2.64-.5-5.36-.5-8 0C6 2 5 2 5 2c-.3 1.15-.3 2.35 0 3.5A5.403 5.403 0 0 0 4 9c0 3.5 3 5.5 6 5.5-.39.49-.68 1.05-.85 1.65-.17.6-.22 1.23-.15 1.85v4"/><path d="M9 18c-4.51 2-5-2-7-2"/></svg>
 </a>
 
@@ -190,7 +190,7 @@ Emits a [`IDKIMRegistry.KeyHashRevoked`](../interfaces#IDKIMRegistry-KeyHashRevo
 
 ## `WebAuthn`
 
-<a target="_blank" style={{marginTop: "1.5em"}} href="https://github.com/OpenZeppelin/openzeppelin-contracts/blob/v0.0.1/contracts/utils/cryptography/WebAuthn.sol">
+<a target="_blank" style={{marginTop: "1.5em"}} href="https://github.com/OpenZeppelin/openzeppelin-community-contracts/blob/master/contracts/utils/cryptography/WebAuthn.sol">
 <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-github-icon lucide-github"><path d="M15 22v-4a4.8 4.8 0 0 0-1-3.5c3 0 6-2 6-5.5.08-1.25-.27-2.48-1-3.5.28-1.15.28-2.35 0-3.5 0 0-1 0-3 1.5-2.64-.5-5.36-.5-8 0C6 2 5 2 5 2c-.3 1.15-.3 2.35 0 3.5A5.403 5.403 0 0 0 4 9c0 3.5 3 5.5 6 5.5-.39.49-.68 1.05-.85 1.65-.17.6-.22 1.23-.15 1.85v4"/><path d="M9 18c-4.51 2-5-2-7-2"/></svg>
 </a>
 
@@ -311,7 +311,7 @@ cause revert/panic.
 
 ## `ZKEmailUtils`
 
-<a target="_blank" style={{marginTop: "1.5em"}} href="https://github.com/OpenZeppelin/openzeppelin-contracts/blob/v0.0.1/contracts/utils/cryptography/ZKEmailUtils.sol">
+<a target="_blank" style={{marginTop: "1.5em"}} href="https://github.com/OpenZeppelin/openzeppelin-community-contracts/blob/master/contracts/utils/cryptography/ZKEmailUtils.sol">
 <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-github-icon lucide-github"><path d="M15 22v-4a4.8 4.8 0 0 0-1-3.5c3 0 6-2 6-5.5.08-1.25-.27-2.48-1-3.5.28-1.15.28-2.35 0-3.5 0 0-1 0-3 1.5-2.64-.5-5.36-.5-8 0C6 2 5 2 5 2c-.3 1.15-.3 2.35 0 3.5A5.403 5.403 0 0 0 4 9c0 3.5 3 5.5 6 5.5-.39.49-.68 1.05-.85 1.65-.17.6-.22 1.23-.15 1.85v4"/><path d="M9 18c-4.51 2-5-2-7-2"/></svg>
 </a>
 
@@ -458,7 +458,7 @@ into a uint256 array in the order expected by the verifier circuit.
 
 ## `SignerWebAuthn`
 
-<a target="_blank" style={{marginTop: "1.5em"}} href="https://github.com/OpenZeppelin/openzeppelin-contracts/blob/v0.0.1/contracts/utils/cryptography/signers/SignerWebAuthn.sol">
+<a target="_blank" style={{marginTop: "1.5em"}} href="https://github.com/OpenZeppelin/openzeppelin-community-contracts/blob/master/contracts/utils/cryptography/signers/SignerWebAuthn.sol">
 <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-github-icon lucide-github"><path d="M15 22v-4a4.8 4.8 0 0 0-1-3.5c3 0 6-2 6-5.5.08-1.25-.27-2.48-1-3.5.28-1.15.28-2.35 0-3.5 0 0-1 0-3 1.5-2.64-.5-5.36-.5-8 0C6 2 5 2 5 2c-.3 1.15-.3 2.35 0 3.5A5.403 5.403 0 0 0 4 9c0 3.5 3 5.5 6 5.5-.39.49-.68 1.05-.85 1.65-.17.6-.22 1.23-.15 1.85v4"/><path d="M9 18c-4.51 2-5-2-7-2"/></svg>
 </a>
 
@@ -538,7 +538,7 @@ the raw `r` and `s` values from the signature.
 
 ## `SignerZKEmail`
 
-<a target="_blank" style={{marginTop: "1.5em"}} href="https://github.com/OpenZeppelin/openzeppelin-contracts/blob/v0.0.1/contracts/utils/cryptography/signers/SignerZKEmail.sol">
+<a target="_blank" style={{marginTop: "1.5em"}} href="https://github.com/OpenZeppelin/openzeppelin-community-contracts/blob/master/contracts/utils/cryptography/signers/SignerZKEmail.sol">
 <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-github-icon lucide-github"><path d="M15 22v-4a4.8 4.8 0 0 0-1-3.5c3 0 6-2 6-5.5.08-1.25-.27-2.48-1-3.5.28-1.15.28-2.35 0-3.5 0 0-1 0-3 1.5-2.64-.5-5.36-.5-8 0C6 2 5 2 5 2c-.3 1.15-.3 2.35 0 3.5A5.403 5.403 0 0 0 4 9c0 3.5 3 5.5 6 5.5-.39.49-.68 1.05-.85 1.65-.17.6-.22 1.23-.15 1.85v4"/><path d="M9 18c-4.51 2-5-2-7-2"/></svg>
 </a>
 
@@ -769,7 +769,7 @@ Proof verification error.
 
 ## `ERC7913WebAuthnVerifier`
 
-<a target="_blank" style={{marginTop: "1.5em"}} href="https://github.com/OpenZeppelin/openzeppelin-contracts/blob/v0.0.1/contracts/utils/cryptography/verifiers/ERC7913WebAuthnVerifier.sol">
+<a target="_blank" style={{marginTop: "1.5em"}} href="https://github.com/OpenZeppelin/openzeppelin-community-contracts/blob/master/contracts/utils/cryptography/verifiers/ERC7913WebAuthnVerifier.sol">
 <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-github-icon lucide-github"><path d="M15 22v-4a4.8 4.8 0 0 0-1-3.5c3 0 6-2 6-5.5.08-1.25-.27-2.48-1-3.5.28-1.15.28-2.35 0-3.5 0 0-1 0-3 1.5-2.64-.5-5.36-.5-8 0C6 2 5 2 5 2c-.3 1.15-.3 2.35 0 3.5A5.403 5.403 0 0 0 4 9c0 3.5 3 5.5 6 5.5-.39.49-.68 1.05-.85 1.65-.17.6-.22 1.23-.15 1.85v4"/><path d="M9 18c-4.51 2-5-2-7-2"/></svg>
 </a>
 
@@ -827,7 +827,7 @@ SHOULD return 0xffffffff or revert if the key is empty
 
 ## `ERC7913ZKEmailVerifier`
 
-<a target="_blank" style={{marginTop: "1.5em"}} href="https://github.com/OpenZeppelin/openzeppelin-contracts/blob/v0.0.1/contracts/utils/cryptography/verifiers/ERC7913ZKEmailVerifier.sol">
+<a target="_blank" style={{marginTop: "1.5em"}} href="https://github.com/OpenZeppelin/openzeppelin-community-contracts/blob/master/contracts/utils/cryptography/verifiers/ERC7913ZKEmailVerifier.sol">
 <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-github-icon lucide-github"><path d="M15 22v-4a4.8 4.8 0 0 0-1-3.5c3 0 6-2 6-5.5.08-1.25-.27-2.48-1-3.5.28-1.15.28-2.35 0-3.5 0 0-1 0-3 1.5-2.64-.5-5.36-.5-8 0C6 2 5 2 5 2c-.3 1.15-.3 2.35 0 3.5A5.403 5.403 0 0 0 4 9c0 3.5 3 5.5 6 5.5-.39.49-.68 1.05-.85 1.65-.17.6-.22 1.23-.15 1.85v4"/><path d="M9 18c-4.51 2-5-2-7-2"/></svg>
 </a>
 

--- a/content/community-contracts/index.mdx
+++ b/content/community-contracts/index.mdx
@@ -42,4 +42,4 @@ Contracts in the community library are provided as is, with no particular guaran
 
 Similarly, the code has no backward compatibility guarantees.
 
-We kindly ask to report any issue directly to our security mailto:security@openzeppelin.org[contact]. The team will do its best to assist and mitigate any potential misuses of the library. However, keep in mind the flexibility assumed for this repository may relax our assessment.
+We kindly ask to report any issue directly to our security [contact](mailto:security@openzeppelin.org). The team will do its best to assist and mitigate any potential misuses of the library. However, keep in mind the flexibility assumed for this repository may relax our assessment.

--- a/content/confidential-contracts/api/finance.mdx
+++ b/content/confidential-contracts/api/finance.mdx
@@ -21,16 +21,16 @@ For convenience, this directory also includes:
 
 <div style={{marginTop: "4em"}} className="w-full flex flex-row items-center justify-between">
 
-## `ERC7821WithExecutor` 
+## `ERC7821WithExecutor`
 
-<a target="_blank" style={{marginTop: "1.5em"}} href="https://github.com/OpenZeppelin/openzeppelin-contracts/blob/v0.2.0/contracts/finance/ERC7821WithExecutor.sol">
+<a target="_blank" style={{marginTop: "1.5em"}} href="https://github.com/OpenZeppelin/openzeppelin-confidential-contracts/blob/v0.2.0/contracts/finance/ERC7821WithExecutor.sol">
 <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-github-icon lucide-github"><path d="M15 22v-4a4.8 4.8 0 0 0-1-3.5c3 0 6-2 6-5.5.08-1.25-.27-2.48-1-3.5.28-1.15.28-2.35 0-3.5 0 0-1 0-3 1.5-2.64-.5-5.36-.5-8 0C6 2 5 2 5 2c-.3 1.15-.3 2.35 0 3.5A5.403 5.403 0 0 0 4 9c0 3.5 3 5.5 6 5.5-.39.49-.68 1.05-.85 1.65-.17.6-.22 1.23-.15 1.85v4"/><path d="M9 18c-4.51 2-5-2-7-2"/></svg>
 </a>
 
 </div>
 
 ```solidity
-import "@openzeppelin/contracts/finance/ERC7821WithExecutor.sol";
+import "@openzeppelin/confidential-contracts/finance/ERC7821WithExecutor.sol";
 ```
 
 Extension of `ERC7821` that adds an [`ERC7821WithExecutor.executor`](#ERC7821WithExecutor-executor--) address that is able to execute arbitrary calls via `ERC7821.execute`.
@@ -143,16 +143,16 @@ function _erc7821AuthorizedExecutor(
 
 <div style={{marginTop: "4em"}} className="w-full flex flex-row items-center justify-between">
 
-## `VestingWalletCliffConfidential` 
+## `VestingWalletCliffConfidential`
 
-<a target="_blank" style={{marginTop: "1.5em"}} href="https://github.com/OpenZeppelin/openzeppelin-contracts/blob/v0.2.0/contracts/finance/VestingWalletCliffConfidential.sol">
+<a target="_blank" style={{marginTop: "1.5em"}} href="https://github.com/OpenZeppelin/openzeppelin-confidential-contracts/blob/v0.2.0/contracts/finance/VestingWalletCliffConfidential.sol">
 <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-github-icon lucide-github"><path d="M15 22v-4a4.8 4.8 0 0 0-1-3.5c3 0 6-2 6-5.5.08-1.25-.27-2.48-1-3.5.28-1.15.28-2.35 0-3.5 0 0-1 0-3 1.5-2.64-.5-5.36-.5-8 0C6 2 5 2 5 2c-.3 1.15-.3 2.35 0 3.5A5.403 5.403 0 0 0 4 9c0 3.5 3 5.5 6 5.5-.39.49-.68 1.05-.85 1.65-.17.6-.22 1.23-.15 1.85v4"/><path d="M9 18c-4.51 2-5-2-7-2"/></svg>
 </a>
 
 </div>
 
 ```solidity
-import "@openzeppelin/contracts/finance/VestingWalletCliffConfidential.sol";
+import "@openzeppelin/confidential-contracts/finance/VestingWalletCliffConfidential.sol";
 ```
 
 An extension of [`VestingWalletConfidential`](#VestingWalletConfidential) that adds a cliff to the vesting schedule. The cliff is `cliffSeconds` long and
@@ -326,16 +326,16 @@ The specified cliff duration is larger than the vesting duration.
 
 <div style={{marginTop: "4em"}} className="w-full flex flex-row items-center justify-between">
 
-## `VestingWalletConfidential` 
+## `VestingWalletConfidential`
 
-<a target="_blank" style={{marginTop: "1.5em"}} href="https://github.com/OpenZeppelin/openzeppelin-contracts/blob/v0.2.0/contracts/finance/VestingWalletConfidential.sol">
+<a target="_blank" style={{marginTop: "1.5em"}} href="https://github.com/OpenZeppelin/openzeppelin-confidential-contracts/blob/v0.2.0/contracts/finance/VestingWalletConfidential.sol">
 <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-github-icon lucide-github"><path d="M15 22v-4a4.8 4.8 0 0 0-1-3.5c3 0 6-2 6-5.5.08-1.25-.27-2.48-1-3.5.28-1.15.28-2.35 0-3.5 0 0-1 0-3 1.5-2.64-.5-5.36-.5-8 0C6 2 5 2 5 2c-.3 1.15-.3 2.35 0 3.5A5.403 5.403 0 0 0 4 9c0 3.5 3 5.5 6 5.5-.39.49-.68 1.05-.85 1.65-.17.6-.22 1.23-.15 1.85v4"/><path d="M9 18c-4.51 2-5-2-7-2"/></svg>
 </a>
 
 </div>
 
 ```solidity
-import "@openzeppelin/contracts/finance/VestingWalletConfidential.sol";
+import "@openzeppelin/confidential-contracts/finance/VestingWalletConfidential.sol";
 ```
 
 A vesting wallet is an ownable contract that can receive ConfidentialFungibleTokens, and release these
@@ -620,16 +620,16 @@ Emitted when releasable vested tokens are released.
 
 <div style={{marginTop: "4em"}} className="w-full flex flex-row items-center justify-between">
 
-## `VestingWalletConfidentialFactory` 
+## `VestingWalletConfidentialFactory`
 
-<a target="_blank" style={{marginTop: "1.5em"}} href="https://github.com/OpenZeppelin/openzeppelin-contracts/blob/v0.2.0/contracts/finance/VestingWalletConfidentialFactory.sol">
+<a target="_blank" style={{marginTop: "1.5em"}} href="https://github.com/OpenZeppelin/openzeppelin-confidential-contracts/blob/v0.2.0/contracts/finance/VestingWalletConfidentialFactory.sol">
 <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-github-icon lucide-github"><path d="M15 22v-4a4.8 4.8 0 0 0-1-3.5c3 0 6-2 6-5.5.08-1.25-.27-2.48-1-3.5.28-1.15.28-2.35 0-3.5 0 0-1 0-3 1.5-2.64-.5-5.36-.5-8 0C6 2 5 2 5 2c-.3 1.15-.3 2.35 0 3.5A5.403 5.403 0 0 0 4 9c0 3.5 3 5.5 6 5.5-.39.49-.68 1.05-.85 1.65-.17.6-.22 1.23-.15 1.85v4"/><path d="M9 18c-4.51 2-5-2-7-2"/></svg>
 </a>
 
 </div>
 
 ```solidity
-import "@openzeppelin/contracts/finance/VestingWalletConfidentialFactory.sol";
+import "@openzeppelin/confidential-contracts/finance/VestingWalletConfidentialFactory.sol";
 ```
 
 A factory which enables batch funding of vesting wallets.
@@ -836,4 +836,3 @@ Emitted when a vesting wallet is deployed.
 
 </div>
 </div>
-

--- a/content/confidential-contracts/api/governance.mdx
+++ b/content/confidential-contracts/api/governance.mdx
@@ -14,16 +14,16 @@ This directory includes primitives for on-chain confidential governance.
 
 <div style={{marginTop: "4em"}} className="w-full flex flex-row items-center justify-between">
 
-## `VotesConfidential` 
+## `VotesConfidential`
 
-<a target="_blank" style={{marginTop: "1.5em"}} href="https://github.com/OpenZeppelin/openzeppelin-contracts/blob/v0.2.0/contracts/governance/utils/VotesConfidential.sol">
+<a target="_blank" style={{marginTop: "1.5em"}} href="https://github.com/OpenZeppelin/openzeppelin-confidential-contracts/blob/v0.2.0/contracts/governance/utils/VotesConfidential.sol">
 <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-github-icon lucide-github"><path d="M15 22v-4a4.8 4.8 0 0 0-1-3.5c3 0 6-2 6-5.5.08-1.25-.27-2.48-1-3.5.28-1.15.28-2.35 0-3.5 0 0-1 0-3 1.5-2.64-.5-5.36-.5-8 0C6 2 5 2 5 2c-.3 1.15-.3 2.35 0 3.5A5.403 5.403 0 0 0 4 9c0 3.5 3 5.5 6 5.5-.39.49-.68 1.05-.85 1.65-.17.6-.22 1.23-.15 1.85v4"/><path d="M9 18c-4.51 2-5-2-7-2"/></svg>
 </a>
 
 </div>
 
 ```solidity
-import "@openzeppelin/contracts/governance/utils/VotesConfidential.sol";
+import "@openzeppelin/confidential-contracts/governance/utils/VotesConfidential.sol";
 ```
 
 A confidential votes contract tracking confidential voting power of accounts over time.
@@ -33,7 +33,7 @@ This contract keeps a history (checkpoints) of each account's confidential vote 
 voting power can be delegated either by calling the [`VotesConfidential.delegate`](#VotesConfidential-delegate-address-) function directly, or by providing
 a signature to be used with [`VotesConfidential.delegateBySig`](#VotesConfidential-delegateBySig-address-uint256-uint256-uint8-bytes32-bytes32-). Confidential voting power handles can be queried
 through the public accessors [`VotesConfidential.getVotes`](#VotesConfidential-getVotes-address-) and [`VotesConfidential.getPastVotes`](#VotesConfidential-getPastVotes-address-uint256-) but can only be decrypted by accounts
-allowed to access them. Ensure that [`HandleAccessManager._validateHandleAllowance`](utils#HandleAccessManager-_validateHandleAllowance-bytes32-) is implemented properly, allowing all 
+allowed to access them. Ensure that [`HandleAccessManager._validateHandleAllowance`](utils#HandleAccessManager-_validateHandleAllowance-bytes32-) is implemented properly, allowing all
 necessary addresses to access voting power handles.
 
 By default, voting units does not account for voting power. This makes transfers of underlying
@@ -452,4 +452,3 @@ Lookup to future votes is not available.
 
 </div>
 </div>
-

--- a/content/confidential-contracts/api/interfaces.mdx
+++ b/content/confidential-contracts/api/interfaces.mdx
@@ -16,16 +16,16 @@ These interfaces are available as `.sol` files and are useful to interact with t
 
 <div style={{marginTop: "4em"}} className="w-full flex flex-row items-center justify-between">
 
-## `IConfidentialFungibleToken` 
+## `IConfidentialFungibleToken`
 
-<a target="_blank" style={{marginTop: "1.5em"}} href="https://github.com/OpenZeppelin/openzeppelin-contracts/blob/v0.2.0/contracts/interfaces/IConfidentialFungibleToken.sol">
+<a target="_blank" style={{marginTop: "1.5em"}} href="https://github.com/OpenZeppelin/openzeppelin-confidential-contracts/blob/v0.2.0/contracts/interfaces/IConfidentialFungibleToken.sol">
 <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-github-icon lucide-github"><path d="M15 22v-4a4.8 4.8 0 0 0-1-3.5c3 0 6-2 6-5.5.08-1.25-.27-2.48-1-3.5.28-1.15.28-2.35 0-3.5 0 0-1 0-3 1.5-2.64-.5-5.36-.5-8 0C6 2 5 2 5 2c-.3 1.15-.3 2.35 0 3.5A5.403 5.403 0 0 0 4 9c0 3.5 3 5.5 6 5.5-.39.49-.68 1.05-.85 1.65-.17.6-.22 1.23-.15 1.85v4"/><path d="M9 18c-4.51 2-5-2-7-2"/></svg>
 </a>
 
 </div>
 
 ```solidity
-import "@openzeppelin/contracts/interfaces/IConfidentialFungibleToken.sol";
+import "@openzeppelin/confidential-contracts/interfaces/IConfidentialFungibleToken.sol";
 ```
 
 Draft interface for a confidential fungible token standard utilizing the Zama FHE library.
@@ -411,16 +411,16 @@ should be able to disclose the amount. This functionality is implementation spec
 
 <div style={{marginTop: "4em"}} className="w-full flex flex-row items-center justify-between">
 
-## `IConfidentialFungibleTokenReceiver` 
+## `IConfidentialFungibleTokenReceiver`
 
-<a target="_blank" style={{marginTop: "1.5em"}} href="https://github.com/OpenZeppelin/openzeppelin-contracts/blob/v0.2.0/contracts/interfaces/IConfidentialFungibleTokenReceiver.sol">
+<a target="_blank" style={{marginTop: "1.5em"}} href="https://github.com/OpenZeppelin/openzeppelin-confidential-contracts/blob/v0.2.0/contracts/interfaces/IConfidentialFungibleTokenReceiver.sol">
 <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-github-icon lucide-github"><path d="M15 22v-4a4.8 4.8 0 0 0-1-3.5c3 0 6-2 6-5.5.08-1.25-.27-2.48-1-3.5.28-1.15.28-2.35 0-3.5 0 0-1 0-3 1.5-2.64-.5-5.36-.5-8 0C6 2 5 2 5 2c-.3 1.15-.3 2.35 0 3.5A5.403 5.403 0 0 0 4 9c0 3.5 3 5.5 6 5.5-.39.49-.68 1.05-.85 1.65-.17.6-.22 1.23-.15 1.85v4"/><path d="M9 18c-4.51 2-5-2-7-2"/></svg>
 </a>
 
 </div>
 
 ```solidity
-import "@openzeppelin/contracts/interfaces/IConfidentialFungibleTokenReceiver.sol";
+import "@openzeppelin/confidential-contracts/interfaces/IConfidentialFungibleTokenReceiver.sol";
 ```
 
 Interface for contracts that can receive confidential token transfers with a callback.
@@ -449,4 +449,3 @@ of the callback. If false is returned, the transfer must be reversed.
 
 </div>
 </div>
-

--- a/content/confidential-contracts/api/token.mdx
+++ b/content/confidential-contracts/api/token.mdx
@@ -7,7 +7,7 @@ This set of interfaces, contracts, and utilities are all related to the evolving
 
 * [`ConfidentialFungibleToken`](#ConfidentialFungibleToken): Implementation of [`IConfidentialFungibleToken`](interfaces#IConfidentialFungibleToken).
 * [`ConfidentialFungibleTokenERC20Wrapper`](#ConfidentialFungibleTokenERC20Wrapper): Extension of [`ConfidentialFungibleToken`](#ConfidentialFungibleToken) which wraps an `ERC20` into a confidential token. The wrapper allows for free conversion in both directions at a fixed rate.
-* [`ConfidentialFungibleTokenUtils`](#ConfidentialFungibleTokenUtils): A library that provides the on-transfer callback check used by [`ConfidentialFungibleToken`](#ConfidentialFungibleToken). 
+* [`ConfidentialFungibleTokenUtils`](#ConfidentialFungibleTokenUtils): A library that provides the on-transfer callback check used by [`ConfidentialFungibleToken`](#ConfidentialFungibleToken).
 
 ## Core
 [`ConfidentialFungibleToken`](#ConfidentialFungibleToken)
@@ -22,16 +22,16 @@ This set of interfaces, contracts, and utilities are all related to the evolving
 
 <div style={{marginTop: "4em"}} className="w-full flex flex-row items-center justify-between">
 
-## `ConfidentialFungibleToken` 
+## `ConfidentialFungibleToken`
 
-<a target="_blank" style={{marginTop: "1.5em"}} href="https://github.com/OpenZeppelin/openzeppelin-contracts/blob/v0.2.0/contracts/token/ConfidentialFungibleToken.sol">
+<a target="_blank" style={{marginTop: "1.5em"}} href="https://github.com/OpenZeppelin/openzeppelin-confidential-contracts/blob/v0.2.0/contracts/token/ConfidentialFungibleToken.sol">
 <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-github-icon lucide-github"><path d="M15 22v-4a4.8 4.8 0 0 0-1-3.5c3 0 6-2 6-5.5.08-1.25-.27-2.48-1-3.5.28-1.15.28-2.35 0-3.5 0 0-1 0-3 1.5-2.64-.5-5.36-.5-8 0C6 2 5 2 5 2c-.3 1.15-.3 2.35 0 3.5A5.403 5.403 0 0 0 4 9c0 3.5 3 5.5 6 5.5-.39.49-.68 1.05-.85 1.65-.17.6-.22 1.23-.15 1.85v4"/><path d="M9 18c-4.51 2-5-2-7-2"/></svg>
 </a>
 
 </div>
 
 ```solidity
-import "@openzeppelin/contracts/token/ConfidentialFungibleToken.sol";
+import "@openzeppelin/confidential-contracts/token/ConfidentialFungibleToken.sol";
 ```
 
 Reference implementation for [`IConfidentialFungibleToken`](interfaces#IConfidentialFungibleToken).
@@ -666,16 +666,16 @@ The given gateway request ID `requestId` is invalid.
 
 <div style={{marginTop: "4em"}} className="w-full flex flex-row items-center justify-between">
 
-## `ConfidentialFungibleTokenERC20Wrapper` 
+## `ConfidentialFungibleTokenERC20Wrapper`
 
-<a target="_blank" style={{marginTop: "1.5em"}} href="https://github.com/OpenZeppelin/openzeppelin-contracts/blob/v0.2.0/contracts/token/extensions/ConfidentialFungibleTokenERC20Wrapper.sol">
+<a target="_blank" style={{marginTop: "1.5em"}} href="https://github.com/OpenZeppelin/openzeppelin-confidential-contracts/blob/v0.2.0/contracts/token/extensions/ConfidentialFungibleTokenERC20Wrapper.sol">
 <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-github-icon lucide-github"><path d="M15 22v-4a4.8 4.8 0 0 0-1-3.5c3 0 6-2 6-5.5.08-1.25-.27-2.48-1-3.5.28-1.15.28-2.35 0-3.5 0 0-1 0-3 1.5-2.64-.5-5.36-.5-8 0C6 2 5 2 5 2c-.3 1.15-.3 2.35 0 3.5A5.403 5.403 0 0 0 4 9c0 3.5 3 5.5 6 5.5-.39.49-.68 1.05-.85 1.65-.17.6-.22 1.23-.15 1.85v4"/><path d="M9 18c-4.51 2-5-2-7-2"/></svg>
 </a>
 
 </div>
 
 ```solidity
-import "@openzeppelin/contracts/token/extensions/ConfidentialFungibleTokenERC20Wrapper.sol";
+import "@openzeppelin/confidential-contracts/token/extensions/ConfidentialFungibleTokenERC20Wrapper.sol";
 ```
 
 A wrapper contract built on top of [`ConfidentialFungibleToken`](#ConfidentialFungibleToken) that allows wrapping an `ERC20` token
@@ -980,16 +980,16 @@ Returns the maximum number that will be used for [`IConfidentialFungibleToken.de
 
 <div style={{marginTop: "4em"}} className="w-full flex flex-row items-center justify-between">
 
-## `ConfidentialFungibleTokenVotes` 
+## `ConfidentialFungibleTokenVotes`
 
-<a target="_blank" style={{marginTop: "1.5em"}} href="https://github.com/OpenZeppelin/openzeppelin-contracts/blob/v0.2.0/contracts/token/extensions/ConfidentialFungibleTokenVotes.sol">
+<a target="_blank" style={{marginTop: "1.5em"}} href="https://github.com/OpenZeppelin/openzeppelin-confidential-contracts/blob/v0.2.0/contracts/token/extensions/ConfidentialFungibleTokenVotes.sol">
 <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-github-icon lucide-github"><path d="M15 22v-4a4.8 4.8 0 0 0-1-3.5c3 0 6-2 6-5.5.08-1.25-.27-2.48-1-3.5.28-1.15.28-2.35 0-3.5 0 0-1 0-3 1.5-2.64-.5-5.36-.5-8 0C6 2 5 2 5 2c-.3 1.15-.3 2.35 0 3.5A5.403 5.403 0 0 0 4 9c0 3.5 3 5.5 6 5.5-.39.49-.68 1.05-.85 1.65-.17.6-.22 1.23-.15 1.85v4"/><path d="M9 18c-4.51 2-5-2-7-2"/></svg>
 </a>
 
 </div>
 
 ```solidity
-import "@openzeppelin/contracts/token/extensions/ConfidentialFungibleTokenVotes.sol";
+import "@openzeppelin/confidential-contracts/token/extensions/ConfidentialFungibleTokenVotes.sol";
 ```
 
 Extension of [`ConfidentialFungibleToken`](#ConfidentialFungibleToken) supporting confidential votes tracking and delegation.
@@ -1155,16 +1155,16 @@ Returns the confidential total supply of the token.
 
 <div style={{marginTop: "4em"}} className="w-full flex flex-row items-center justify-between">
 
-## `ConfidentialFungibleTokenUtils` 
+## `ConfidentialFungibleTokenUtils`
 
-<a target="_blank" style={{marginTop: "1.5em"}} href="https://github.com/OpenZeppelin/openzeppelin-contracts/blob/v0.2.0/contracts/token/utils/ConfidentialFungibleTokenUtils.sol">
+<a target="_blank" style={{marginTop: "1.5em"}} href="https://github.com/OpenZeppelin/openzeppelin-confidential-contracts/blob/v0.2.0/contracts/token/utils/ConfidentialFungibleTokenUtils.sol">
 <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-github-icon lucide-github"><path d="M15 22v-4a4.8 4.8 0 0 0-1-3.5c3 0 6-2 6-5.5.08-1.25-.27-2.48-1-3.5.28-1.15.28-2.35 0-3.5 0 0-1 0-3 1.5-2.64-.5-5.36-.5-8 0C6 2 5 2 5 2c-.3 1.15-.3 2.35 0 3.5A5.403 5.403 0 0 0 4 9c0 3.5 3 5.5 6 5.5-.39.49-.68 1.05-.85 1.65-.17.6-.22 1.23-.15 1.85v4"/><path d="M9 18c-4.51 2-5-2-7-2"/></svg>
 </a>
 
 </div>
 
 ```solidity
-import "@openzeppelin/contracts/token/utils/ConfidentialFungibleTokenUtils.sol";
+import "@openzeppelin/confidential-contracts/token/utils/ConfidentialFungibleTokenUtils.sol";
 ```
 
 Library that provides common [`ConfidentialFungibleToken`](#ConfidentialFungibleToken) utility functions.
@@ -1198,4 +1198,3 @@ whether the transfer was accepted or not. If the `ebool` is `false`, the transfe
 
 </div>
 </div>
-

--- a/content/confidential-contracts/api/utils.mdx
+++ b/content/confidential-contracts/api/utils.mdx
@@ -24,16 +24,16 @@ Miscellaneous contracts and libraries containing utility functions you can use t
 
 <div style={{marginTop: "4em"}} className="w-full flex flex-row items-center justify-between">
 
-## `FHESafeMath` 
+## `FHESafeMath`
 
-<a target="_blank" style={{marginTop: "1.5em"}} href="https://github.com/OpenZeppelin/openzeppelin-contracts/blob/v0.2.0/contracts/utils/FHESafeMath.sol">
+<a target="_blank" style={{marginTop: "1.5em"}} href="https://github.com/OpenZeppelin/openzeppelin-confidential-contracts/blob/v0.2.0/contracts/utils/FHESafeMath.sol">
 <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-github-icon lucide-github"><path d="M15 22v-4a4.8 4.8 0 0 0-1-3.5c3 0 6-2 6-5.5.08-1.25-.27-2.48-1-3.5.28-1.15.28-2.35 0-3.5 0 0-1 0-3 1.5-2.64-.5-5.36-.5-8 0C6 2 5 2 5 2c-.3 1.15-.3 2.35 0 3.5A5.403 5.403 0 0 0 4 9c0 3.5 3 5.5 6 5.5-.39.49-.68 1.05-.85 1.65-.17.6-.22 1.23-.15 1.85v4"/><path d="M9 18c-4.51 2-5-2-7-2"/></svg>
 </a>
 
 </div>
 
 ```solidity
-import "@openzeppelin/contracts/utils/FHESafeMath.sol";
+import "@openzeppelin/confidential-contracts/utils/FHESafeMath.sol";
 ```
 
 Library providing safe arithmetic operations for encrypted values
@@ -89,16 +89,16 @@ and `updated` will be the original value.
 
 <div style={{marginTop: "4em"}} className="w-full flex flex-row items-center justify-between">
 
-## `HandleAccessManager` 
+## `HandleAccessManager`
 
-<a target="_blank" style={{marginTop: "1.5em"}} href="https://github.com/OpenZeppelin/openzeppelin-contracts/blob/v0.2.0/contracts/utils/HandleAccessManager.sol">
+<a target="_blank" style={{marginTop: "1.5em"}} href="https://github.com/OpenZeppelin/openzeppelin-confidential-contracts/blob/v0.2.0/contracts/utils/HandleAccessManager.sol">
 <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-github-icon lucide-github"><path d="M15 22v-4a4.8 4.8 0 0 0-1-3.5c3 0 6-2 6-5.5.08-1.25-.27-2.48-1-3.5.28-1.15.28-2.35 0-3.5 0 0-1 0-3 1.5-2.64-.5-5.36-.5-8 0C6 2 5 2 5 2c-.3 1.15-.3 2.35 0 3.5A5.403 5.403 0 0 0 4 9c0 3.5 3 5.5 6 5.5-.39.49-.68 1.05-.85 1.65-.17.6-.22 1.23-.15 1.85v4"/><path d="M9 18c-4.51 2-5-2-7-2"/></svg>
 </a>
 
 </div>
 
 ```solidity
-import "@openzeppelin/contracts/utils/HandleAccessManager.sol";
+import "@openzeppelin/confidential-contracts/utils/HandleAccessManager.sol";
 ```
 
 <div className="bg-secondary p-4 rounded-md mb-6">
@@ -154,16 +154,16 @@ Unimplemented function that must revert if the message sender is not allowed to 
 
 <div style={{marginTop: "4em"}} className="w-full flex flex-row items-center justify-between">
 
-## `CheckpointsConfidential` 
+## `CheckpointsConfidential`
 
-<a target="_blank" style={{marginTop: "1.5em"}} href="https://github.com/OpenZeppelin/openzeppelin-contracts/blob/v0.2.0/contracts/utils/structs/CheckpointsConfidential.sol">
+<a target="_blank" style={{marginTop: "1.5em"}} href="https://github.com/OpenZeppelin/openzeppelin-confidential-contracts/blob/v0.2.0/contracts/utils/structs/CheckpointsConfidential.sol">
 <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-github-icon lucide-github"><path d="M15 22v-4a4.8 4.8 0 0 0-1-3.5c3 0 6-2 6-5.5.08-1.25-.27-2.48-1-3.5.28-1.15.28-2.35 0-3.5 0 0-1 0-3 1.5-2.64-.5-5.36-.5-8 0C6 2 5 2 5 2c-.3 1.15-.3 2.35 0 3.5A5.403 5.403 0 0 0 4 9c0 3.5 3 5.5 6 5.5-.39.49-.68 1.05-.85 1.65-.17.6-.22 1.23-.15 1.85v4"/><path d="M9 18c-4.51 2-5-2-7-2"/></svg>
 </a>
 
 </div>
 
 ```solidity
-import "@openzeppelin/contracts/utils/structs/CheckpointsConfidential.sol";
+import "@openzeppelin/confidential-contracts/utils/structs/CheckpointsConfidential.sol";
 ```
 
 This library defines the `Trace*` struct, for checkpointing values as they change at different points in
@@ -502,16 +502,16 @@ Returns checkpoint at given position.
 
 <div style={{marginTop: "4em"}} className="w-full flex flex-row items-center justify-between">
 
-## `Checkpoints` 
+## `Checkpoints`
 
-<a target="_blank" style={{marginTop: "1.5em"}} href="https://github.com/OpenZeppelin/openzeppelin-contracts/blob/v0.2.0/contracts/utils/structs/temporary-Checkpoints.sol">
+<a target="_blank" style={{marginTop: "1.5em"}} href="https://github.com/OpenZeppelin/openzeppelin-confidential-contracts/blob/v0.2.0/contracts/utils/structs/temporary-Checkpoints.sol">
 <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-github-icon lucide-github"><path d="M15 22v-4a4.8 4.8 0 0 0-1-3.5c3 0 6-2 6-5.5.08-1.25-.27-2.48-1-3.5.28-1.15.28-2.35 0-3.5 0 0-1 0-3 1.5-2.64-.5-5.36-.5-8 0C6 2 5 2 5 2c-.3 1.15-.3 2.35 0 3.5A5.403 5.403 0 0 0 4 9c0 3.5 3 5.5 6 5.5-.39.49-.68 1.05-.85 1.65-.17.6-.22 1.23-.15 1.85v4"/><path d="M9 18c-4.51 2-5-2-7-2"/></svg>
 </a>
 
 </div>
 
 ```solidity
-import "@openzeppelin/contracts/utils/structs/temporary-Checkpoints.sol";
+import "@openzeppelin/confidential-contracts/utils/structs/temporary-Checkpoints.sol";
 ```
 
 This library defines the `Trace*` struct, for checkpointing values as they change at different points in
@@ -1189,4 +1189,3 @@ A value was attempted to be inserted on a past checkpoint.
 
 </div>
 </div>
-

--- a/content/confidential-contracts/index.mdx
+++ b/content/confidential-contracts/index.mdx
@@ -14,4 +14,4 @@ Contracts in the confidential contracts library are provided as is, with no part
 
 Similarly, the code has no backward compatibility guarantees.
 
-We kindly ask to report any issue directly to our security mailto:security@openzeppelin.org[contact]. The team will do its best to assist and mitigate any potential misuses of the library. However, keep in mind the flexibility assumed for this repository may relax our assessment.
+We kindly ask to report any issue directly to our security [contact](mailto:security@openzeppelin.org). The team will do its best to assist and mitigate any potential misuses of the library. However, keep in mind the flexibility assumed for this repository may relax our assessment.

--- a/content/confidential-contracts/token.mdx
+++ b/content/confidential-contracts/token.mdx
@@ -2,7 +2,7 @@
 title: ERC7984
 ---
 
-[`ERC7984`](/contracts/5.x/api/token#ERC7984) is a standard fungible token implementation that is similar to ERC-20, but built from the ground up with confidentiality in mind. All balance and transfer amounts are represented as ciphertext handles, ensuring that no data is leaked to the public.
+[`ERC7984`](/confidential-contracts/api/token#ERC7984) is a standard fungible token implementation that is similar to ERC-20, but built from the ground up with confidentiality in mind. All balance and transfer amounts are represented as ciphertext handles, ensuring that no data is leaked to the public.
 
 While the standard is built with inspiration from ERC-20, it is not ERC-20 compliant--the standard takes learning from all tokens built over the past 10 years (ERC-20, ERC-721, ERC-1155, ERC-6909 etc) and provides an interface for maximal functionality.
 
@@ -41,7 +41,7 @@ Setting an operator for any amount of time allows the operator to _***take all o
 
 The token standard exposes transfer functions with and without callbacks. It is up to the caller to decide if a callback is necessary for the transfer. For smart contracts that support it, callbacks allow the operator approval step to be skipped and directly invoke the receiver contract via a callback.
 
-Smart contracts that are the target of a callback must implement [`IERC7984Receiver`](/contracts/5.x/api/interfaces#IERC7984Receiver). After balances are updated for a transfer, the callback is triggered by calling the [`onConfidentialTransferReceived`](/contracts/5.x/api/interfaces#IERC7984Receiver-onConfidentialTransferReceived-address-address-euint64-bytes-) function. The function must either revert or return an `ebool` indicating success. If the callback returns false, the token transfer is reversed.
+Smart contracts that are the target of a callback must implement [`IERC7984Receiver`](/confidential-contracts/api/interfaces#IERC7984Receiver). After balances are updated for a transfer, the callback is triggered by calling the [`onConfidentialTransferReceived`](/confidential-contracts/api/interfaces#IERC7984Receiver-onConfidentialTransferReceived-address-address-euint64-bytes-) function. The function must either revert or return an `ebool` indicating success. If the callback returns false, the token transfer is reversed.
 
 ## Examples
 

--- a/content/contracts-compact/access.mdx
+++ b/content/contracts-compact/access.mdx
@@ -28,7 +28,7 @@ The Compact contracts library provides `AccessControl` for implementing role-bas
 Its usage is straightforward: for each role that you want to define,
 you will create a new role identifier that is used to grant, revoke, and check if an account has that role.
 
-Here’s a simple example of using `AccessControl` with [FungibleToken](fungibleToken) to define a 'minter' role, which allows accounts that have this role to create new tokens:
+Here's a simple example of using `AccessControl` with [FungibleToken](/contracts-compact/fungibleToken) to define a 'minter' role, which allows accounts that have this role to create new tokens:
 
 ```ts
 pragma language_version >= 0.16.0;
@@ -59,14 +59,13 @@ export circuit mint(recipient: Either<ZswapCoinPublicKey, ContractAddress>, valu
 }
 
 ```
-
 <Callout>
-Make sure you fully understand how [AccessControl](api/accessControl#accessControl) works before using it on your system, or copy-pasting the examples from this guide.
+Make sure you fully understand how [AccessControl](/contracts-compact/api/accessControl#accessControl) works before using it on your system, or copy-pasting the examples from this guide.
 </Callout>
 
-While clear and explicit, this isn’t anything we wouldn’t have been able to achieve with [Ownable](ownable). Indeed, where `AccessControl` shines is in scenarios where granular permissions are required, which can be implemented by defining _multiple_ roles.
+While clear and explicit, this isn't anything we wouldn't have been able to achieve with [Ownable](/contracts-compact/ownable). Indeed, where `AccessControl` shines is in scenarios where granular permissions are required, which can be implemented by defining _multiple_ roles.
 
-Let’s augment our FungibleToken example by also defining a 'burner' role, which lets accounts destroy tokens.
+Let's augment our FungibleToken example by also defining a 'burner' role, which lets accounts destroy tokens.
 
 ```ts
 pragma language_version >= 0.16.0;
@@ -169,7 +168,7 @@ Dynamic role allocation is often a desirable property, for example in systems wh
 
 ### Experimental features
 
-This module offers an experimental circuit that allow access control permissions to be granted to contract addresses [_unsafeGrantRole](api/accessControl#AccessControl-_unsafeGrantRole).
+This module offers an experimental circuit that allow access control permissions to be granted to contract addresses [_unsafeGrantRole](/contracts-compact/api/accessControl#AccessControl-_unsafeGrantRole).
 Note that the circuit name is very explicit ("unsafe") with this experimental circuit.
 Until contract-to-contract calls are supported, there is no direct way for a contract to call permissioned circuits of other contracts or grant/revoke role permissions.
 

--- a/content/contracts-compact/access.mdx
+++ b/content/contracts-compact/access.mdx
@@ -60,7 +60,7 @@ export circuit mint(recipient: Either<ZswapCoinPublicKey, ContractAddress>, valu
 
 ```
 <Callout>
-Make sure you fully understand how [AccessControl](/contracts-compact/api/accessControl#accessControl) works before using it on your system, or copy-pasting the examples from this guide.
+Make sure you fully understand how [AccessControl](/contracts-compact/api/access) works before using it on your system, or copy-pasting the examples from this guide.
 </Callout>
 
 While clear and explicit, this isn't anything we wouldn't have been able to achieve with [Ownable](/contracts-compact/ownable). Indeed, where `AccessControl` shines is in scenarios where granular permissions are required, which can be implemented by defining _multiple_ roles.

--- a/content/contracts-compact/api/access.mdx
+++ b/content/contracts-compact/api/access.mdx
@@ -17,7 +17,7 @@ constructor()
 
 ```
 
-To restrict access to a circuit, use [assertOnlyRole](#assertonlyrole):
+To restrict access to a circuit, use [assertOnlyRole](/contracts-compact/#assertonlyrole):
 
 ```typescript
 circuit foo(): []

--- a/content/contracts-compact/api/fungibleToken.mdx
+++ b/content/contracts-compact/api/fungibleToken.mdx
@@ -5,7 +5,7 @@ title: FungibleToken
 This module provides the full FungibleToken module API.
 
 <Callout>
-For an overview of the module, read the [FungibleToken guide](fungibleToken).
+For an overview of the module, read the [FungibleToken guide](/contracts-compact/fungibleToken).
 </Callout>
 
 ## Core

--- a/content/contracts-compact/api/nonFungibleToken.mdx
+++ b/content/contracts-compact/api/nonFungibleToken.mdx
@@ -5,7 +5,7 @@ title: NonFungibleToken
 This module provides the full NonFungibleToken module API.
 
 <Callout>
-For an overview of the module, read the [NonFungibleToken guide](nonFungibleToken).
+For an overview of the module, read the [NonFungibleToken guide](/contracts-compact/nonFungibleToken).
 </Callout>
 
 ## Core

--- a/content/contracts-compact/fungibleToken.mdx
+++ b/content/contracts-compact/fungibleToken.mdx
@@ -56,9 +56,9 @@ constructor(
 ```
 
 Next, expose the circuits that users may call in the contract.
-This library enables extensibility by following the rules of the [Module/Contract Pattern](extensibility#the_module_contract_pattern).
+This library enables extensibility by following the rules of the [Module/Contract Pattern](/contracts-compact/extensibility#the_module_contract_pattern).
 Note that circuits with a preceding underscore (`_likeThis`) are meant to be building blocks for implementing contracts.
-Exposing [_mint](/api/fungibleToken#FungibleTokenModule-_mint) without some sort of access control, for example, would allow ANYONE to mint tokens.
+Exposing [_mint](/contracts-compact/api/fungibleToken#FungibleTokenModule-_mint) without some sort of access control, for example, would allow ANYONE to mint tokens.
 
 ```typescript
 export circuit name(): Opaque<"string">

--- a/content/contracts-compact/multitoken.mdx
+++ b/content/contracts-compact/multitoken.mdx
@@ -71,9 +71,9 @@ constructor(
 ```
 
 Next, expose the circuits that users may call in the contract.
-This library enables extensibility by following the rules of the [Module/Contract Pattern](extensibility#the_module_contract_pattern).
+This library enables extensibility by following the rules of the [Module/Contract Pattern](/contracts-compact/extensibility#the_module_contract_pattern).
 Note that circuits with a preceding underscore (`_likeThis`) are meant to be building blocks for implementing contracts.
-Exposing [_mint](/api/multitoken#MultiTokenModule-_mint) without some sort of access control, for example, would allow ANYONE to mint tokens.
+Exposing [_mint](/contracts-compact/api/multitoken#MultiTokenModule-_mint) without some sort of access control, for example, would allow ANYONE to mint tokens.
 
 ```typescript
 export circuit uri(id: Uint<128>): Opaque<"string">

--- a/content/contracts-compact/nonFungibleToken.mdx
+++ b/content/contracts-compact/nonFungibleToken.mdx
@@ -60,9 +60,9 @@ constructor(
 ```
 
 Next, expose the circuits that users may call in the contract.
-This library enables extensibility by following the rules of the [Module/Contract Pattern](extensibility#the_module_contract_pattern).
+This library enables extensibility by following the rules of the [Module/Contract Pattern](/contracts-compact/extensibility#the_module_contract_pattern).
 Note that circuits with a preceding underscore (`_likeThis`) are meant to be building blocks for implementing contracts.
-Exposing [_mint](/api/nonFungibleToken#NonFungibleTokenModule-_mint) without some sort of access control, for example, would allow ANYONE to mint tokens.
+Exposing [_mint](/contracts-compact/api/nonFungibleToken#NonFungibleTokenModule-_mint) without some sort of access control, for example, would allow ANYONE to mint tokens.
 
 ```typescript
 export circuit name(): Opaque<"string">

--- a/content/contracts-compact/ownable.mdx
+++ b/content/contracts-compact/ownable.mdx
@@ -7,18 +7,18 @@ This modules provides a basic access control mechanism, where there is an owner
 that can be granted exclusive access to specific circuits.
 This approach is perfectly reasonable for contracts that have a single administrative user.
 
-The initial owner must be set by using the [initialize](api/ownable#Ownable-initialize) circuit during construction.
-This can later be changed with [transferOwnership](api/ownable#Ownable-transferOwnership).
+The initial owner must be set by using the [initialize](/contracts-compact/api/ownable#Ownable-initialize) circuit during construction.
+This can later be changed with [transferOwnership](/contracts-compact/api/ownable#Ownable-transferOwnership).
 
 ## Ownership transfers
 
-Ownership can only be transferred to `ZswapCoinPublicKeys` through the main transfer circuits ([transferOwnership](api/ownable#Ownable-transferOwnership) and [_transferOwnership](api/ownable#Ownable-_transferOwnership)).
+Ownership can only be transferred to `ZswapCoinPublicKeys` through the main transfer circuits ([transferOwnership](/contracts-compact/api/ownable#Ownable-transferOwnership) and [_transferOwnership](/contracts-compact/api/ownable#Ownable-_transferOwnership)).
 In other words, ownership transfers to contract addresses are disallowed through these circuits.
 This is because Compact currently does not support contract-to-contract calls which means if a contract is granted ownership, the owner contract cannot directly call the protected circuit.
 
 ### Experimental features
 
-This module offers experimental circuits that allow ownership to be granted to contract addresses ([_unsafeTransferOwnership](api/ownable#Ownable-_unsafeTransferOwnership) and [_unsafeUncheckedTransferOwnership](api/ownable#Ownable-_unsafeUncheckedTransferOwnership)).
+This module offers experimental circuits that allow ownership to be granted to contract addresses ([_unsafeTransferOwnership](/contracts-compact/api/ownable#Ownable-_unsafeTransferOwnership) and [_unsafeUncheckedTransferOwnership](/contracts-compact/api/ownable#Ownable-_unsafeUncheckedTransferOwnership)).
 Note that the circuit names are very explicit ("unsafe") with these experimental circuits.
 Until contract-to-contract calls are supported,
 there is no direct way for a contract to call circuits of other contracts or transfer ownership back to a user.
@@ -52,11 +52,11 @@ export circuit mySensitiveCircuit(): []
   Ownable_assertOnlyOwner();
 
   // Do something
-```
+  ```
 
-Contracts may expose [transferOwnership](api/ownable#Ownable-transferOwnership) to allow the owner to transfer ownership.
+  Contracts may expose [transferOwnership](/contracts-compact/api/ownable#Ownable-transferOwnership) to allow the owner to transfer ownership.
 
-```ts
+  ```ts
 export circuit transferOwnership(newOwner: Either<ZswapCoinPublicKey, ContractAddress>): []
   Ownable_transferOwnership(newOwner);
 ```
@@ -105,8 +105,7 @@ export circuit mySensitiveCircuit(): []
 
   // Do something
 ```
-
 <Callout>
-For more complex logic, contracts may transfer ownership to another user irrespective of the caller by leveraging [_transferOwnership](api/ownable#Ownable-_transferOwnership).
+For more complex logic, contracts may transfer ownership to another user irrespective of the caller by leveraging [_transferOwnership](/contracts-compact/api/ownable#Ownable-_transferOwnership).
 This is generally more useful when contract addresses are the owner or when a contract has a unique deployment process.
 </Callout>

--- a/content/contracts-compact/utils.mdx
+++ b/content/contracts-compact/utils.mdx
@@ -55,7 +55,7 @@ insert calls to assertPaused and assertNotPaused respectively.
 
 ### Usage
 
-For example (using the [Ownable](ownable) module for access control):
+For example (using the [Ownable](/contracts-compact/ownable) module for access control):
 
 ```typescript
 pragma language_version >= 0.16.0;

--- a/content/contracts-stylus/access-control.mdx
+++ b/content/contracts-stylus/access-control.mdx
@@ -102,7 +102,7 @@ Most software uses access control systems that are role-based: some users are re
 OpenZeppelin Contracts provides [`AccessControl`](https://docs.rs/openzeppelin-stylus/0.3.0/openzeppelin_stylus/access/control/struct.AccessControl.html) for implementing role-based access control. Its usage is straightforward: for each role that you want to define,
 you will create a new _role identifier_ that is used to grant, revoke, and check if an account has that role.
 
-Here’s a simple example of using `AccessControl` in an [ERC-20 token](erc20) to define a 'minter' role, which allows accounts that have it create new tokens. Note that the example is unassuming of the way you construct your contract.
+Here’s a simple example of using `AccessControl` in an [ERC-20 token](/contracts-stylus/erc20) to define a 'minter' role, which allows accounts that have it create new tokens. Note that the example is unassuming of the way you construct your contract.
 
 ```rust
 use openzeppelin_stylus::{

--- a/content/contracts-stylus/beacon-proxy.mdx
+++ b/content/contracts-stylus/beacon-proxy.mdx
@@ -327,6 +327,6 @@ Beacon proxies are particularly useful for:
 
 ## Related Patterns
 
-* [Basic proxy](proxy): Basic proxy pattern using `delegate_call` for upgradeable contracts.
-* [Beacon Proxy](beacon-proxy): Multiple proxies pointing to a single beacon contract for mass upgrades of the implementation contract address.
-* [UUPS Proxy](uups-proxy): The Universal Upgradeable Proxy Standard (UUPS) that is a minimal and gas-efficient pattern for upgradeable contracts.
+* [Basic proxy](/contracts-stylus/proxy): Basic proxy pattern using `delegate_call` for upgradeable contracts.
+* [Beacon Proxy](/contracts-stylus/beacon-proxy): Multiple proxies pointing to a single beacon contract for mass upgrades of the implementation contract address.
+* [UUPS Proxy](/contracts-stylus/uups-proxy): The Universal Upgradeable Proxy Standard (UUPS) that is a minimal and gas-efficient pattern for upgradeable contracts.

--- a/content/contracts-stylus/erc1155-burnable.mdx
+++ b/content/contracts-stylus/erc1155-burnable.mdx
@@ -2,7 +2,7 @@
 title: ERC-1155 Burnable
 ---
 
-Extension of [ERC-1155](erc1155) that allows token holders to destroy both their
+Extension of [ERC-1155](/contracts-stylus/erc1155) that allows token holders to destroy both their
 own tokens and those that they have been approved to use.
 
 ## Usage

--- a/content/contracts-stylus/erc1155-metadata-uri.mdx
+++ b/content/contracts-stylus/erc1155-metadata-uri.mdx
@@ -2,13 +2,13 @@
 title: ERC-1155 Metadata URI
 ---
 
-The OpenZeppelin [ERC-1155](erc1155) Metadata URI extension is needed to manage and store URIs for individual tokens. This extension allows each token to have its own unique URI,
+The OpenZeppelin [ERC-1155](/contracts-stylus/erc1155) Metadata URI extension is needed to manage and store URIs for individual tokens. This extension allows each token to have its own unique URI,
 which points to a JSON file that conforms to the [ERC-1155 Metadata URI JSON Schema](https://eips.ethereum.org/EIPS/eip-1155#erc-1155-metadata-uri-json-schema).
 This is particularly useful for non-fungible tokens (NFTs) where each token is unique and may have different metadata.
 
 ## Usage
 
-In order to make an [ERC-1155](erc1155) token with [Metadata URI](https://docs.rs/openzeppelin-stylus/0.3.0/openzeppelin_stylus/token/erc1155/extensions/metadata_uri/index.html) flavour,
+In order to make an [ERC-1155](/contracts-stylus/erc1155) token with [Metadata URI](https://docs.rs/openzeppelin-stylus/0.3.0/openzeppelin_stylus/token/erc1155/extensions/metadata_uri/index.html) flavour,
 you need to add the following code to your contract:
 
 ```rust

--- a/content/contracts-stylus/erc1155-pausable.mdx
+++ b/content/contracts-stylus/erc1155-pausable.mdx
@@ -2,13 +2,13 @@
 title: ERC-1155 Pausable
 ---
 
-[ERC-1155](erc1155) token with pausable token transfers, minting, and burning.
+[ERC-1155](/contracts-stylus/erc1155) token with pausable token transfers, minting, and burning.
 
 Useful for scenarios such as preventing trades until the end of an evaluation period, or having an emergency switch for freezing all token transfers in the event of a large bug.
 
 ## Usage
 
-In order to make your [ERC-1155](erc1155) token `pausable`, you need to use the [`Pausable`](https://docs.rs/openzeppelin-stylus/0.3.0/openzeppelin_stylus/utils/pausable/index.html) contract and apply its mechanisms to ERC1155 token functions as follows:
+In order to make your [ERC-1155](/contracts-stylus/erc1155) token `pausable`, you need to use the [`Pausable`](https://docs.rs/openzeppelin-stylus/0.3.0/openzeppelin_stylus/utils/pausable/index.html) contract and apply its mechanisms to ERC1155 token functions as follows:
 
 ```rust
 use openzeppelin_stylus::{

--- a/content/contracts-stylus/erc1155-supply.mdx
+++ b/content/contracts-stylus/erc1155-supply.mdx
@@ -2,12 +2,12 @@
 title: ERC-1155 Supply
 ---
 
-The OpenZeppelin [ERC-1155](erc1155) Supply extension that adds tracking of total supply per token id.
+The OpenZeppelin [ERC-1155](/contracts-stylus/erc1155) Supply extension that adds tracking of total supply per token id.
 Useful for scenarios where Fungible and Non-fungible tokens have to be clearly identified.
 
 ## Usage
 
-In order to make an [ERC-1155](erc1155) token with [Supply](https://docs.rs/openzeppelin-stylus/0.3.0/openzeppelin_stylus/token/erc1155/extensions/supply/index.html) flavour,
+In order to make an [ERC-1155](/contracts-stylus/erc1155) token with [Supply](https://docs.rs/openzeppelin-stylus/0.3.0/openzeppelin_stylus/token/erc1155/extensions/supply/index.html) flavour,
 you need to reexport all the supply-related functions.
 Make sure to apply the `#[selector(name = "totalSupply")]` attribute to the `total_supply_all` function!
 You need to create the specified contract as follows:

--- a/content/contracts-stylus/erc1155-uri-storage.mdx
+++ b/content/contracts-stylus/erc1155-uri-storage.mdx
@@ -2,13 +2,13 @@
 title: ERC-1155 URI Storage
 ---
 
-The OpenZeppelin [ERC-1155](erc1155) URI Storage extension is needed to manage and store URIs for individual tokens. This extension allows each token to have its own unique URI,
+The OpenZeppelin [ERC-1155](/contracts-stylus/erc1155) URI Storage extension is needed to manage and store URIs for individual tokens. This extension allows each token to have its own unique URI,
 which can point to metadata about the token, such as images, descriptions, and other attributes.
 This is particularly useful for non-fungible tokens (NFTs) where each token is unique and may have different metadata.
 
 ## Usage
 
-In order to make an [ERC-1155](erc1155) token with [URI Storage](https://docs.rs/openzeppelin-stylus/0.3.0/openzeppelin_stylus/token/erc1155/extensions/uri_storage/index.html) flavour,
+In order to make an [ERC-1155](/contracts-stylus/erc1155) token with [URI Storage](https://docs.rs/openzeppelin-stylus/0.3.0/openzeppelin_stylus/token/erc1155/extensions/uri_storage/index.html) flavour,
 your token should also use [`ERC-1155 Metadata URI`](https://docs.rs/openzeppelin-stylus/0.3.0/openzeppelin_stylus/token/erc1155/extensions/metadata_uri/index.html) extension to provide additional URI metadata for each token.
 You need to create a specified contract as follows:
 

--- a/content/contracts-stylus/erc1155.mdx
+++ b/content/contracts-stylus/erc1155.mdx
@@ -8,8 +8,8 @@ ERC1155 is a novel token standard that aims to take the best from previous stand
 
 Additionally, there are multiple custom extensions, including:
 
-* [ERC-1155 Burnable](erc1155-burnable): Optional Burnable extension of the ERC-1155 standard.
-* [ERC-1155 Metadata URI](erc1155-metadata-uri): Optional extension that adds a token metadata URI.
-* [ERC-1155 Pausable](erc1155-pausable): A primitive to pause contract operation like token transfers, minting and burning.
-* [ERC-1155 URI Storage](erc1155-uri-storage): A more flexible but more expensive way of storing URI metadata.
-* [ERC-1155 Supply](erc1155-supply): Extension of the ERC-1155 standard that adds tracking of total supply per token id.
+* [ERC-1155 Burnable](/contracts-stylus/erc1155-burnable): Optional Burnable extension of the ERC-1155 standard.
+* [ERC-1155 Metadata URI](/contracts-stylus/erc1155-metadata-uri): Optional extension that adds a token metadata URI.
+* [ERC-1155 Pausable](/contracts-stylus/erc1155-pausable): A primitive to pause contract operation like token transfers, minting and burning.
+* [ERC-1155 URI Storage](/contracts-stylus/erc1155-uri-storage): A more flexible but more expensive way of storing URI metadata.
+* [ERC-1155 Supply](/contracts-stylus/erc1155-supply): Extension of the ERC-1155 standard that adds tracking of total supply per token id.

--- a/content/contracts-stylus/erc1967.mdx
+++ b/content/contracts-stylus/erc1967.mdx
@@ -271,6 +271,6 @@ struct MyToken {
 
 ## Related Patterns
 
-* [Basic Proxy](proxy): Basic proxy pattern using `delegate_call` for upgradeable contracts.
-* [Beacon Proxy](beacon-proxy): Multiple proxies pointing to a single beacon contract for mass upgrades of the implementation contract address.
-* [UUPS Proxy](uups-proxy): The Universal Upgradeable Proxy Standard (UUPS) that is a minimal and gas-efficient pattern for upgradeable contracts.
+* [Basic Proxy](/contracts-stylus/proxy): Basic proxy pattern using `delegate_call` for upgradeable contracts.
+* [Beacon Proxy](/contracts-stylus/beacon-proxy): Multiple proxies pointing to a single beacon contract for mass upgrades of the implementation contract address.
+* [UUPS Proxy](/contracts-stylus/uups-proxy): The Universal Upgradeable Proxy Standard (UUPS) that is a minimal and gas-efficient pattern for upgradeable contracts.

--- a/content/contracts-stylus/erc20-burnable.mdx
+++ b/content/contracts-stylus/erc20-burnable.mdx
@@ -2,11 +2,11 @@
 title: ERC-20 Burnable
 ---
 
-Extension of [ERC-20](erc20) that allows token holders to destroy both their own tokens and those that they have an allowance for, in a way that can be recognized off-chain (via event analysis).
+Extension of [ERC-20](/contracts-stylus/erc20) that allows token holders to destroy both their own tokens and those that they have an allowance for, in a way that can be recognized off-chain (via event analysis).
 
 ## Usage
 
-In order to make [`ERC-20 Burnable`](https://docs.rs/openzeppelin-stylus/0.3.0/openzeppelin_stylus/token/erc20/extensions/burnable/index.html) methods “external” so that other contracts can call them, you need to implement them by yourself for your final contract as follows:
+In order to make [`ERC-20 Burnable`](https://docs.rs/openzeppelin-stylus/0.3.0/openzeppelin_stylus/token/erc20/extensions/burnable/index.html) methods "external" so that other contracts can call them, you need to implement them by yourself for your final contract as follows:
 
 ```rust
 use openzeppelin_stylus::token::erc20::{

--- a/content/contracts-stylus/erc20-capped.mdx
+++ b/content/contracts-stylus/erc20-capped.mdx
@@ -2,7 +2,7 @@
 title: ERC-20 Capped
 ---
 
-Extension of [ERC-20](erc20) that adds a cap to the supply of tokens.
+Extension of [ERC-20](/contracts-stylus/erc20) that adds a cap to the supply of tokens.
 
 ## Usage
 

--- a/content/contracts-stylus/erc20-flash-mint.mdx
+++ b/content/contracts-stylus/erc20-flash-mint.mdx
@@ -2,11 +2,11 @@
 title: ERC-20 Flash Mint
 ---
 
-Extension of [ERC-20](erc20) that provides flash loan support at the token level.
+Extension of [ERC-20](/contracts-stylus/erc20) that provides flash loan support at the token level.
 
 ## Usage
 
-In order to make [`ERC-20 Flash Mint`](https://docs.rs/openzeppelin-stylus/0.3.0/openzeppelin_stylus/token/erc20/extensions/flash_mint/index.html)  methods “external” so that other contracts can call them, you need to add the following code to your contract:
+In order to make [`ERC-20 Flash Mint`](https://docs.rs/openzeppelin-stylus/0.3.0/openzeppelin_stylus/token/erc20/extensions/flash_mint/index.html)  methods "external" so that other contracts can call them, you need to add the following code to your contract:
 
 ```rust
 use openzeppelin_stylus::token::erc20::{

--- a/content/contracts-stylus/erc20-metadata.mdx
+++ b/content/contracts-stylus/erc20-metadata.mdx
@@ -2,11 +2,11 @@
 title: ERC-20 Metadata
 ---
 
-Extension of [ERC-20](erc20) that adds the optional metadata functions from the ERC20 standard.
+Extension of [ERC-20](/contracts-stylus/erc20) that adds the optional metadata functions from the ERC20 standard.
 
 ## Usage
 
-In order to make [`ERC-20 Metadata`](https://docs.rs/openzeppelin-stylus/0.3.0/openzeppelin_stylus/token/erc20/extensions/metadata/index.html)  methods “external” so that other contracts can call them, you need to add the following code to your contract:
+In order to make [`ERC-20 Metadata`](https://docs.rs/openzeppelin-stylus/0.3.0/openzeppelin_stylus/token/erc20/extensions/metadata/index.html)  methods "external" so that other contracts can call them, you need to add the following code to your contract:
 
 ```rust
 use openzeppelin_stylus::{

--- a/content/contracts-stylus/erc20-pausable.mdx
+++ b/content/contracts-stylus/erc20-pausable.mdx
@@ -8,7 +8,7 @@ Useful for scenarios such as preventing trades until the end of an evaluation pe
 
 ## Usage
 
-In order to make your ERC20 token `pausable`, you need to use the [`Pausable`](https://docs.rs/openzeppelin-stylus/0.3.0/openzeppelin_stylus/utils/pausable/index.html) contract and apply its mechanisms to ERC20 token functions as follows:
+In order to make your ERC20 token `pausable`, you need to use the [`Pausable`](/contracts-stylus/api/utils#pausable) contract and apply its mechanisms to ERC20 token functions as follows:
 
 ```rust
 use openzeppelin_stylus::{

--- a/content/contracts-stylus/erc20-permit.mdx
+++ b/content/contracts-stylus/erc20-permit.mdx
@@ -2,11 +2,11 @@
 title: ERC-20 Permit
 ---
 
-Adds the permit method, which can be used to change an account’s ERC20 allowance (see [`IErc20::allowance`](https://docs.rs/openzeppelin-stylus/0.3.0/openzeppelin_stylus/token/erc20/trait.IErc20.html#tymethod.allowance)) by presenting a message signed by the account. By not relying on [`IErc20::approve`](https://docs.rs/openzeppelin-stylus/0.3.0/openzeppelin_stylus/token/erc20/trait.IErc20.html#tymethod.approve), the token holder account doesn’t need to send a transaction, and thus is not required to hold Ether at all.
+Adds the permit method, which can be used to change an account's ERC20 allowance (see [`IErc20::allowance`](https://docs.rs/openzeppelin-stylus/0.3.0/openzeppelin_stylus/token/erc20/trait.IErc20.html#tymethod.allowance)) by presenting a message signed by the account. By not relying on [`IErc20::approve`](https://docs.rs/openzeppelin-stylus/0.3.0/openzeppelin_stylus/token/erc20/trait.IErc20.html#tymethod.approve), the token holder account doesn't need to send a transaction, and thus is not required to hold Ether at all.
 
 ## Usage
 
-In order to have [`ERC-20 Permit`](https://docs.rs/openzeppelin-stylus/0.3.0/openzeppelin_stylus/token/erc20/extensions/permit/index.html) token, you need to use only this contract without [ERC-20](erc20) as follows:
+In order to have [`ERC-20 Permit`](https://docs.rs/openzeppelin-stylus/0.3.0/openzeppelin_stylus/token/erc20/extensions/permit/index.html) token, you need to use only this contract without [ERC-20](/contracts-stylus/erc20) as follows:
 
 ```rust
 use openzeppelin_stylus::{

--- a/content/contracts-stylus/erc20.mdx
+++ b/content/contracts-stylus/erc20.mdx
@@ -2,11 +2,11 @@
 title: ERC-20
 ---
 
-An ERC-20 token contract keeps track of [_fungible_ tokens](tokens#different-kinds-of-tokens): any token is exactly equal to any other token; no token has a special right or behavior associated with them.
+An ERC-20 token contract keeps track of [_fungible_ tokens](/contracts-stylus/tokens#different-kinds-of-tokens): any token is exactly equal to any other token; no token has a special right or behavior associated with them.
 This makes ERC-20 tokens useful for things like a **medium of exchange currency**, **voting rights**, **staking**, and more.
 
 OpenZeppelin Contracts provide many ERC20-related contracts for Arbitrum Stylus.
-On the [`API reference`](https://docs.rs/openzeppelin-stylus/0.3.0/openzeppelin_stylus/token/erc20/struct.Erc20.html) you’ll find detailed information on their properties and usage.
+On the [`API reference`](https://docs.rs/openzeppelin-stylus/0.3.0/openzeppelin_stylus/token/erc20/struct.Erc20.html) you'll find detailed information on their properties and usage.
 
 ## Constructing an ERC-20 Token Contract
 
@@ -107,7 +107,7 @@ impl IErc165 for GLDToken {
 }
 ```
 
-Our contracts are often used via stylus-sdk [inheritance](https://docs.arbitrum.io/stylus/reference/rust-sdk-guide#inheritance-inherit-and-borrow), and here we’re reusing [`ERC20`](https://docs.rs/openzeppelin-stylus/0.3.0/openzeppelin_stylus/token/erc20/struct.Erc20.html) for both the basic standard implementation and with optional extensions.
+Our contracts are often used via stylus-sdk [inheritance](https://docs.arbitrum.io/stylus/reference/rust-sdk-guide#inheritance-inherit-and-borrow), and here we're reusing [`ERC20`](https://docs.rs/openzeppelin-stylus/0.3.0/openzeppelin_stylus/token/erc20/struct.Erc20.html) for both the basic standard implementation and with optional extensions.
 
 ## A Note on `decimals`
 
@@ -117,7 +117,6 @@ You may send `1` or `2` tokens, but not `1.5`.
 
 To work around this, ERC20 provides a [`decimals`](https://docs.rs/openzeppelin-stylus/0.3.0/openzeppelin_stylus/token/erc20/extensions/metadata/trait.IErc20Metadata.html#tymethod.decimals) field, which is used to specify how many decimal places a token has.
 To be able to transfer `1.5 GLD`, `decimals` must be at least `1`, since that number has a single decimal place.
-
 How can this be achieved?
 It’s actually very simple: a token contract can use larger integer values, so that a balance of `50` will represent `5 GLD`, a transfer of `15` will correspond to `1.5 GLD` being sent, and so on.
 
@@ -149,11 +148,11 @@ token.transfer(recipient, 5 * uint!(10_U256).pow(uint!(18_U256)));
 ## Extensions
 Additionally, there are multiple custom extensions, including:
 
-* [ERC-20 Burnable](erc20-burnable): destruction of own tokens.
-* [ERC-20 Capped](erc20-capped): enforcement of a cap to the total supply when minting tokens.
-* [ERC-20 Metadata](erc20-metadata): the extended ERC20 interface including the name, symbol, and decimals functions.
-* [ERC-20 Pausable](erc20-pausable): ability to pause token transfers.
-* [ERC-20 Permit](erc20-permit): gasless approval of tokens (standardized as [`EIP-2612`](https://eips.ethereum.org/EIPS/eip-2612)).
-* [ERC-4626](erc4626): tokenized vault that manages shares (represented as ERC-20) that are backed by assets (another ERC-20).
-* [ERC-20 Flash-Mint](erc20-flash-mint): token level support for flash loans through the minting and burning of ephemeral tokens (standardized as [`EIP-3156`](https://eips.ethereum.org/EIPS/eip-3156)).
-* [ERC-20 Wrapper](erc20-wrapper): wrapper to create an ERC-20 backed by another ERC-20, with deposit and withdraw methods.
+* [ERC-20 Burnable](/contracts-stylus/erc20-burnable): destruction of own tokens.
+* [ERC-20 Capped](/contracts-stylus/erc20-capped): enforcement of a cap to the total supply when minting tokens.
+* [ERC-20 Metadata](/contracts-stylus/erc20-metadata): the extended ERC20 interface including the name, symbol, and decimals functions.
+* [ERC-20 Pausable](/contracts-stylus/erc20-pausable): ability to pause token transfers.
+* [ERC-20 Permit](/contracts-stylus/erc20-permit): gasless approval of tokens (standardized as [`EIP-2612`](https://eips.ethereum.org/EIPS/eip-2612)).
+* [ERC-4626](/contracts-stylus/erc4626): tokenized vault that manages shares (represented as ERC-20) that are backed by assets (another ERC-20).
+* [ERC-20 Flash-Mint](/contracts-stylus/erc20-flash-mint): token level support for flash loans through the minting and burning of ephemeral tokens (standardized as [`EIP-3156`](https://eips.ethereum.org/EIPS/eip-3156)).
+* [ERC-20 Wrapper](/contracts-stylus/erc20-wrapper): wrapper to create an ERC-20 backed by another ERC-20, with deposit and withdraw methods.

--- a/content/contracts-stylus/erc4626.mdx
+++ b/content/contracts-stylus/erc4626.mdx
@@ -7,11 +7,11 @@ Implementation of the ERC-4626 "Tokenized Vault Standard" as defined in [ERC-462
 This extension allows the minting and burning of "shares" (represented using the ERC-20 inheritance) in exchange for underlying "assets" through standardized `deposit`, `mint`, `redeem` and `burn` workflows. This contract extends the ERC-20 standard. Any additional extensions included along it would affect the "shares" token represented by this contract and not the "assets" token which is an independent contract.
 
 ## Security concern: Inflation attack
-To read more about the security concerns associated with the ERC-4626, check the [Inflation attack](https://docs.openzeppelin.com/contracts/5.x/erc4626#inflation-attack) description.
+To read more about the security concerns associated with the ERC-4626, check the [Inflation attack](/contracts-stylus/docs.openzeppelin.com/contracts/5.x/erc4626#inflation-attack) description.
 
 ## Usage
 
-In order to make [`ERC-4626`](https://docs.rs/openzeppelin-stylus/0.3.0/openzeppelin_stylus/token/erc20/extensions/erc4626/index.html) methods “external” so that other contracts can call them, you need to implement them by yourself for your final contract as follows:
+In order to make [`ERC-4626`](/contracts-stylus/docs.rs/openzeppelin-stylus/0.3.0/openzeppelin_stylus/token/erc20/extensions/erc4626/index.html) methods "external" so that other contracts can call them, you need to implement them by yourself for your final contract as follows:
 
 ```rust
 use openzeppelin_stylus::{

--- a/content/contracts-stylus/erc721-burnable.mdx
+++ b/content/contracts-stylus/erc721-burnable.mdx
@@ -2,11 +2,11 @@
 title: ERC-721 Burnable
 ---
 
-[ERC-721](erc721) Token that can be burned (destroyed).
+[ERC-721](/contracts-stylus/erc721) Token that can be burned (destroyed).
 
 ## Usage
 
-In order to make [`ERC-721 Burnable`](https://docs.rs/openzeppelin-stylus/0.3.0/openzeppelin_stylus/token/erc721/extensions/burnable/index.html) methods “external” so that other contracts can call them, you need to implement them by yourself for your final contract as follows:
+In order to make [`ERC-721 Burnable`](https://docs.rs/openzeppelin-stylus/0.3.0/openzeppelin_stylus/token/erc721/extensions/burnable/index.html) methods "external" so that other contracts can call them, you need to implement them by yourself for your final contract as follows:
 
 ```rust
 use openzeppelin_stylus::{

--- a/content/contracts-stylus/erc721-consecutive.mdx
+++ b/content/contracts-stylus/erc721-consecutive.mdx
@@ -2,11 +2,11 @@
 title: ERC-721 Consecutive
 ---
 
-Consecutive extension for [ERC-721](erc721) is useful for efficiently minting multiple tokens in a single transaction. This can significantly reduce gas costs and improve performance when creating a large number of tokens at once.
+Consecutive extension for [ERC-721](/contracts-stylus/erc721) is useful for efficiently minting multiple tokens in a single transaction. This can significantly reduce gas costs and improve performance when creating a large number of tokens at once.
 
 ## Usage
 
-In order to make [`ERC-721 Consecutive`](https://docs.rs/openzeppelin-stylus/0.3.0/openzeppelin_stylus/token/erc721/extensions/consecutive/index.html) methods “external” so that other contracts can call them, you need to add the following code to your contract:
+In order to make [`ERC-721 Consecutive`](https://docs.rs/openzeppelin-stylus/0.3.0/openzeppelin_stylus/token/erc721/extensions/consecutive/index.html) methods "external" so that other contracts can call them, you need to add the following code to your contract:
 
 ```rust
 use openzeppelin_stylus::{

--- a/content/contracts-stylus/erc721-enumerable.mdx
+++ b/content/contracts-stylus/erc721-enumerable.mdx
@@ -2,13 +2,12 @@
 title: ERC-721 Enumerable
 ---
 
-The OpenZeppelin [ERC-721](erc721) Enumerable extension is used to provide additional functionality to the standard ERC-721 token. Specifically, it allows for enumeration of all the token IDs in the contract as well as all the token IDs owned by each account. This is useful for applications that need to list or iterate over tokens, such as marketplaces or wallets.
+The OpenZeppelin [ERC-721](/contracts-stylus/erc721) Enumerable extension is used to provide additional functionality to the standard ERC-721 token. Specifically, it allows for enumeration of all the token IDs in the contract as well as all the token IDs owned by each account. This is useful for applications that need to list or iterate over tokens, such as marketplaces or wallets.
 
 ## Usage
 
-In order to make an [ERC-721](erc721) token with [Enumerable](https://docs.rs/openzeppelin-stylus/0.3.0/openzeppelin_stylus/token/erc721/extensions/enumerable/index.html) flavour,
+In order to make an [ERC-721](/contracts-stylus/erc721) token with [Enumerable](https://docs.rs/openzeppelin-stylus/0.3.0/openzeppelin_stylus/token/erc721/extensions/enumerable/index.html) flavour,
 you need to create a specified contract as follows:
-
 ```rust
 use openzeppelin_stylus::{
     token::erc721::{

--- a/content/contracts-stylus/erc721-metadata.mdx
+++ b/content/contracts-stylus/erc721-metadata.mdx
@@ -2,7 +2,7 @@
 title: ERC-721 Metadata
 ---
 
-Extension of [ERC-721](erc721) that adds the optional metadata functions from the ERC721 standard.
+Extension of [ERC-721](/contracts-stylus/erc721) that adds the optional metadata functions from the ERC721 standard.
 
 ## Usage
 

--- a/content/contracts-stylus/erc721-pausable.mdx
+++ b/content/contracts-stylus/erc721-pausable.mdx
@@ -8,7 +8,7 @@ Useful for scenarios such as preventing trades until the end of an evaluation pe
 
 ## Usage
 
-In order to make your ERC721 token `pausable`, you need to use the [`Pausable`](https://docs.rs/openzeppelin-stylus/0.3.0/openzeppelin_stylus/utils/pausable/index.html) contract and apply its mechanisms to ERC721 token functions as follows:
+In order to make your ERC721 token `pausable`, you need to use the [`Pausable`](/contracts-stylus/api/utils#pausable) contract and apply its mechanisms to ERC721 token functions as follows:
 
 ```rust
 use openzeppelin_stylus::{

--- a/content/contracts-stylus/erc721-uri-storage.mdx
+++ b/content/contracts-stylus/erc721-uri-storage.mdx
@@ -2,16 +2,15 @@
 title: ERC-721 Uri Storage
 ---
 
-The OpenZeppelin [ERC-721](erc721) URI Storage extension is needed to manage and store URIs for individual tokens. This extension allows each token to have its own unique URI,
+The OpenZeppelin [ERC-721](/contracts-stylus/erc721) URI Storage extension is needed to manage and store URIs for individual tokens. This extension allows each token to have its own unique URI,
 which can point to metadata about the token, such as images, descriptions, and other attributes.
 This is particularly useful for non-fungible tokens (NFTs) where each token is unique and may have different metadata.
 
 ## Usage
 
-In order to make an [ERC-721](erc721) token with [URI Storage](https://docs.rs/openzeppelin-stylus/0.3.0/openzeppelin_stylus/token/erc721/extensions/uri_storage/index.html) flavour,
+In order to make an [ERC-721](/contracts-stylus/erc721) token with [URI Storage](https://docs.rs/openzeppelin-stylus/0.3.0/openzeppelin_stylus/token/erc721/extensions/uri_storage/index.html) flavour,
 your token should also use [`ERC-721 Metadata`](https://docs.rs/openzeppelin-stylus/0.3.0/openzeppelin_stylus/token/erc721/extensions/metadata/index.html) extension to provide additional metadata for each token.
 You need to create a specified contract as follows:
-
 ```rust
 use openzeppelin_stylus::{
     token::erc721::{

--- a/content/contracts-stylus/erc721-wrapper.mdx
+++ b/content/contracts-stylus/erc721-wrapper.mdx
@@ -9,7 +9,7 @@ This is useful in conjunction with other modules.
 
 ## Usage
 
-In order to make [`ERC721Wrapper`](https://docs.rs/openzeppelin-stylus/0.3.0/openzeppelin_stylus/token/erc721/extensions/wrapper/index.html) methods “external” so that other contracts can call them, you need to implement them by yourself for your final contract as follows:
+In order to make [`ERC721Wrapper`](/contracts-stylus/api/token#erc721wrapper) methods "external" so that other contracts can call them, you need to implement them by yourself for your final contract as follows:
 
 ```rust
 use openzeppelin_stylus::{

--- a/content/contracts-stylus/erc721.mdx
+++ b/content/contracts-stylus/erc721.mdx
@@ -2,9 +2,9 @@
 title: ERC-721
 ---
 
-We’ve discussed how you can make a _fungible_ token using [ERC-20](erc20), but what if not all tokens are alike?
+We've discussed how you can make a _fungible_ token using [ERC-20](/contracts-stylus/erc20), but what if not all tokens are alike?
 This comes up in situations like **real estate**, **voting rights**, or **collectibles**, where some items are valued more than others, due to their usefulness, rarity, etc.
-ERC-721 is a standard for representing ownership of [_non-fungible_ tokens](tokens#different-kinds-of-tokens), that is, where each token is unique.
+ERC-721 is a standard for representing ownership of [_non-fungible_ tokens](/contracts-stylus/tokens#different-kinds-of-tokens), that is, where each token is unique.
 
 ERC-721 is a more complex standard than ERC-20, with multiple optional extensions, and is split across a number of contracts.
 The OpenZeppelin Contracts provide flexibility regarding how these are combined, along with custom useful extensions.
@@ -17,9 +17,9 @@ Whenever one is to be awarded to a player, it will be minted and sent to them.
 Players are free to keep their token or trade it with other people as they see fit, as they would any other asset on the blockchain!
 Please note any account can call `awardItem` to mint items.
 To restrict what accounts can be minted per item.
-We can use an [Access Control](access-control) extension.
+We can use an [Access Control](/contracts-stylus/access-control) extension.
 
-Here’s what a contract for tokenized items might look like:
+Here's what a contract for tokenized items might look like:
 
 ```rust
 use openzeppelin_stylus::{
@@ -166,10 +166,10 @@ So a game developer could change the underlying metadata, changing the rules of 
 
 Additionally, there are multiple custom extensions, including:
 
-* [ERC-721 Burnable](erc721-burnable): A way for token holders to burn their own tokens.
-* [ERC-721 Consecutive](erc721-consecutive): An implementation of [ERC2309](https://eips.ethereum.org/EIPS/eip-2309) for minting batches of tokens during construction, in accordance with ERC721.
-* [ERC-721 Enumerable](erc721-enumerable): Optional extension that allows enumerating the tokens on chain, often not included since it requires large gas overhead.
-* [ERC-721 Metadata](erc721-metadata): Optional extension that adds name, symbol, and token URI, almost always included.
-* [ERC-721 Pausable](erc721-pausable): A primitive to pause contract operation.
-* [ERC-721 Uri Storage](erc721-uri-storage): A more flexible but more expensive way of storing metadata.
-* [ERC-721 Wrapper](erc721-wrapper): Wrapper to create an ERC-721 backed by another ERC-721, with deposit and withdraw methods.
+* [ERC-721 Burnable](/contracts-stylus/erc721-burnable): A way for token holders to burn their own tokens.
+* [ERC-721 Consecutive](/contracts-stylus/erc721-consecutive): An implementation of [ERC2309](https://eips.ethereum.org/EIPS/eip-2309) for minting batches of tokens during construction, in accordance with ERC721.
+* [ERC-721 Enumerable](/contracts-stylus/erc721-enumerable): Optional extension that allows enumerating the tokens on chain, often not included since it requires large gas overhead.
+* [ERC-721 Metadata](/contracts-stylus/erc721-metadata): Optional extension that adds name, symbol, and token URI, almost always included.
+* [ERC-721 Pausable](/contracts-stylus/erc721-pausable): A primitive to pause contract operation.
+* [ERC-721 Uri Storage](/contracts-stylus/erc721-uri-storage): A more flexible but more expensive way of storing metadata.
+* [ERC-721 Wrapper](/contracts-stylus/erc721-wrapper): Wrapper to create an ERC-721 backed by another ERC-721, with deposit and withdraw methods.

--- a/content/contracts-stylus/finance.mdx
+++ b/content/contracts-stylus/finance.mdx
@@ -5,7 +5,7 @@ title: Finance
 Contracts that include primitives for financial systems.
 
 ## VestingWallet
-* [VestingWallet](vesting-wallet) handles the vesting of Ether and ERC-20
+* [VestingWallet](/contracts-stylus/vesting-wallet) handles the vesting of Ether and ERC-20
   tokens for a given beneficiary. Custody of multiple tokens can be given to this
   contract, which will release the token to the beneficiary following a given,
   customizable, vesting schedule.

--- a/content/contracts-stylus/index.mdx
+++ b/content/contracts-stylus/index.mdx
@@ -4,7 +4,7 @@ title: OpenZeppelin Contracts for Stylus
 
 **A secure, modular smart contract library for [Stylus](https://docs.arbitrum.io/stylus/gentle-introduction), written in Rust.**
 
-OpenZeppelin Contracts for Stylus brings time-tested smart contract patterns to Arbitrum’s WASM-based execution environment. This library provides `no_std`-compatible modules for building secure, reusable contracts in [Stylus](https://docs.arbitrum.io/stylus/gentle-introduction).
+OpenZeppelin Contracts for Stylus brings time-tested smart contract patterns to Arbitrum's WASM-based execution environment. This library provides `no_std`-compatible modules for building secure, reusable contracts in [Stylus](https://docs.arbitrum.io/stylus/gentle-introduction).
 
 ## Features
 
@@ -42,7 +42,7 @@ use stylus_sdk::
 
 #[entrypoint]
 #[storage]
-struct Erc20Example 
+struct Erc20Example
     erc20: Erc20,
 
 
@@ -51,7 +51,7 @@ struct Erc20Example
 impl Erc20Example {}
 
 #[public]
-impl IErc20 for Erc20Example 
+impl IErc20 for Erc20Example
     // ERC-20 logic implementation...
 
 ```
@@ -64,7 +64,7 @@ This library is designed to work with `no_std`. To keep your contracts compatibl
 
 ```toml
 [dependencies]
-alloy-primitives =  version = "=0.8.20", default-features = false 
+alloy-primitives =  version = "=0.8.20", default-features = false
 stylus-sdk = "=0.9.0"
 ```
 
@@ -72,7 +72,7 @@ stylus-sdk = "=0.9.0"
 
 See what’s planned or in development in our [roadmap](https://github.com/orgs/OpenZeppelin/projects/35).
 
-Interested in contributing? Read the [contribution guide](https://github.com/OpenZeppelin/rust-contracts-stylus/blob/main/CONTRIBUTING.md).
+Interested in contributing? Read the [contribution guide](/contracts-stylus/CONTRIBUTING.md).
 
 ## Security
 

--- a/content/contracts-stylus/proxy.mdx
+++ b/content/contracts-stylus/proxy.mdx
@@ -254,11 +254,10 @@ By structuring your proxy’s storage this way, you ensure that both the proxy a
 
 ## Common Pitfalls
 
-* ***Storage collisions***: Ensure proxy and implementation storage don’t conflict.
+* ***Storage collisions***: Ensure proxy and implementation storage don't conflict.
 * ***Missing validation***: Always validate implementation addresses.
 * ***Incorrect delegatecall usage***: The proxy must use [`delegate_call`](https://docs.rs/stylus-sdk/0.9.0/stylus_sdk/call/fn.delegate_call.html), not [`call`](https://docs.rs/stylus-sdk/0.9.0/stylus_sdk/call/fn.call.html).
 * ***Forgetting to implement IProxy***: The trait must be implemented for the fallback to work.
-
 ## Working Example
 
 A complete working example of the basic proxy pattern can be found in the repository at `examples/proxy/`. This example demonstrates:
@@ -270,6 +269,6 @@ A complete working example of the basic proxy pattern can be found in the reposi
 
 ## Related Patterns
 
-* [ERC-1967 Proxy](erc1967): A standardized proxy pattern with specific storage slots.
-* [Beacon Proxy](beacon-proxy): Multiple proxies pointing to a single beacon contract for mass upgrades of the implementation contract address.
-* [UUPS Proxy](uups-proxy): The Universal Upgradeable Proxy Standard (UUPS) that is a minimal and gas-efficient pattern for upgradeable contracts.
+* [ERC-1967 Proxy](/contracts-stylus/erc1967): A standardized proxy pattern with specific storage slots.
+* [Beacon Proxy](/contracts-stylus/beacon-proxy): Multiple proxies pointing to a single beacon contract for mass upgrades of the implementation contract address.
+* [UUPS Proxy](/contracts-stylus/uups-proxy): The Universal Upgradeable Proxy Standard (UUPS) that is a minimal and gas-efficient pattern for upgradeable contracts.

--- a/content/contracts-stylus/tokens.mdx
+++ b/content/contracts-stylus/tokens.mdx
@@ -24,8 +24,8 @@ In a nutshell, when dealing with non-fungibles (like your house) you care about 
 
 Even though the concept of a token is simple, they have a variety of complexities in the implementation. Because everything in Ethereum is just a smart contract, and there are no rules about what smart contracts have to do, the community has developed a variety of **standards** (called EIPs or ERCs) for documenting how a contract can interoperate with other contracts.
 
-You’ve probably heard of the ERC-20, ERC-721 or ERC-1155 token standards, and that’s why you’re here. Head to our specialized guides to learn more about these:
+You've probably heard of the ERC-20, ERC-721 or ERC-1155 token standards, and that's why you're here. Head to our specialized guides to learn more about these:
 
-* [ERC-20](erc20): the most widespread token standard for fungible assets, albeit somewhat limited by its simplicity.
-* [ERC-721](erc721): the de-facto solution for non-fungible tokens, often used for collectibles and games.
-* [ERC-1155](erc1155): a novel standard for multi-tokens, allowing for a single contract to represent multiple fungible and non-fungible tokens, along with batched operations for increased gas efficiency.
+* [ERC-20](/contracts-stylus/erc20): the most widespread token standard for fungible assets, albeit somewhat limited by its simplicity.
+* [ERC-721](/contracts-stylus/erc721): the de-facto solution for non-fungible tokens, often used for collectibles and games.
+* [ERC-1155](/contracts-stylus/erc1155): a novel standard for multi-tokens, allowing for a single contract to represent multiple fungible and non-fungible tokens, along with batched operations for increased gas efficiency.

--- a/content/contracts-stylus/utilities.mdx
+++ b/content/contracts-stylus/utilities.mdx
@@ -8,7 +8,7 @@ Here are some of the more popular ones.
 
 ## Introspection
 
-It’s frequently helpful to know whether a contract supports an interface you’d like to use.
+It's frequently helpful to know whether a contract supports an interface you'd like to use.
 [`ERC-165`](https://eips.ethereum.org/EIPS/eip-165) is a standard that helps do runtime interface detection.
 Contracts for Stylus provides helpers for implementing ERC-165 in your contracts:
 

--- a/content/contracts-stylus/uups-proxy.mdx
+++ b/content/contracts-stylus/uups-proxy.mdx
@@ -1,7 +1,6 @@
 ---
 title: UUPS Proxy
 ---
-
 The Universal Upgradeable Proxy Standard (UUPS) is a minimal and gas-efficient
 pattern for upgradeable contracts. Defined in the [ERC-1822](https://eips.ethereum.org/EIPS/eip-1822)
 specification, UUPS delegates upgrade logic to the implementation contract
@@ -282,6 +281,6 @@ This setup call is run via `delegate_call` during proxy deployment.
 
 ## Related
 
-* [ERC-1967 Proxy](erc1967)
-* [Beacon Proxy](beacon-proxy)
-* [Basic Proxy](proxy)
+* [ERC-1967 Proxy](/contracts-stylus/erc1967)
+* [Beacon Proxy](/contracts-stylus/beacon-proxy)
+* [Basic Proxy](/contracts-stylus/proxy)

--- a/content/contracts-stylus/vesting-wallet.mdx
+++ b/content/contracts-stylus/vesting-wallet.mdx
@@ -17,7 +17,7 @@ an asset timelock that hold tokens for a beneficiary until a specified time.
 <Callout>
 
 
-Since the wallet is [Ownable](access-control#ownership-and-ownable),
+Since the wallet is [Ownable](/contracts-stylus/access-control#ownership-and-ownable),
 and ownership can be transferred, it is possible to sell unvested tokens.
 Preventing this in a smart contract is difficult, considering that: 1) a
 beneficiary address could be a counterfactually deployed contract, 2)

--- a/content/contracts/5.x/api/index.mdx
+++ b/content/contracts/5.x/api/index.mdx
@@ -7,27 +7,23 @@ This API reference is automatically generated from the OpenZeppelin Contracts re
 ## Contract Categories
 
 ### Access Control
-- [Access Control](access.md) - Role-based access control mechanisms
-- [Ownable](access.md#ownable) - Simple ownership access control
+- [Access Control](/contracts/5.x/api/access) - Role-based access control mechanisms
+- [Ownable](/contracts/5.x/api/access#ownable) - Simple ownership access control
 
 ### Tokens
-- [ERC20](token/ERC20.md) - Fungible token standard implementation
-- [ERC721](token/ERC721.md) - Non-fungible token standard implementation
-- [ERC1155](token/ERC1155.md) - Multi-token standard implementation
+- [ERC20](/contracts/5.x/api/token/ERC20) - Fungible token standard implementation
+- [ERC721](/contracts/5.x/api/token/ERC721) - Non-fungible token standard implementation
+- [ERC1155](/contracts/5.x/api/token/ERC1155) - Multi-token standard implementation
 
 ### Utilities
-- [Utils](utils.md) - General utility functions and contracts
-- [Cryptography](utils/cryptography.md) - Cryptographic utilities
+- [Utils](/contracts/5.x/api/utils) - General utility functions and contracts
+- [Cryptography](/contracts/5.x/api/utils/cryptography) - Cryptographic utilities
 
 ### Governance
-- [Governance](governance.md) - On-chain governance systems
+- [Governance](/contracts/5.x/api/governance) - On-chain governance systems
 
 ### Proxy Patterns
-- [Proxy](proxy.md) - Upgradeable proxy patterns
+- [Proxy](/contracts/5.x/api/proxy) - Upgradeable proxy patterns
 
 ### Interfaces
-- [Interfaces](interfaces.md) - Standard interfaces
-
----
-
-*Generated from OpenZeppelin Contracts v$(cat ../temp-contracts/package.json | grep '"version"' | cut -d '"' -f 4)*
+- [Interfaces](/contracts/5.x/api/interfaces) - Standard interfaces

--- a/content/contracts/5.x/governance.mdx
+++ b/content/contracts/5.x/governance.mdx
@@ -36,7 +36,7 @@ When using a timelock with your Governor contract, you can use either OpenZeppel
 
 [Tally](https://www.tally.xyz) is a full-fledged application for user owned on-chain governance. It comprises a voting dashboard, proposal creation wizard, real time research and analysis, and educational content.
 
-For all of these options, the Governor will be compatible with Tally: users will be able to create proposals, see voting periods and delays following [IERC6372](/contracts/5.x/api/interfaces#IERC6372), visualize voting power and advocates, navigate proposals, and cast votes. For proposal creation in particular, projects can also use [Defender Transaction Proposals](https://docs.openzeppelin.com/defender/module/actions#transaction-proposals-reference) as an alternative interface.
+For all of these options, the Governor will be compatible with Tally: users will be able to create proposals, see voting periods and delays following [IERC6372](/contracts/5.x/api/interfaces#IERC6372), visualize voting power and advocates, navigate proposals, and cast votes. For proposal creation in particular, projects can also use [Defender Transaction Proposals](/defender/module/actions#transaction-proposals-reference) as an alternative interface.
 
 In the rest of this guide, we will focus on a fresh deploy of the vanilla OpenZeppelin Governor features without concern for compatibility with GovernorAlpha or Bravo.
 
@@ -106,7 +106,7 @@ A proposal is a sequence of actions that the Governor contract will perform if i
 
 Let’s say we want to create a proposal to give a team a grant, in the form of ERC-20 tokens from the governance treasury. This proposal will consist of a single action where the target is the ERC-20 token, calldata is the encoded function call `transfer(<team wallet>, <grant amount>)`, and with 0 ETH attached.
 
-Generally a proposal will be created with the help of an interface such as Tally or [Defender Proposals](https://docs.openzeppelin.com/defender/module/actions#transaction-proposals-reference). Here we will show how to create the proposal using Ethers.js.
+Generally a proposal will be created with the help of an interface such as Tally or [Defender Proposals](/defender/module/actions#transaction-proposals-reference). Here we will show how to create the proposal using Ethers.js.
 
 First we get all the parameters necessary for the proposal action.
 

--- a/content/contracts/5.x/index.mdx
+++ b/content/contracts/5.x/index.mdx
@@ -9,7 +9,7 @@ title: Overview
 * Reusable [Solidity components](/contracts/5.x/utilities) to build custom contracts and complex decentralized systems.
 
 <Callout type='warn'>
-OpenZeppelin Contracts uses semantic versioning to communicate backwards compatibility of its API and storage layout. For upgradeable contracts, the storage layout of different major versions should be assumed incompatible, for example, it is unsafe to upgrade from 4.9.3 to 5.0.0. Learn more at [Backwards Compatibility](backwards-compatibility).
+OpenZeppelin Contracts uses semantic versioning to communicate backwards compatibility of its API and storage layout. For upgradeable contracts, the storage layout of different major versions should be assumed incompatible, for example, it is unsafe to upgrade from 4.9.3 to 5.0.0. Learn more at [Backwards Compatibility](/contracts/5.x/backwards-compatibility).
 </Callout>
 
 ## Overview

--- a/content/contracts/5.x/index.mdx
+++ b/content/contracts/5.x/index.mdx
@@ -4,9 +4,9 @@ title: Overview
 
 **A library for secure smart contract development.** Build on a solid foundation of community-vetted code.
 
-* Implementations of standards like [ERC20](erc20) and [ERC721](erc721).
-* Flexible [role-based permissioning](access-control) scheme.
-* Reusable [Solidity components](utilities) to build custom contracts and complex decentralized systems.
+* Implementations of standards like [ERC20](/contracts/5.x/erc20) and [ERC721](/contracts/5.x/erc721).
+* Flexible [role-based permissioning](/contracts/5.x/access-control) scheme.
+* Reusable [Solidity components](/contracts/5.x/utilities) to build custom contracts and complex decentralized systems.
 
 <Callout type='warn'>
 OpenZeppelin Contracts uses semantic versioning to communicate backwards compatibility of its API and storage layout. For upgradeable contracts, the storage layout of different major versions should be assumed incompatible, for example, it is unsafe to upgrade from 4.9.3 to 5.0.0. Learn more at [Backwards Compatibility](backwards-compatibility).

--- a/content/contracts/5.x/learn/index.mdx
+++ b/content/contracts/5.x/learn/index.mdx
@@ -4,12 +4,12 @@ title: Learn
 
 Comprehensive guides for every step of your development journey.
 
-* [Setting up a Node project](setting-up-a-node-project) - Get your Node development environment set up for using OpenZeppelin tools
-* [Developing smart contracts](developing-smart-contracts) - Learn the basics of writing Solidity contracts with OpenZeppelin
-* [Deploying and interacting with smart contracts](deploying-and-interacting) - Deploy contracts to local and test networks and interact with them
-* [Writing automated smart contract tests](writing-automated-tests) - Write comprehensive tests to verify your contracts work as intended
-* [Upgrading smart contracts](upgrading-smart-contracts) - Modify your contract code while preserving state and address using OpenZeppelin Upgrades
-* [Connecting to public test networks](connecting-to-public-test-networks) - Move from local development to persistent test environments
-* [Preparing for mainnet](preparing-for-mainnet) - Security considerations and best practices for production deployment
-* [Building a dapp](building-a-dapp) - Create decentralized web applications with OpenZeppelin Network JS and hot-loading
-* [Sending gasless transactions](sending-gasless-transactions) - Enable meta-transactions using the Gas Station Network for better user onboarding
+* [Setting up a Node project](/contracts/5.x/learn/setting-up-a-node-project) - Get your Node development environment set up for using OpenZeppelin tools
+* [Developing smart contracts](/contracts/5.x/learn/developing-smart-contracts) - Learn the basics of writing Solidity contracts with OpenZeppelin
+* [Deploying and interacting with smart contracts](/contracts/5.x/learn/deploying-and-interacting) - Deploy contracts to local and test networks and interact with them
+* [Writing automated smart contract tests](/contracts/5.x/learn/writing-automated-tests) - Write comprehensive tests to verify your contracts work as intended
+* [Upgrading smart contracts](/contracts/5.x/learn/upgrading-smart-contracts) - Modify your contract code while preserving state and address using OpenZeppelin Upgrades
+* [Connecting to public test networks](/contracts/5.x/learn/connecting-to-public-test-networks) - Move from local development to persistent test environments
+* [Preparing for mainnet](/contracts/5.x/learn/preparing-for-mainnet) - Security considerations and best practices for production deployment
+* [Building a dapp](/contracts/5.x/learn/building-a-dapp) - Create decentralized web applications with OpenZeppelin Network JS and hot-loading
+* [Sending gasless transactions](/contracts/5.x/learn/sending-gasless-transactions) - Enable meta-transactions using the Gas Station Network for better user onboarding

--- a/content/contracts/5.x/subgraphs/index.mdx
+++ b/content/contracts/5.x/subgraphs/index.mdx
@@ -26,13 +26,13 @@ You can build a manifest for your application using the templates provided for e
 
 **Note:** For the indexing logic to work you will have, for each module used, to name one of your datasources with the name of the module.
 
-The `@amxx/graphprotocol-utils` provides tooling to [automate the generation of manifests.](generate)
+The `@amxx/graphprotocol-utils` provides tooling to [automate the generation of manifests.](/contracts/5.x/subgraphs/generate)
 
 ### Assembling your schema
 
 Depending on the modules you are using, your schema will have to include the corresponding entities. Assembling a schema can be difficult since graphql schema do not natively support import and merging operations. We do provide precompiled schemas for each module in `generated/<module-name>.schema.graphql`. We also provide a schema that includes all the entities for all the modules in `generated/all.schema.graphql`.
 
-Similar to the manifest, `@amxx/graphprotocol-utils` provides tooling to [automate the generation of schemas.](generate)
+Similar to the manifest, `@amxx/graphprotocol-utils` provides tooling to [automate the generation of schemas.](/contracts/5.x/generate)
 
 ## Modules
 

--- a/content/defender/guide/factory-monitor.mdx
+++ b/content/defender/guide/factory-monitor.mdx
@@ -6,7 +6,7 @@ The factory-clone pattern can be advantageous for minimizing gas costs. However,
 
 This guide shows how to use Defender to monitor a factory contract as well as the clone contracts created by it. Monitor automation is achieved through the following structure of Defender modules:
 
-* A Monitor watches for successful event emitted by the factory contract that creates a clone. If detected, it triggers an [Action](module/actions) and [passes along information](module/actions#monitor_invocations) about the transaction.
+* A Monitor watches for successful event emitted by the factory contract that creates a clone. If detected, it triggers an [Action](/defender/module/actions) and [passes along information](module/actions#monitor_invocations) about the transaction.
 * The Action makes use of the [`defender-sdk`](https://www.npmjs.com/package/@openzeppelin/defender-sdk) to add the address of the newly created contract to the [address book](module/address-book) for easier monitoring.
 * Aditionally, the Action uses the [`defender-sdk`](https://www.npmjs.com/package/@openzeppelin/defender-sdk) to add the clone address to the list of addresses watched by a Monitor.
 

--- a/content/monitor/architecture.mdx
+++ b/content/monitor/architecture.mdx
@@ -293,7 +293,7 @@ The architecture includes several resilience mechanisms:
 * ***Retry Logic***: Notification delivery includes configurable retry mechanisms for transient failures
 * ***Graceful Degradation***: Individual component failures don’t cascade to the entire system
 
-For detailed information about RPC logic and network communication, see the [RPC section](rpc).
+For detailed information about RPC logic and network communication, see the [RPC section](/monitor/rpc).
 
 ## Configuration Architecture
 
@@ -316,7 +316,7 @@ The system implements comprehensive validation:
 
 
 
-For configuration examples and best practices, see the [Configuration Guidelines](index#configuration_guidelines) section in the user documentation.
+For configuration examples and best practices, see the [Configuration Guidelines](/monitor/#configuration_guidelines) section in the user documentation.
 
 
 ## Extensibility Points
@@ -355,8 +355,8 @@ The system implements several security measures:
 
 ## Related Documentation
 
-For detailed information about the project structure, source code organization, and development resources, see the [Project Structure](project-structure) guide.
+For detailed information about the project structure, source code organization, and development resources, see the [Project Structure](/monitor/project-structure) guide.
 
-For information about RPC logic and network communication, see the [RPC section](rpc).
+For information about RPC logic and network communication, see the [RPC section](/monitor/rpc).
 
-For configuration examples and best practices, see the [Configuration Guidelines](index#configuration_guidelines) section in the user documentation.
+For configuration examples and best practices, see the [Configuration Guidelines](/monitor/#configuration_guidelines) section in the user documentation.

--- a/content/monitor/contribution.mdx
+++ b/content/monitor/contribution.mdx
@@ -200,7 +200,7 @@ RUST_TEST_THREADS=1 cargo test
 * Ensure all tests pass before submitting
 * Maintain or improve code coverage
 
-For detailed testing information, see the [Testing Guide](testing).
+For detailed testing information, see the [Testing Guide](/monitor/testing).
 
 ### Commit Message Format
 

--- a/content/monitor/index.mdx
+++ b/content/monitor/index.mdx
@@ -31,7 +31,7 @@ In the rapidly evolving world of blockchain technology, effective monitoring is 
 
 
 
-To get started immediately, see [Quickstart](quickstart).
+To get started immediately, see [Quickstart](/monitor/quickstart).
 
 
 ## Installation
@@ -658,7 +658,7 @@ A Trigger defines actions to take when monitored conditions are met. Triggers ca
 | `**arguments**` | `Array[String]` | The arguments of the script (optional). |
 | `**timeout_ms**` | `Number` | The timeout of the script is important to avoid infinite loops during the execution. If the script takes longer than the timeout, it will be killed. |
 
-For more information about custom scripts, see [Custom Scripts Section](scripts).
+For more information about custom scripts, see [Custom Scripts Section](/monitor/scripts).
 
 
 
@@ -1206,7 +1206,7 @@ You can find the contract specification through Stellar contract explorer tool. 
 
 Custom filters allow you to create sophisticated filtering logic for processing monitor matches. These filters act as additional validation layers that determine whether a match should trigger the execution of a trigger or not.
 
-For more information about custom scripts, see [Custom Scripts Section](scripts).
+For more information about custom scripts, see [Custom Scripts Section](/monitor/scripts).
 
 
 
@@ -1397,21 +1397,21 @@ Specific Block Mode requires both parameters:
 
 ## Error Handling
 
-The monitor implements a comprehensive error handling system with rich context and tracing capabilities. For detailed information about error handling, see [Error Handling Guide](error).
+The monitor implements a comprehensive error handling system with rich context and tracing capabilities. For detailed information about error handling, see [Error Handling Guide](/monitor/error).
 
 ## Important Considerations
 
 ### Performance Considerations
 
 * Monitor performance depends on network congestion and RPC endpoint reliability.
-  * View the [list of RPC calls](rpc#list_of_rpc_calls) made by the monitor.
+  * View the [list of RPC calls](/monitor/rpc#list_of_rpc_calls) made by the monitor.
 * The `max_past_blocks` configuration is critical:
   * Calculate as: `(cron_interval_ms/block_time_ms) + confirmation_blocks + 1` (defaults to this calculation if not specified).
   * Example for 1-minute Ethereum cron: `(60000/12000) + 12 + 1 = 18 blocks`.
   * Too low settings may result in missed blocks.
 * Trigger conditions are executed sequentially based on their position in the trigger conditions array. Proper execution also depends on the number of available file descriptors on your system. To ensure optimal performance, it is recommended to increase the limit for open file descriptors to at least 2048 or higher. On Unix-based systems you can check the current limit by running `ulimit -n` and _***temporarily***_ increase it with `ulimit -n 2048`.
 * Since scripts are loaded at startup, any modifications to script files require restarting the monitor to take effect.
-* See performance considerations about custom scripts [here](scripts#performance_considerations).
+* See performance considerations about custom scripts [here](/monitor/scripts#performance_considerations).
 
 ### Notification Considerations
 

--- a/content/monitor/project-structure.mdx
+++ b/content/monitor/project-structure.mdx
@@ -203,4 +203,4 @@ The project includes Docker configurations for different environments:
 
 
 
-For detailed information about running the monitor in containers, see the Docker deployment [section](index#docker_installation) in the user documentation.
+For detailed information about running the monitor in containers, see the Docker deployment [section](/monitor/#docker_installation) in the user documentation.

--- a/content/monitor/quickstart.mdx
+++ b/content/monitor/quickstart.mdx
@@ -153,7 +153,7 @@ Copy the example environment file and customize it:
 cp .env.example .env
 ```
 
-For detailed configuration options, see [Basic Configuration](index#basic_configuration).
+For detailed configuration options, see [Basic Configuration](/monitor/#basic_configuration).
 
 ## Practical Examples
 
@@ -587,13 +587,13 @@ Now that you have OpenZeppelin Monitor running, here are some suggestions for wh
 
 ### Testing and Validation
 
-* [Test your configuration](index#testing_your_configuration) against specific block numbers
+* [Test your configuration](/monitor#testing_your_configuration) against specific block numbers
 * Verify your RPC endpoints are working correctly
 * Test notification channels with small transactions
 
 ### Security and Best Practices
 
-* [Configure secure secret management](index#secret_management) for sensitive data
+* [Configure secure secret management](/monitor#secret_management) for sensitive data
 * Use environment variables or Hashicorp Cloud Vault for credentials
 * Regularly update your RPC endpoints and monitor configurations
 
@@ -606,7 +606,7 @@ Now that you have OpenZeppelin Monitor running, here are some suggestions for wh
 ### Getting Help
 
 * Check the [GitHub Issues](https://github.com/OpenZeppelin/openzeppelin-monitor/issues) for known problems
-* Review the [User Documentation](index) for detailed configuration options
+* Review the [User Documentation](/monitor) for detailed configuration options
 * Join the OpenZeppelin community for support
 
 

--- a/content/monitor/scripts.mdx
+++ b/content/monitor/scripts.mdx
@@ -434,7 +434,7 @@ This examples script filters EVM transactions based on their block number:
 
 ### Integration
 
-Integrate your custom filter script with the monitor by following the [configuration guidelines](index#trigger_conditions_custom_filters).
+Integrate your custom filter script with the monitor by following the [configuration guidelines](/monitor#trigger_conditions_custom_filters).
 
 
 
@@ -599,7 +599,7 @@ This examples demonstrates how to:
 
 ### Integration
 
-Integrate your custom notification script with the triggers by following the [configuration guidelines](index#custom_script_notifications).
+Integrate your custom notification script with the triggers by following the [configuration guidelines](/monitor#custom_script_notifications).
 
 ## Performance Considerations
 

--- a/content/relayer/configuration/index.mdx
+++ b/content/relayer/configuration/index.mdx
@@ -21,7 +21,7 @@ The OpenZeppelin Relayer supports two configuration approaches:
 - Changes take effect immediately (no container restart required)
 - See the ***API Reference*** page for detailed endpoints documentation
 
-See [Storage Configuration](storage) for detailed information about how file-based and API-based configurations work together, storage behavior, and best practices.
+See [Storage Configuration](/relayer/storage) for detailed information about how file-based and API-based configurations work together, storage behavior, and best practices.
 
 For quick setup examples with pre-configured files, see the [examples directory](https://github.com/OpenZeppelin/openzeppelin-relayer/tree/main/examples) in our GitHub repository.
 
@@ -127,7 +127,7 @@ For comprehensive details on configuring all supported signer types including:
 * Turnkey signers
 * Security best practices and troubleshooting
 
-See the dedicated [Signers Configuration](signers) guide.
+See the dedicated [Signers Configuration](/relayer/signers) guide.
 
 
 
@@ -213,9 +213,9 @@ Available configuration fields
 | notification_id | String | ID of a configured notification object |
 | signer_id | String | ID of a configured signer |
 | network_type | String | Type of network the relayer will connect to (`evm`, `solana`) |
-| network | String | Network the relayer will connect to. Must match a network identifier defined in your network configuration files. See [Network Configuration](network_configuration) for details on defining networks. |
+| network | String | Network the relayer will connect to. Must match a network identifier defined in your network configuration files. See [Network Configuration](/relayer/network_configuration) for details on defining networks. |
 | custom_rpc_urls | list | Optional custom RPC URLs for the network. If provided, this will be used instead of the public RPC URLs. This is useful for using your own RPC node or a paid service provider. The first url of the list is going to be used as the default |
-| policies | list | Overrides default policies. Please refer to the [`Policies`](configuration#network_policies) table |
+| policies | list | Overrides default policies. Please refer to the [`Policies`](/relayer/configuration#network_policies) table |
 
 <a name="network_policies"></a>Policies
 | Network type | Policy | Type | Description |
@@ -303,7 +303,7 @@ See the ***API Reference*** page for detailed endpoints documentation.
 
 ### 4. Plugins
 
-For more information on how to write a plugin, please refer to the [Plugins](plugins) page.
+For more information on how to write a plugin, please refer to the [Plugins](/relayer/plugins) page.
 
 * `plugins` array, containing plugin configurations:
 
@@ -337,7 +337,7 @@ For comprehensive network configuration details, including:
 * Special tags and their behavior
 * Best practices and troubleshooting
 
-See the dedicated [Network Configuration](network_configuration) guide.
+See the dedicated [Network Configuration](/relayer/network_configuration) guide.
 
 ## Configuration File Example
 
@@ -523,4 +523,4 @@ The OpenZeppelin Relayer supports two complementary approaches for configuration
 
 
 
-See [Storage Configuration](storage) for detailed information about how file-based and API-based configurations work together, storage behavior, and best practices.
+See [Storage Configuration](/relayer/storage) for detailed information about how file-based and API-based configurations work together, storage behavior, and best practices.

--- a/content/relayer/evm.mdx
+++ b/content/relayer/evm.mdx
@@ -27,7 +27,7 @@ EVM networks are defined via JSON configuration files, providing flexibility to:
 * Create network variants using inheritance from base configurations
 * Support both Layer 1 and Layer 2 networks
 
-For detailed network configuration options, see the [Network Configuration](network_configuration) guide.
+For detailed network configuration options, see the [Network Configuration](/relayer/network_configuration) guide.
 
 ## Supported Signers
 
@@ -38,7 +38,7 @@ For detailed network configuration options, see the [Network Configuration](netw
 * `google_cloud_kms` (Google Cloud KMS)
 * `aws_kms` (Amazon AWS KMS)
 
-For detailed signer configuration options, see the [Signers](signers) guide.
+For detailed signer configuration options, see the [Signers](/relayer/signers) guide.
 
 
 
@@ -47,7 +47,7 @@ In production systems, hosted signers (AWS KMS, Google Cloud KMS, Turnkey) are r
 
 ## Quickstart
 
-For a step-by-step setup, see [Quick Start Guide](quickstart).
+For a step-by-step setup, see [Quick Start Guide](/relayer/quickstart).
 Key prerequisites:
 
 * Rust 2021, version `1.86` or later
@@ -101,7 +101,7 @@ In addition to standard relayer configuration and policies, EVM relayers support
 * `min_balance`: Minimum balance required for the relayer to operate (in wei)
 * `eip1559_pricing`: Enable/disable EIP-1559 pricing methodology for transaction fees
 
-You can check all options in [User Documentation - Relayers](index#3_relayers).
+You can check all options in [User Documentation - Relayers](/relayer/#3_relayers).
 
 ### Gas Management Configuration
 

--- a/content/relayer/index.mdx
+++ b/content/relayer/index.mdx
@@ -45,16 +45,16 @@ Networks can be loaded from:
 * ***JSON arrays***: Direct network definitions in configuration files
 * ***Directory of files***: Multiple JSON files each containing network definitions
 
-For detailed network configuration options and examples, see the [Network Configuration](network_configuration) page.
+For detailed network configuration options and examples, see the [Network Configuration](/relayer/network_configuration) page.
 
 
 
-For information about our development plans and upcoming features, see [Project Roadmap](roadmap).
+For information about our development plans and upcoming features, see [Project Roadmap](/relayer/roadmap).
 
 
 
 
-To get started immediately, see [Quickstart](quickstart).
+To get started immediately, see [Quickstart](/relayer/quickstart).
 
 
 ## Technical Overview
@@ -184,7 +184,7 @@ openzeppelin-relayer/
 └── ... other root files (Cargo.toml, README.md, etc.)
 ```
 
-For detailed information about each directory and its contents, see [Project Structure Details](structure).
+For detailed information about each directory and its contents, see [Project Structure Details](/relayer/structure).
 
 ## Getting Started
 
@@ -242,7 +242,7 @@ cargo run
 ```
 
 <Callout>
-Before executing the command, ensure that the `.env` and `config.json` files are configured as detailed in the [Configuration References](index#configuration_references) section.
+Before executing the command, ensure that the `.env` and `config.json` files are configured as detailed in the [Configuration References](/relayer/#configuration_references) section.
 </Callout>
 
 ### Option 2: Run with Docker
@@ -314,7 +314,7 @@ For comprehensive configuration details, including:
 * Plugin configuration
 * Complete configuration examples
 
-See the dedicated [Configuration Guide](configuration).
+See the dedicated [Configuration Guide](/relayer/configuration).
 
 ## Important Considerations
 

--- a/content/relayer/network_configuration.mdx
+++ b/content/relayer/network_configuration.mdx
@@ -381,7 +381,7 @@ Once networks are defined, reference them in your relayer configurations:
 
 ## See Also
 
-* [Relayer Configuration](index#relayer_configuration)
-* [Quickstart Guide](quickstart)
-* [Solana Integration](solana)
-* [API Reference](https://openzeppelin-relayer.netlify.app/api_docs.html)
+* [Relayer Configuration](/relayer/#relayer_configuration)
+* [Quickstart Guide](/relayer/quickstart)
+* [Solana Integration](/relayer/solana)
+* [API Reference](/relayer/api)

--- a/content/relayer/solana.mdx
+++ b/content/relayer/solana.mdx
@@ -54,7 +54,7 @@ Example Solana network configurations:
 }
 ```
 
-For detailed network configuration options, see the [Network Configuration](network_configuration) guide.
+For detailed network configuration options, see the [Network Configuration](/relayer/network_configuration) guide.
 
 ## Supported Signers
 
@@ -71,7 +71,7 @@ In production systems, hosted signers are recommended for the best security mode
 
 ## Quickstart
 
-For a step-by-step setup, see [Quick Start Guide](quickstart).
+For a step-by-step setup, see [Quick Start Guide](/relayer/quickstart).
 Key prerequisites:
 
 * Rust 2021, version `1.86` or later
@@ -134,7 +134,7 @@ In addition to standard relayer configuration and policies, Solana relayers supp
 * `allowed_programs`, `allowed_accounts`, `disallowed_accounts`: Restrict relayer operations to specific programs/accounts
 * `swap_config`: Automated token swap settings (see below)
 
-You can check all options in [User Documentation - Relayers](index#3_relayers).
+You can check all options in [User Documentation - Relayers](/relayer/#3_relayers).
 
 ### Automated token swap configuration options:
 
@@ -209,7 +209,7 @@ See [API Reference](https://release-v1-0-0%2D%2Dopenzeppelin-relayer.netlify.app
 
 ## Roadmap
 
-* See [Project Roadmap](roadmap) for upcoming features
+* See [Project Roadmap](/relayer/roadmap) for upcoming features
 
 ## Support
 

--- a/content/relayer/stellar.mdx
+++ b/content/relayer/stellar.mdx
@@ -56,11 +56,11 @@ Example Stellar network configurations:
 }
 ```
 
-For detailed network configuration options, see the [Network Configuration](network_configuration) guide.
+For detailed network configuration options, see the [Network Configuration](/relayer/network_configuration) guide.
 
 ## Quickstart
 
-For a step-by-step setup, see [Quick Start Guide](quickstart).
+For a step-by-step setup, see [Quick Start Guide](/relayer/quickstart).
 Key prerequisites:
 
 * Rust 2021, version `1.86` or later
@@ -86,7 +86,7 @@ For more configuration examples, visit the [OpenZeppelin Relayer examples reposi
 
 ### Relayer Policies
 
-Stellar relayers support standard relayer configuration options. Check all options in [User Documentation - Relayers](index#3_relayers).
+Stellar relayers support standard relayer configuration options. Check all options in [User Documentation - Relayers](/relayer/#3_relayers).
 
 ## API Reference
 
@@ -320,7 +320,7 @@ Soroban operations support different authorization modes:
 
 ## Roadmap
 
-* See [Project Roadmap](roadmap) for upcoming features
+* See [Project Roadmap](/relayer/roadmap) for upcoming features
 
 ## Support
 

--- a/content/stellar-contracts/0.2.0/index.mdx
+++ b/content/stellar-contracts/0.2.0/index.mdx
@@ -8,15 +8,15 @@ supporting Fungible, Non-Fungible, and Multi-Token standards.
 ## Tokens
 Explore our implementations for token standards on Stellar Soroban:
 
-* ***[Fungible Tokens](tokens/fungible)***: Digital assets representing a fixed or dynamic supply of identical units.
-* ***[Non-Fungible Tokens](tokens/non-fungible)***: Unique digital assets with verifiable ownership.
+* ***[Fungible Tokens](/stellar-contracts/tokens/fungible)***: Digital assets representing a fixed or dynamic supply of identical units.
+* ***[Non-Fungible Tokens](/stellar-contracts/tokens/non-fungible)***: Unique digital assets with verifiable ownership.
 * ***Multi-Token***: Hybrid tokens enabling both fungible and non-fungible token functionalities (work in progress).
 
 ## Utilities
 Discover our utility contracts for Stellar Soroban, applicable to all token standards mentioned above:
 
-* ***[Pausable](utils/pausable)***
-* ***[Upgrades and Migrations](utils/upgradeable)***
+* ***[Pausable](/stellar-contracts/utils/pausable)***
+* ***[Upgrades and Migrations](/stellar-contracts/upgradeable)***
 
 ## Error Codes
 In Stellar Soroban, each error variant is assigned an integer. To prevent duplication of error codes,
@@ -34,4 +34,4 @@ we use the following convention:
 You can find our audit reports [here](https://github.com/OpenZeppelin/stellar-contracts/tree/main/audits).
 
 ## Get Started
-Get started [here](get-started).
+Get started [here](/stllar-contracts/get-started).

--- a/content/stellar-contracts/0.2.0/tokens/nft-consecutive.mdx
+++ b/content/stellar-contracts/0.2.0/tokens/nft-consecutive.mdx
@@ -4,13 +4,13 @@ title: Non-Fungible Consecutive
 
 [Source Code](https://github.com/OpenZeppelin/stellar-contracts/tree/main/packages/tokens/non-fungible/src/extensions/consecutive)
 
-Consecutive extension for [Non-Fungible Token](tokens/non-fungible) is useful
+Consecutive extension for [Non-Fungible Token](/stellar-contracts/tokens/non-fungible) is useful
 for efficiently minting multiple tokens in a single transaction. This can significantly
 reduce costs and improve performance when creating a large number of tokens at once.
 
 ## Usage
 
-We’ll continue with the [example](tokens/non-fungible#usage) from **Non-Fungible Token**
+We’ll continue with the [example](/stellar-contracts/tokens/non-fungible#usage) from **Non-Fungible Token**
 and modify the contract so that now batches of tokens can be minted with each call
 to `award_items`. Please note any account can call `award_items` and we might want to
 implement access control to restrict who can mint.

--- a/content/stellar-contracts/0.2.0/tokens/nft-enumerable.mdx
+++ b/content/stellar-contracts/0.2.0/tokens/nft-enumerable.mdx
@@ -4,13 +4,13 @@ title: Non-Fungible Enumerable
 
 [Source Code](https://github.com/OpenZeppelin/stellar-contracts/tree/main/packages/tokens/non-fungible/src/extensions/enumerable)
 
-Enumerable extension for [Non-Fungible Token](tokens/non-fungible) allows for enumeration
+Enumerable extension for [Non-Fungible Token](/stellar-contracts/tokens/non-fungible) allows for enumeration
 of all the token IDs in the contract as well as all the token IDs owned by each account. This is
 useful for applications that need to list or iterate over tokens, such as marketplaces or wallets.
 
 ## Usage
 
-We’ll build on the [example](tokens/non-fungible#usage) from **Non-Fungible Token**
+We’ll build on the [example](/stellar-contracts/tokens/non-fungible#usage) from **Non-Fungible Token**
 and modify the contract so that all tokens an address own can be listed. Please note any account
 can call `award_item` and we might want to implement access control to restrict who can mint.
 

--- a/content/stellar-contracts/0.2.0/tokens/non-fungible.mdx
+++ b/content/stellar-contracts/0.2.0/tokens/non-fungible.mdx
@@ -87,5 +87,5 @@ customization for various use cases.
 
 The following optional extensions are also provided:
 
-* [Non-Fungible Consecutive](tokens/nft-consecutive): Extension for optimized minting of batches of tokens.
-* [Non-Fungible Enumerable](tokens/nft-enumerable): Extension that allows enumerating the tokens on-chain.
+* [Non-Fungible Consecutive](/stellar-contracts/tokens/nft-consecutive): Extension for optimized minting of batches of tokens.
+* [Non-Fungible Enumerable](/stellar-contracts/tokens/nft-enumerable): Extension that allows enumerating the tokens on-chain.

--- a/content/stellar-contracts/0.2.0/utils/upgradeable.mdx
+++ b/content/stellar-contracts/0.2.0/utils/upgradeable.mdx
@@ -23,8 +23,8 @@ provides a lightweight upgradeability framework with additional support for stru
 
 It consists of two main components:
 
-1. ***[`Upgradeable`](utils/upgradeable#upgrade_only)*** for cases where only the WASM binary needs to be updated.
-2. ***[`UpgradeableMigratable`](utils/upgradeable#upgrade_and_migrate)*** for more advanced scenarios where, in addition to the WASM binary, specific storage entries
+1. ***[`Upgradeable`](/stellar-contracts/utils/upgradeable#upgrade_only)*** for cases where only the WASM binary needs to be updated.
+2. ***[`UpgradeableMigratable`](/stellar-contracts/utils/upgradeable#upgrade_and_migrate)*** for more advanced scenarios where, in addition to the WASM binary, specific storage entries
 must be modified (migrated) during the upgrade process.
 
 The recommended way to use this module is through the `\#[derive(Upgradeable)]` and `#[derive(UpgradeableMigratable)]`

--- a/content/stellar-contracts/0.3.0/index.mdx
+++ b/content/stellar-contracts/0.3.0/index.mdx
@@ -8,8 +8,8 @@ supporting Fungible, Non-Fungible, and Multi-Token standards.
 ## Tokens
 Explore our implementations for token standards on Stellar Soroban:
 
-* ***[Fungible Tokens](tokens/fungible/fungible)***: Digital assets representing a fixed or dynamic supply of identical units.
-* ***[Non-Fungible Tokens](tokens/non-fungible/non-fungible)***: Unique digital assets with verifiable ownership.
+* ***[Fungible Tokens](/stellar-contracts/tokens/fungible/fungible)***: Digital assets representing a fixed or dynamic supply of identical units.
+* ***[Non-Fungible Tokens](/stellar-contracts/tokens/non-fungible/non-fungible)***: Unique digital assets with verifiable ownership.
 * ***Multi-Token***: Hybrid tokens enabling both fungible and non-fungible token functionalities (work in progress).
 
 ## Utilities

--- a/content/substrate-runtimes/2.0.2/guides/contract_migration.mdx
+++ b/content/substrate-runtimes/2.0.2/guides/contract_migration.mdx
@@ -6,7 +6,7 @@ This EVM template is powered by Frontier. It allows you to deploy almost any Sol
 
 ## Step 1: Prepare and run the chain
 
-This step is basic, you can use our [guide for generic template](index). It is recommended to use [async backing](guides/async_backing) for better experience.
+This step is basic, you can use our [guide for generic template](index). It is recommended to use [async backing](async_backing) for better experience.
 The only additional thing that you will need to specify is the EVM Chain Id in your chainspec. For that, you need:
 
 * During the "Edit the chainspec" step execute one additional step:

--- a/content/substrate-runtimes/guides/contract_migration.mdx
+++ b/content/substrate-runtimes/guides/contract_migration.mdx
@@ -6,7 +6,7 @@ This EVM template is powered by Frontier. It allows you to deploy almost any Sol
 
 ## Step 1: Prepare and run the chain
 
-This step is basic, you can use our [guide for generic template](index). It is recommended to use [async backing](guides/async_backing) for better experience.
+This step is basic, you can use our [guide for generic template](index). It is recommended to use [async backing](async_backing) for better experience.
 The only additional thing that you will need to specify is the EVM Chain Id in your chainspec. For that, you need:
 
 * During the "Edit the chainspec" step execute one additional step:

--- a/content/substrate-runtimes/index.mdx
+++ b/content/substrate-runtimes/index.mdx
@@ -10,4 +10,4 @@ A collection of secure runtime templates to build parachains more easily on Polk
 
 ## Where to get started
 * [Quick Start](/substrate-runtimes/guides/quick_start): a generic parachain runtime that works out of the box. It has all the must have features, and allows further customization based on your project’s needs. Generic Runtime Template also serves as the base for our other runtime templates.
-* [Testing with Zombienet](guides/testing_with_zombienet): a more opinionated parachain runtime template that maximizes Ethereum compatibility by using `AccountId20` and configures a local EVM instance. You can easily migrate/deploy Solidity Smart Contracts to this one.
+* [Testing with Zombienet](/substrate-runtimes/guides/testing_with_zombienet): a more opinionated parachain runtime template that maximizes Ethereum compatibility by using `AccountId20` and configures a local EVM instance. You can easily migrate/deploy Solidity Smart Contracts to this one.

--- a/content/uniswap-hooks/api/base.mdx
+++ b/content/uniswap-hooks/api/base.mdx
@@ -7,16 +7,16 @@ description: "Smart contract base utilities and implementations"
 
 <div style={{marginTop: "4em"}} className="w-full flex flex-row items-center justify-between">
 
-## `BaseAsyncSwap` 
+## `BaseAsyncSwap`
 
-<a target="_blank" style={{marginTop: "1.5em"}} href="https://github.com/OpenZeppelin/openzeppelin-contracts/blob/v1.1.0/src/base/BaseAsyncSwap.sol">
+<a target="_blank" style={{marginTop: "1.5em"}} href="https://github.com/OpenZeppelin/uniswap-hooks/blob/v1.1.0/src/base/BaseAsyncSwap.sol">
 <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-github-icon lucide-github"><path d="M15 22v-4a4.8 4.8 0 0 0-1-3.5c3 0 6-2 6-5.5.08-1.25-.27-2.48-1-3.5.28-1.15.28-2.35 0-3.5 0 0-1 0-3 1.5-2.64-.5-5.36-.5-8 0C6 2 5 2 5 2c-.3 1.15-.3 2.35 0 3.5A5.403 5.403 0 0 0 4 9c0 3.5 3 5.5 6 5.5-.39.49-.68 1.05-.85 1.65-.17.6-.22 1.23-.15 1.85v4"/><path d="M9 18c-4.51 2-5-2-7-2"/></svg>
 </a>
 
 </div>
 
 ```solidity
-import "@openzeppelin/src/base/BaseAsyncSwap.sol";
+import "uniswap-hooks/src/base/BaseAsyncSwap.sol";
 ```
 
 Base implementation for async swaps, which skip the v3-like swap implementation of the `PoolManager`
@@ -181,16 +181,16 @@ Set the hook permissions, specifically `beforeSwap` and `beforeSwapReturnDelta`.
 
 <div style={{marginTop: "4em"}} className="w-full flex flex-row items-center justify-between">
 
-## `BaseCustomAccounting` 
+## `BaseCustomAccounting`
 
-<a target="_blank" style={{marginTop: "1.5em"}} href="https://github.com/OpenZeppelin/openzeppelin-contracts/blob/v1.1.0/src/base/BaseCustomAccounting.sol">
+<a target="_blank" style={{marginTop: "1.5em"}} href="https://github.com/OpenZeppelin/uniswap-hooks/blob/v1.1.0/src/base/BaseCustomAccounting.sol">
 <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-github-icon lucide-github"><path d="M15 22v-4a4.8 4.8 0 0 0-1-3.5c3 0 6-2 6-5.5.08-1.25-.27-2.48-1-3.5.28-1.15.28-2.35 0-3.5 0 0-1 0-3 1.5-2.64-.5-5.36-.5-8 0C6 2 5 2 5 2c-.3 1.15-.3 2.35 0 3.5A5.403 5.403 0 0 0 4 9c0 3.5 3 5.5 6 5.5-.39.49-.68 1.05-.85 1.65-.17.6-.22 1.23-.15 1.85v4"/><path d="M9 18c-4.51 2-5-2-7-2"/></svg>
 </a>
 
 </div>
 
 ```solidity
-import "@openzeppelin/src/base/BaseCustomAccounting.sol";
+import "uniswap-hooks/src/base/BaseCustomAccounting.sol";
 ```
 
 Base implementation for custom accounting and hook-owned liquidity.
@@ -688,16 +688,16 @@ Hook was already initialized.
 
 <div style={{marginTop: "4em"}} className="w-full flex flex-row items-center justify-between">
 
-## `BaseCustomCurve` 
+## `BaseCustomCurve`
 
-<a target="_blank" style={{marginTop: "1.5em"}} href="https://github.com/OpenZeppelin/openzeppelin-contracts/blob/v1.1.0/src/base/BaseCustomCurve.sol">
+<a target="_blank" style={{marginTop: "1.5em"}} href="https://github.com/OpenZeppelin/uniswap-hooks/blob/v1.1.0/src/base/BaseCustomCurve.sol">
 <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-github-icon lucide-github"><path d="M15 22v-4a4.8 4.8 0 0 0-1-3.5c3 0 6-2 6-5.5.08-1.25-.27-2.48-1-3.5.28-1.15.28-2.35 0-3.5 0 0-1 0-3 1.5-2.64-.5-5.36-.5-8 0C6 2 5 2 5 2c-.3 1.15-.3 2.35 0 3.5A5.403 5.403 0 0 0 4 9c0 3.5 3 5.5 6 5.5-.39.49-.68 1.05-.85 1.65-.17.6-.22 1.23-.15 1.85v4"/><path d="M9 18c-4.51 2-5-2-7-2"/></svg>
 </a>
 
 </div>
 
 ```solidity
-import "@openzeppelin/src/base/BaseCustomCurve.sol";
+import "uniswap-hooks/src/base/BaseCustomCurve.sol";
 ```
 
 Base implementation for custom curves, inheriting from [`BaseCustomAccounting`](#BaseCustomAccounting).
@@ -1007,16 +1007,16 @@ Set the hook permissions, specifically `beforeInitialize`, `beforeAddLiquidity`,
 
 <div style={{marginTop: "4em"}} className="w-full flex flex-row items-center justify-between">
 
-## `BaseHook` 
+## `BaseHook`
 
-<a target="_blank" style={{marginTop: "1.5em"}} href="https://github.com/OpenZeppelin/openzeppelin-contracts/blob/v1.1.0/src/base/BaseHook.sol">
+<a target="_blank" style={{marginTop: "1.5em"}} href="https://github.com/OpenZeppelin/uniswap-hooks/blob/v1.1.0/src/base/BaseHook.sol">
 <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-github-icon lucide-github"><path d="M15 22v-4a4.8 4.8 0 0 0-1-3.5c3 0 6-2 6-5.5.08-1.25-.27-2.48-1-3.5.28-1.15.28-2.35 0-3.5 0 0-1 0-3 1.5-2.64-.5-5.36-.5-8 0C6 2 5 2 5 2c-.3 1.15-.3 2.35 0 3.5A5.403 5.403 0 0 0 4 9c0 3.5 3 5.5 6 5.5-.39.49-.68 1.05-.85 1.65-.17.6-.22 1.23-.15 1.85v4"/><path d="M9 18c-4.51 2-5-2-7-2"/></svg>
 </a>
 
 </div>
 
 ```solidity
-import "@openzeppelin/src/base/BaseHook.sol";
+import "uniswap-hooks/src/base/BaseHook.sol";
 ```
 
 Base hook implementation.
@@ -1603,4 +1603,3 @@ The hook function is not implemented.
 
 </div>
 </div>
-

--- a/content/uniswap-hooks/api/fee.mdx
+++ b/content/uniswap-hooks/api/fee.mdx
@@ -7,16 +7,16 @@ description: "Smart contract fee utilities and implementations"
 
 <div style={{marginTop: "4em"}} className="w-full flex flex-row items-center justify-between">
 
-## `BaseDynamicAfterFee` 
+## `BaseDynamicAfterFee`
 
-<a target="_blank" style={{marginTop: "1.5em"}} href="https://github.com/OpenZeppelin/openzeppelin-contracts/blob/v1.1.0/src/fee/BaseDynamicAfterFee.sol">
+<a target="_blank" style={{marginTop: "1.5em"}} href="https://github.com/OpenZeppelin/uniswap-hooks/blob/v1.1.0/src/fee/BaseDynamicAfterFee.sol">
 <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-github-icon lucide-github"><path d="M15 22v-4a4.8 4.8 0 0 0-1-3.5c3 0 6-2 6-5.5.08-1.25-.27-2.48-1-3.5.28-1.15.28-2.35 0-3.5 0 0-1 0-3 1.5-2.64-.5-5.36-.5-8 0C6 2 5 2 5 2c-.3 1.15-.3 2.35 0 3.5A5.403 5.403 0 0 0 4 9c0 3.5 3 5.5 6 5.5-.39.49-.68 1.05-.85 1.65-.17.6-.22 1.23-.15 1.85v4"/><path d="M9 18c-4.51 2-5-2-7-2"/></svg>
 </a>
 
 </div>
 
 ```solidity
-import "@openzeppelin/src/fee/BaseDynamicAfterFee.sol";
+import "uniswap-hooks/src/fee/BaseDynamicAfterFee.sol";
 ```
 
 Base implementation for dynamic target hook fees applied after swaps.
@@ -292,16 +292,16 @@ Set the hook permissions, specifically [`BaseHook.beforeSwap`](base#BaseHook-bef
 
 <div style={{marginTop: "4em"}} className="w-full flex flex-row items-center justify-between">
 
-## `BaseDynamicFee` 
+## `BaseDynamicFee`
 
-<a target="_blank" style={{marginTop: "1.5em"}} href="https://github.com/OpenZeppelin/openzeppelin-contracts/blob/v1.1.0/src/fee/BaseDynamicFee.sol">
+<a target="_blank" style={{marginTop: "1.5em"}} href="https://github.com/OpenZeppelin/uniswap-hooks/blob/v1.1.0/src/fee/BaseDynamicFee.sol">
 <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-github-icon lucide-github"><path d="M15 22v-4a4.8 4.8 0 0 0-1-3.5c3 0 6-2 6-5.5.08-1.25-.27-2.48-1-3.5.28-1.15.28-2.35 0-3.5 0 0-1 0-3 1.5-2.64-.5-5.36-.5-8 0C6 2 5 2 5 2c-.3 1.15-.3 2.35 0 3.5A5.403 5.403 0 0 0 4 9c0 3.5 3 5.5 6 5.5-.39.49-.68 1.05-.85 1.65-.17.6-.22 1.23-.15 1.85v4"/><path d="M9 18c-4.51 2-5-2-7-2"/></svg>
 </a>
 
 </div>
 
 ```solidity
-import "@openzeppelin/src/fee/BaseDynamicFee.sol";
+import "uniswap-hooks/src/fee/BaseDynamicFee.sol";
 ```
 
 Base implementation to apply a dynamic fee via the `PoolManager`'s `updateDynamicLPFee` function.
@@ -481,16 +481,16 @@ The hook was attempted to be initialized with a non-dynamic fee.
 
 <div style={{marginTop: "4em"}} className="w-full flex flex-row items-center justify-between">
 
-## `BaseOverrideFee` 
+## `BaseOverrideFee`
 
-<a target="_blank" style={{marginTop: "1.5em"}} href="https://github.com/OpenZeppelin/openzeppelin-contracts/blob/v1.1.0/src/fee/BaseOverrideFee.sol">
+<a target="_blank" style={{marginTop: "1.5em"}} href="https://github.com/OpenZeppelin/uniswap-hooks/blob/v1.1.0/src/fee/BaseOverrideFee.sol">
 <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-github-icon lucide-github"><path d="M15 22v-4a4.8 4.8 0 0 0-1-3.5c3 0 6-2 6-5.5.08-1.25-.27-2.48-1-3.5.28-1.15.28-2.35 0-3.5 0 0-1 0-3 1.5-2.64-.5-5.36-.5-8 0C6 2 5 2 5 2c-.3 1.15-.3 2.35 0 3.5A5.403 5.403 0 0 0 4 9c0 3.5 3 5.5 6 5.5-.39.49-.68 1.05-.85 1.65-.17.6-.22 1.23-.15 1.85v4"/><path d="M9 18c-4.51 2-5-2-7-2"/></svg>
 </a>
 
 </div>
 
 ```solidity
-import "@openzeppelin/src/fee/BaseOverrideFee.sol";
+import "uniswap-hooks/src/fee/BaseOverrideFee.sol";
 ```
 
 Base implementation for automatic dynamic fees applied before swaps.
@@ -650,4 +650,3 @@ The hook was attempted to be initialized with a non-dynamic fee.
 
 </div>
 </div>
-

--- a/content/uniswap-hooks/api/general.mdx
+++ b/content/uniswap-hooks/api/general.mdx
@@ -7,16 +7,16 @@ description: "Smart contract general utilities and implementations"
 
 <div style={{marginTop: "4em"}} className="w-full flex flex-row items-center justify-between">
 
-## `AntiSandwichHook` 
+## `AntiSandwichHook`
 
-<a target="_blank" style={{marginTop: "1.5em"}} href="https://github.com/OpenZeppelin/openzeppelin-contracts/blob/v1.1.0/src/general/AntiSandwichHook.sol">
+<a target="_blank" style={{marginTop: "1.5em"}} href="https://github.com/OpenZeppelin/uniswap-hooks/blob/v1.1.0/src/general/AntiSandwichHook.sol">
 <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-github-icon lucide-github"><path d="M15 22v-4a4.8 4.8 0 0 0-1-3.5c3 0 6-2 6-5.5.08-1.25-.27-2.48-1-3.5.28-1.15.28-2.35 0-3.5 0 0-1 0-3 1.5-2.64-.5-5.36-.5-8 0C6 2 5 2 5 2c-.3 1.15-.3 2.35 0 3.5A5.403 5.403 0 0 0 4 9c0 3.5 3 5.5 6 5.5-.39.49-.68 1.05-.85 1.65-.17.6-.22 1.23-.15 1.85v4"/><path d="M9 18c-4.51 2-5-2-7-2"/></svg>
 </a>
 
 </div>
 
 ```solidity
-import "@openzeppelin/src/general/AntiSandwichHook.sol";
+import "uniswap-hooks/src/general/AntiSandwichHook.sol";
 ```
 
 This hook implements the sandwich-resistant AMM design introduced
@@ -228,16 +228,16 @@ Set the hook permissions, specifically `beforeSwap`, `afterSwap`, and `afterSwap
 
 <div style={{marginTop: "4em"}} className="w-full flex flex-row items-center justify-between">
 
-## `OrderIdLibrary` 
+## `OrderIdLibrary`
 
-<a target="_blank" style={{marginTop: "1.5em"}} href="https://github.com/OpenZeppelin/openzeppelin-contracts/blob/v1.1.0/src/general/LimitOrderHook.sol">
+<a target="_blank" style={{marginTop: "1.5em"}} href="https://github.com/OpenZeppelin/uniswap-hooks/blob/v1.1.0/src/general/LimitOrderHook.sol">
 <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-github-icon lucide-github"><path d="M15 22v-4a4.8 4.8 0 0 0-1-3.5c3 0 6-2 6-5.5.08-1.25-.27-2.48-1-3.5.28-1.15.28-2.35 0-3.5 0 0-1 0-3 1.5-2.64-.5-5.36-.5-8 0C6 2 5 2 5 2c-.3 1.15-.3 2.35 0 3.5A5.403 5.403 0 0 0 4 9c0 3.5 3 5.5 6 5.5-.39.49-.68 1.05-.85 1.65-.17.6-.22 1.23-.15 1.85v4"/><path d="M9 18c-4.51 2-5-2-7-2"/></svg>
 </a>
 
 </div>
 
 ```solidity
-import "@openzeppelin/src/general/LimitOrderHook.sol";
+import "uniswap-hooks/src/general/LimitOrderHook.sol";
 ```
 
 The order id library.
@@ -289,16 +289,16 @@ Increment the order id `a`. Might overflow.
 
 <div style={{marginTop: "4em"}} className="w-full flex flex-row items-center justify-between">
 
-## `LimitOrderHook` 
+## `LimitOrderHook`
 
-<a target="_blank" style={{marginTop: "1.5em"}} href="https://github.com/OpenZeppelin/openzeppelin-contracts/blob/v1.1.0/src/general/LimitOrderHook.sol">
+<a target="_blank" style={{marginTop: "1.5em"}} href="https://github.com/OpenZeppelin/uniswap-hooks/blob/v1.1.0/src/general/LimitOrderHook.sol">
 <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-github-icon lucide-github"><path d="M15 22v-4a4.8 4.8 0 0 0-1-3.5c3 0 6-2 6-5.5.08-1.25-.27-2.48-1-3.5.28-1.15.28-2.35 0-3.5 0 0-1 0-3 1.5-2.64-.5-5.36-.5-8 0C6 2 5 2 5 2c-.3 1.15-.3 2.35 0 3.5A5.403 5.403 0 0 0 4 9c0 3.5 3 5.5 6 5.5-.39.49-.68 1.05-.85 1.65-.17.6-.22 1.23-.15 1.85v4"/><path d="M9 18c-4.51 2-5-2-7-2"/></svg>
 </a>
 
 </div>
 
 ```solidity
-import "@openzeppelin/src/general/LimitOrderHook.sol";
+import "uniswap-hooks/src/general/LimitOrderHook.sol";
 ```
 
 Limit Order Mechanism hook.
@@ -920,16 +920,16 @@ Limit order is not filled.
 
 <div style={{marginTop: "4em"}} className="w-full flex flex-row items-center justify-between">
 
-## `LiquidityPenaltyHook` 
+## `LiquidityPenaltyHook`
 
-<a target="_blank" style={{marginTop: "1.5em"}} href="https://github.com/OpenZeppelin/openzeppelin-contracts/blob/v1.1.0/src/general/LiquidityPenaltyHook.sol">
+<a target="_blank" style={{marginTop: "1.5em"}} href="https://github.com/OpenZeppelin/uniswap-hooks/blob/v1.1.0/src/general/LiquidityPenaltyHook.sol">
 <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-github-icon lucide-github"><path d="M15 22v-4a4.8 4.8 0 0 0-1-3.5c3 0 6-2 6-5.5.08-1.25-.27-2.48-1-3.5.28-1.15.28-2.35 0-3.5 0 0-1 0-3 1.5-2.64-.5-5.36-.5-8 0C6 2 5 2 5 2c-.3 1.15-.3 2.35 0 3.5A5.403 5.403 0 0 0 4 9c0 3.5 3 5.5 6 5.5-.39.49-.68 1.05-.85 1.65-.17.6-.22 1.23-.15 1.85v4"/><path d="M9 18c-4.51 2-5-2-7-2"/></svg>
 </a>
 
 </div>
 
 ```solidity
-import "@openzeppelin/src/general/LiquidityPenaltyHook.sol";
+import "uniswap-hooks/src/general/LiquidityPenaltyHook.sol";
 ```
 
 Just-in-Time (JIT) liquidity provisioning resistant hook.
@@ -1312,4 +1312,3 @@ A penalty was attempted to be applied and donated to LP's in range, but there ar
 
 </div>
 </div>
-

--- a/content/uniswap-hooks/api/interfaces.mdx
+++ b/content/uniswap-hooks/api/interfaces.mdx
@@ -7,16 +7,16 @@ description: "Smart contract interfaces utilities and implementations"
 
 <div style={{marginTop: "4em"}} className="w-full flex flex-row items-center justify-between">
 
-## `IHookEvents` 
+## `IHookEvents`
 
-<a target="_blank" style={{marginTop: "1.5em"}} href="https://github.com/OpenZeppelin/openzeppelin-contracts/blob/v1.1.0/src/interfaces/IHookEvents.sol">
+<a target="_blank" style={{marginTop: "1.5em"}} href="https://github.com/OpenZeppelin/uniswap-hooks/blob/v1.1.0/src/interfaces/IHookEvents.sol">
 <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-github-icon lucide-github"><path d="M15 22v-4a4.8 4.8 0 0 0-1-3.5c3 0 6-2 6-5.5.08-1.25-.27-2.48-1-3.5.28-1.15.28-2.35 0-3.5 0 0-1 0-3 1.5-2.64-.5-5.36-.5-8 0C6 2 5 2 5 2c-.3 1.15-.3 2.35 0 3.5A5.403 5.403 0 0 0 4 9c0 3.5 3 5.5 6 5.5-.39.49-.68 1.05-.85 1.65-.17.6-.22 1.23-.15 1.85v4"/><path d="M9 18c-4.51 2-5-2-7-2"/></svg>
 </a>
 
 </div>
 
 ```solidity
-import "@openzeppelin/src/interfaces/IHookEvents.sol";
+import "uniswap-hooks/src/interfaces/IHookEvents.sol";
 ```
 
 Interface for standard hook events emission.
@@ -108,4 +108,3 @@ added in currency0 and currency1, defined by the `poolId`.
 
 </div>
 </div>
-

--- a/content/uniswap-hooks/api/utils.mdx
+++ b/content/uniswap-hooks/api/utils.mdx
@@ -7,16 +7,16 @@ description: "Smart contract utils utilities and implementations"
 
 <div style={{marginTop: "4em"}} className="w-full flex flex-row items-center justify-between">
 
-## `CurrencySettler` 
+## `CurrencySettler`
 
-<a target="_blank" style={{marginTop: "1.5em"}} href="https://github.com/OpenZeppelin/openzeppelin-contracts/blob/v1.1.0/src/utils/CurrencySettler.sol">
+<a target="_blank" style={{marginTop: "1.5em"}} href="https://github.com/OpenZeppelin/uniswap-hooks/blob/v1.1.0/src/utils/CurrencySettler.sol">
 <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-github-icon lucide-github"><path d="M15 22v-4a4.8 4.8 0 0 0-1-3.5c3 0 6-2 6-5.5.08-1.25-.27-2.48-1-3.5.28-1.15.28-2.35 0-3.5 0 0-1 0-3 1.5-2.64-.5-5.36-.5-8 0C6 2 5 2 5 2c-.3 1.15-.3 2.35 0 3.5A5.403 5.403 0 0 0 4 9c0 3.5 3 5.5 6 5.5-.39.49-.68 1.05-.85 1.65-.17.6-.22 1.23-.15 1.85v4"/><path d="M9 18c-4.51 2-5-2-7-2"/></svg>
 </a>
 
 </div>
 
 ```solidity
-import "@openzeppelin/src/utils/CurrencySettler.sol";
+import "uniswap-hooks/src/utils/CurrencySettler.sol";
 ```
 
 Library used to interact with the `PoolManager` to settle any open deltas.
@@ -66,4 +66,3 @@ Deltas are synced before any ERC-20 transfers in [`CurrencySettler.settle`](#Cur
 
 </div>
 </div>
-

--- a/content/uniswap-hooks/index.mdx
+++ b/content/uniswap-hooks/index.mdx
@@ -72,4 +72,4 @@ In order to facilitate understanding of Uniswap Hooks and help start building wi
 
 Contracts in the hooks library are provided as is, with no particular guarantees, including backward compatibility.
 
-We kindly ask to report any issue directly to our security mailto:security@openzeppelin.org[contact]. The team will do its best to assist and mitigate any potential misuses of the library.
+We kindly ask to report any issue directly to our security [contact](mailto:security@openzeppelin.org). The team will do its best to assist and mitigate any potential misuses of the library.

--- a/content/upgrades-plugins/foundry/foundry-defender.mdx
+++ b/content/upgrades-plugins/foundry/foundry-defender.mdx
@@ -17,7 +17,7 @@ See [Using with Foundry - Installation](foundry-upgrades#installation).
 1. Install [Node.js](https://nodejs.org/).
 2. Configure your `foundry.toml` to enable ffi, ast, build info and storage layout:
 
-```json
+```toml
 [profile.default]
 ffi = true
 ast = true
@@ -26,7 +26,7 @@ extra_output = ["storageLayout"]
 ```
 
 <Callout>
-Metadata must also be included in the compiler output, which it is by default.  
+Metadata must also be included in the compiler output, which it is by default.
 </Callout>
 
 1. Set the following environment variables in your `.env` file at your project root, using your Team API key and secret from OpenZeppelin Defender:
@@ -65,23 +65,23 @@ To deploy a UUPS proxy, create a script called `Defender.s.sol` like the followi
 ```solidity
 pragma solidity ^0.8.20;
 
-import Script from "forge-std/Script.sol";
-import console from "forge-std/console.sol";
+import {Script} from "forge-std/Script.sol";
+import {console} from "forge-std/console.sol";
 
-import Defender, ApprovalProcessResponse from "openzeppelin-foundry-upgrades/Defender.sol";
-import Upgrades, Options from "openzeppelin-foundry-upgrades/Upgrades.sol";
+import {Defender, ApprovalProcessResponse} from "openzeppelin-foundry-upgrades/Defender.sol";
+import {Upgrades, Options} from "openzeppelin-foundry-upgrades/Upgrades.sol";
 
-import MyContract from "../src/MyContract.sol";
+import {MyContract} from "../src/MyContract.sol";
 
-contract DefenderScript is Script 
-    function setUp() public {
+contract DefenderScript is Script {
+    function setUp() public {}
 
-    function run() public 
+    function run() public {
         ApprovalProcessResponse memory upgradeApprovalProcess = Defender.getUpgradeApprovalProcess();
 
         if (upgradeApprovalProcess.via == address(0)) {
             revert(string.concat("Upgrade approval process with id ", upgradeApprovalProcess.approvalProcessId, " has no assigned address"));
-        
+        }
 
         Options memory opts;
         opts.defender.useDefenderDeploy = true;
@@ -116,17 +116,17 @@ To propose an upgrade through Defender, create a script like the following:
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.20;
 
-import Script from "forge-std/Script.sol";
-import console from "forge-std/console.sol";
+import {Script} from "forge-std/Script.sol";
+import {console} from "forge-std/console.sol";
 
-import MyContractV2 from "../src/MyContractV2.sol";
+import {MyContractV2} from "../src/MyContractV2.sol";
 
-import ProposeUpgradeResponse, Defender, Options from "openzeppelin-foundry-upgrades/Defender.sol";
+import {ProposeUpgradeResponse, Defender, Options} from "openzeppelin-foundry-upgrades/Defender.sol";
 
-contract DefenderScript is Script 
-    function setUp() public {
+contract DefenderScript is Script {
+    function setUp() public {}
 
-    function run() public 
+    function run() public {
         Options memory opts;
         ProposeUpgradeResponse memory response = Defender.proposeUpgrade(
             <MY_PROXY_ADDRESS>,
@@ -135,7 +135,7 @@ contract DefenderScript is Script
         );
         console.log("Proposal id", response.proposalId);
         console.log("Url", response.url);
-    
+    }
 }
 ```
 
@@ -151,20 +151,20 @@ To deploy a non-upgradeable contract, create a script called `Defender.s.sol` li
 ```solidity
 pragma solidity ^0.8.20;
 
-import Script from "forge-std/Script.sol";
-import console from "forge-std/console.sol";
+import {Script} from "forge-std/Script.sol";
+import {console} from "forge-std/console.sol";
 
-import MyContract from "../src/MyContract.sol";
+import {MyContract} from "../src/MyContract.sol";
 
-import Defender from "openzeppelin-foundry-upgrades/Defender.sol";
+import {Defender} from "openzeppelin-foundry-upgrades/Defender.sol";
 
-contract DefenderScript is Script 
-    function setUp() public {
+contract DefenderScript is Script {
+    function setUp() public {}
 
-    function run() public 
+    function run() public {
         address deployed = Defender.deployContract("MyContract.sol", abi.encode("arguments for the constructor"));
         console.log("Deployed contract to address", deployed);
-    
+    }
 }
 ```
 

--- a/content/upgrades-plugins/foundry/foundry-upgrades.mdx
+++ b/content/upgrades-plugins/foundry/foundry-upgrades.mdx
@@ -109,7 +109,7 @@ If you want to use a custom output directory, set it in your `foundry.toml` and 
 ```toml
 [profile.default]
 out = "my-output-dir"
-fs_permissions = [ access = "read", path = "my-output-dir" ]
+fs_permissions = [{ access = "read", path = "my-output-dir" }]
 ```
 
 Then in a `.env` at your project root, set the `FOUNDRY_OUT` environment variable to match the custom output directory, for example:
@@ -130,11 +130,10 @@ OPENZEPPELIN_BASH_PATH="C:/Program Files/Git/bin/bash"
 
 Depending on which major version of OpenZeppelin Contracts you are using, and whether you want to run upgrade safety validations and/or use OpenZeppelin Defender, use the table below to determine which library to import:
 
-|     |     |     |
+|     | OpenZeppelin Contracts v5 | OpenZeppelin Contracts v4 |
 | --- | --- | --- |
-|  | OpenZeppelin Contracts v5 | OpenZeppelin Contracts v4 |
-| **Runs validations, supports Defender** | `import Upgrades from "openzeppelin-foundry-upgrades/Upgrades.sol";` | `import Upgrades from "openzeppelin-foundry-upgrades/LegacyUpgrades.sol";` |
-| **No validations, does not support Defender** | `import UnsafeUpgrades from "openzeppelin-foundry-upgrades/Upgrades.sol";` | `import UnsafeUpgrades from "openzeppelin-foundry-upgrades/LegacyUpgrades.sol";` |
+| **Runs validations, supports Defender** | `import {Upgrades} from "openzeppelin-foundry-upgrades/Upgrades.sol";` | `import {Upgrades} from "openzeppelin-foundry-upgrades/LegacyUpgrades.sol";` |
+| **No validations, does not support Defender** | `import {UnsafeUpgrades} from "openzeppelin-foundry-upgrades/Upgrades.sol";` | `import {UnsafeUpgrades} from "openzeppelin-foundry-upgrades/LegacyUpgrades.sol";` |
 
 Import one of the above libraries in your Foundry scripts or tests, for example:
 ```solidity

--- a/content/upgrades-plugins/foundry/foundry-upgrades.mdx
+++ b/content/upgrades-plugins/foundry/foundry-upgrades.mdx
@@ -87,7 +87,7 @@ If you want to be able to run upgrade safety validations, the following are need
 1. Install [Node.js](https://nodejs.org/).
 2. Configure your `foundry.toml` to enable ffi, ast, build info and storage layout:
 
-```json
+```toml
 [profile.default]
 ffi = true
 ast = true
@@ -106,7 +106,7 @@ By default, this library assumes your Foundry output directory is set to "out".
 
 If you want to use a custom output directory, set it in your `foundry.toml` and provide read permissions for the directory. For example (replace `my-output-dir` with the directory that you want to use):
 
-```json
+```toml
 [profile.default]
 out = "my-output-dir"
 fs_permissions = [ access = "read", path = "my-output-dir" ]
@@ -138,12 +138,12 @@ Depending on which major version of OpenZeppelin Contracts you are using, and wh
 
 Import one of the above libraries in your Foundry scripts or tests, for example:
 ```solidity
-import Upgrades from "openzeppelin-foundry-upgrades/Upgrades.sol";
+import {Upgrades} from "openzeppelin-foundry-upgrades/Upgrades.sol";
 ```
 
 Also import the implementation contract that you want to validate, deploy, or upgrade to, for example:
 ```solidity
-import MyToken from "src/MyToken.sol";
+import {MyToken} from "src/MyToken.sol";
 ```
 
 Then call functions from the imported library to run validations, deployments, or upgrades.


### PR DESCRIPTION
Used the regex `\[([^\]]+)\]\(([^)]+)\)` to find all patterns of links
that used `[somelink](somelink)` to instead use their full path
