### PR TITLE
Fix ERC4626 math rendering in 4.x & 5.x

### DIFF
--- a/content/contracts/4.x/erc4626.mdx
+++ b/content/contracts/4.x/erc4626.mdx
@@ -57,26 +57,26 @@ In math that gives:
 * $a_1$ the attacker donation
 * $u$ the user deposit
 
-|  |
+|  | Assets | Shares | Rate |
 | --- | --- | --- | --- |
-| Assets | Shares | Rate | initial |
-| $0$ | $0$ | - | after attacker’s deposit |
-| $a_0$ | $a_0$ | $1$ | after attacker’s donation |
+| initial | $0$ | $0$ | - |
+| after attacker’s deposit | $a_0$ | $a_0$ | $1$ |
+| after attacker’s donation | $a_0 + a_1$ | $a_0$ | $\frac{a_0 +a_1}{a_0}$ |
 
-This means a deposit of $u$ will give $\fracu \times a_0a_0 + a_1$ shares.
+This means a deposit of $u$ will give $\frac{u \times a_0}{a_0 + a_1}$ shares.
 
 For the attacker to dilute that deposit to 0 shares, causing the user to lose all its deposit, it must ensure that
 
 ```math
-\fracu \times a_0a_0+a_1 < 1 \iff u < 1 + \fraca_1a_0
+\frac{u \times a_0}{a_0+a_1} < 1 \iff u < 1 + \frac{a_1}{a_0}
 ```
 
 Using $a_0 = 1$ and $a_1 = u$ is enough. So the attacker only needs $u+1$ assets to perform a successful attack.
 
-It is easy to generalize the above results to scenarios where the attacker is going after a smaller fraction of the user’s deposit. In order to target $\fracun$, the user needs to suffer rounding of a similar fraction, which means the user must receive at most $n$ shares. This results in:
+It is easy to generalize the above results to scenarios where the attacker is going after a smaller fraction of the user’s deposit. In order to target $\frac{u}{n}$, the user needs to suffer rounding of a similar fraction, which means the user must receive at most $n$ shares. This results in:
 
 ```math
-\fracu \times a_0a_0+a_1 < n \iff \fracun < 1 + \fraca_1a_0
+\frac{u \times a_0}{a_0+a_1} < n \iff \frac{u}{n} < 1 + \frac{a_1}{a_0}
 ```
 
 In this scenario, the attack is $n$ times less powerful (in how much it is stealing) and costs $n$ times less to execute. In both cases, the amount of funds the attacker needs to commit is equivalent to its potential earnings.
@@ -97,40 +97,40 @@ Following the previous math definitions, we have:
 * $a_1$ the attacker donation
 * $u$ the user deposit
 
-|  |
+|  | Assets | Shares | Rate |
 | --- | --- | --- | --- |
-| Assets | Shares | Rate | initial |
-| $1$ | $10^\delta$ | $10^\delta$ | after attacker’s deposit |
-| $1+a_0$ | $10^\delta \times (1+a_0)$ | $10^\delta$ | after attacker’s donation |
+| initial | $1$ | $10^\delta$ | $10^\delta$ |
+| after attacker’s deposit | $1+a_0$ | $10^\delta \times (1+a_0)$ | $10^\delta$ 
+| after attacker’s donation | $1+a_0+a_1$ | $10^\delta \times (1+a_0)$ | $10^\delta$ |
 
-One important thing to note is that the attacker only owns a fraction $\fraca_01 + a_0$ of the shares, so when doing the donation, he will only be able to recover that fraction $\fraca_1 \times a_01 + a_0$ of the donation. The remaining $\fraca_11+a_0$ are captured by the vault.
+One important thing to note is that the attacker only owns a fraction $\frac{a_0}{1 + a_0}$ of the shares, so when doing the donation, he will only be able to recover that fraction $\frac{a_1 \times a_0}{1 + a_0}$ of the donation. The remaining $\frac{a_1}{1+a_0}$ are captured by the vault.
 
 ```math
-\mathitloss = \fraca_11+a_0
+\mathit{loss} = \frac{a_1}{1+a_0}
 ```
 
 When the user deposits $u$, he receives
 
 ```math
-10^\delta \times u \times \frac1+a_01+a_0+a_1
+10^\delta \times u \times \frac{1+a_0}{1+a_0+a_1}
 ```
 
 For the attacker to dilute that deposit to 0 shares, causing the user to lose all its deposit, it must ensure that
 
 ```math
-10^\delta \times u \times \frac1+a_01+a_0+a_1 < 1
+10^\delta \times u \times \frac{1+a_0}{1+a_0+a_1} < 1
 ```
 
 ```math
-\iff 10^\delta \times u < \frac1+a_0+a_11+a_0
+\iff 10^\delta \times u < \frac{1+a_0+a_1}{1+a_0}
 ```
 
 ```math
-\iff 10^\delta \times u < 1 + \fraca_11+a_0
+\iff 10^\delta \times u < 1 + \frac{a_1}{1+a_0}
 ```
 
 ```math
-\iff 10^\delta \times u \le \mathitloss
+\iff 10^\delta \times u \le \mathit{loss}
 ```
 
 * If the offset is 0, the attacker loss is at least equal to the user’s deposit.

--- a/content/contracts/4.x/erc4626.mdx
+++ b/content/contracts/4.x/erc4626.mdx
@@ -101,7 +101,7 @@ Following the previous math definitions, we have:
 | --- | --- | --- | --- |
 | initial | $1$ | $10^\delta$ | $10^\delta$ |
 | after attacker’s deposit | $1+a_0$ | $10^\delta \times (1+a_0)$ | $10^\delta$ 
-| after attacker’s donation | $1+a_0+a_1$ | $10^\delta \times (1+a_0)$ | $10^\delta$ |
+| after attacker’s donation | $1+a_0+a_1$ | $10^\delta \times (1+a_0)$ | $10^\delta \times \frac{1+a_0}{1+a_0+a_1}$ |
 
 One important thing to note is that the attacker only owns a fraction $\frac{a_0}{1 + a_0}$ of the shares, so when doing the donation, he will only be able to recover that fraction $\frac{a_1 \times a_0}{1 + a_0}$ of the donation. The remaining $\frac{a_1}{1+a_0}$ are captured by the vault.
 

--- a/content/contracts/5.x/erc4626.mdx
+++ b/content/contracts/5.x/erc4626.mdx
@@ -101,7 +101,7 @@ Following the previous math definitions, we have:
 | --- | --- | --- | --- |
 | initial | $1$ | $10^\delta$ | $10^\delta$ |
 | after attacker's deposit | $1+a_0$ | $10^\delta \times (1+a_0)$ | $10^\delta$ |
-| after attacker's donation | $1+a_0+a_1$ | $10^\delta \times (1+a_0)$ | $10^\delta$ |
+| after attacker's donation | $1+a_0+a_1$ | $10^\delta \times (1+a_0)$ | $10^\delta \times \frac{1+a_0}{1+a_0+a_1}$ |
 
 One important thing to note is that the attacker only owns a fraction $\frac{a_0}{1 + a_0}$ of the shares, so when doing the donation, he will only be able to recover that fraction $\frac{a_1 \times a_0}{1 + a_0}$ of the donation. The remaining $\frac{a_1}{1+a_0}$ are captured by the vault.
 

--- a/content/contracts/5.x/erc4626.mdx
+++ b/content/contracts/5.x/erc4626.mdx
@@ -61,9 +61,9 @@ In math that gives:
 | --- | --- | --- | --- |
 | initial | $0$ | $0$ | - |
 | after attacker's deposit | $a_0$ | $a_0$ | $1$ |
-| after attacker's donation | $a_0 + a_1$ | $a_0$ | $\fraca_0 + a_1a_0$ |
+| after attacker's donation | $a_0 + a_1$ | $a_0$ | $\frac{a_0 + a_1}{a_0}$ |
 
-This means a deposit of $u$ will give $\fracu \times a_0a_0 + a_1$ shares.
+This means a deposit of $u$ will give $\frac{u \times a_0}{a_0 + a_1}$ shares.
 
 For the attacker to dilute that deposit to 0 shares, causing the user to lose all its deposit, it must ensure that
 
@@ -73,7 +73,7 @@ For the attacker to dilute that deposit to 0 shares, causing the user to lose al
 
 Using $a_0 = 1$ and $a_1 = u$ is enough. So the attacker only needs $u+1$ assets to perform a successful attack.
 
-It is easy to generalize the above results to scenarios where the attacker is going after a smaller fraction of the user’s deposit. In order to target $\fracun$, the user needs to suffer rounding of a similar fraction, which means the user must receive at most $n$ shares. This results in:
+It is easy to generalize the above results to scenarios where the attacker is going after a smaller fraction of the user’s deposit. In order to target $\frac{u}{n}$, the user needs to suffer rounding of a similar fraction, which means the user must receive at most $n$ shares. This results in:
 
 ```math
 \frac{u \times a_0}{a_0+a_1} < n \iff \frac{u}{n} < 1 + \frac{a_1}{a_0}
@@ -103,7 +103,7 @@ Following the previous math definitions, we have:
 | after attacker's deposit | $1+a_0$ | $10^\delta \times (1+a_0)$ | $10^\delta$ |
 | after attacker's donation | $1+a_0+a_1$ | $10^\delta \times (1+a_0)$ | $10^\delta$ |
 
-One important thing to note is that the attacker only owns a fraction $\fraca_01 + a_0$ of the shares, so when doing the donation, he will only be able to recover that fraction $\fraca_1 \times a_01 + a_0$ of the donation. The remaining $\fraca_11+a_0$ are captured by the vault.
+One important thing to note is that the attacker only owns a fraction $\frac{a_0}{1 + a_0}$ of the shares, so when doing the donation, he will only be able to recover that fraction $\frac{a_1 \times a_0}{1 + a_0}$ of the donation. The remaining $\frac{a_1}{1+a_0}$ are captured by the vault.
 
 ```math
 \mathit{loss} = \frac{a_1}{1+a_0}

--- a/scripts/link-validation.ts
+++ b/scripts/link-validation.ts
@@ -4,6 +4,7 @@ import {
 	scanURLs,
 	validateFiles,
 } from "next-validate-link";
+import remarkMath from "remark-math";
 import type { InferPageType } from "fumadocs-core/source";
 import { source } from "@/lib/source";
 import { writeFileSync } from "fs";
@@ -60,6 +61,7 @@ async function checkLinks() {
 			components: {
 				Card: { attributes: ["href"] },
 			},
+			remarkPlugins: [remarkMath],
 		},
 		ignoreFragment: ignoreFragments,
 		// check relative paths


### PR DESCRIPTION
## Documentation Pull Request

### Summary
<!-- Briefly describe what documentation changes are included in this PR -->

Fix malformed KaTeX/TeX expressions in the ERC 4626 guides for `4.x` and `5.x` that were rendering incorrectly. Added `remark-math` to the link validator so `pnpm run check` can parse valid inline LaTeX in MDX without failing. This fixes `lint:links` acorn error.

### Type of Change
<!-- Check all that apply -->
- [ ] New documentation
- [ ] Documentation update/revision
- [x] Fix typos or grammar
- [ ] Restructure/reorganize content
- [ ] Add examples or tutorials
- [ ] Update API documentation
- [ ] Other: ___________

### Related Issues
<!-- Link any related issues -->

Example of rendering issue below:
<img width="501" height="702" alt="image" src="https://github.com/user-attachments/assets/91b78dcb-2ad7-47ef-aadf-35ace40d82f3" />


### Checklist
- [ ] Build succeeds locally with `pnpm run build`
- [ ] Lint is successful when running `pnpm run check`
- [ ] Docs follow [OpenZeppelin Documentation Standards](https://github.com/OpenZeppelin/docs/blob/main/STANDARDS.md)

### Additional Notes
<!-- Any additional context, concerns, or information for reviewers -->
