### PR TITLE
chore: update netlify.toml

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -8,6 +8,41 @@ package = "@netlify/plugin-nextjs"
 # OpenZeppelin Contracts
 
 [[redirects]]
+from = "/contracts/erc20"
+to = "/contracts/5.x/erc20"
+status = 301
+
+[[redirects]]
+from = "/contracts/erc721"
+to = "/contracts/5.x/erc721"
+status = 301
+
+[[redirects]]
+from = "/contracts/access-control"
+to = "/contracts/5.x/access-control"
+status = 301
+
+[[redirects]]
+from = "/contracts/utilities"
+to = "/contracts/5.x/utilities"
+status = 301
+
+[[redirects]]
+from = "/contracts/backwards-compatibility"
+to = "/contracts/5.x/backwards-compatibility"
+status = 301
+
+[[redirects]]
+from = "/contracts/tokens"
+to = "/contracts/5.x/tokens"
+status = 301
+
+[[redirects]]
+from = "/contracts/api/token/ERC20"
+to = "/contracts/5.x/api/token/ERC20"
+status = 301
+
+[[redirects]]
 from = "/contracts/2.x/*"
 to = "/contracts/:splat"
 status = 301


### PR DESCRIPTION
Adds missing redirects used in `openzeppelin/openzeppelin-contracts` README.md