### PR TITLE
Update Wizard to use Contracts version 5.5.0

### DIFF
--- a/content/contracts/5.x/accounts.mdx
+++ b/content/contracts/5.x/accounts.mdx
@@ -10,7 +10,7 @@ User operations are validated using an [`AbstractSigner`](/contracts/5.x/api/uti
 
 To setup an account, you can either start configuring it using our Wizard and selecting a predefined validation scheme, or bring your own logic and start by inheriting [`Account`](/contracts/5.x/api/account#Account) from scratch.
 
-<OZWizard tab="Account" version="5.4.0" />
+<OZWizard tab="Account" version="5.5.0" />
 
 <Callout>
 Accounts don’t support [ERC-721](./erc721) and [ERC-1155](./erc1155) tokens natively since these require the receiving address to implement an acceptance check. It is recommended to inherit [ERC721Holder](/contracts/5.x/api/token/ERC721#ERC721Holder), [ERC1155Holder](/contracts/5.x/api/token/ERC1155#ERC1155Holder) to include these checks in your account.

--- a/content/contracts/5.x/wizard.mdx
+++ b/content/contracts/5.x/wizard.mdx
@@ -9,4 +9,4 @@ contract and learn about the components offered in OpenZeppelin Contracts.
 Place the resulting contract in your `contracts` or `src` directory in order to compile it with a tool like Hardhat or Foundry. Consider reading our guide on [Developing Smart Contracts](./learn/developing-smart-contracts) for more guidance!
 </Callout>
 
-<OZWizard version="5.4.0" />
+<OZWizard version="5.5.0" />


### PR DESCRIPTION
Updates parameter for Wizard to be version 5.5.0, otherwise it gives an error about incompatible versions.