### PR TITLE
Add Hardhat Upgrades docs for Hardhat 3

### DIFF
--- a/content/upgrades-plugins/api-hardhat-upgrades.mdx
+++ b/content/upgrades-plugins/api-hardhat-upgrades.mdx
@@ -3,7 +3,7 @@ title: OpenZeppelin Hardhat Upgrades API
 ---
 
 <Callout>
-This is the documentation for Hardhat 3. For Hardhat 2, see the [Hardhat 2 (legacy) API docs](/upgrades-plugins/hardhat-2/api-hardhat-upgrades).
+This is the documentation for Hardhat 3. For Hardhat 2, see the [Hardhat Upgrades API docs (Hardhat 2)](/upgrades-plugins/hardhat-2/api-hardhat-upgrades).
 </Callout>
 
 Both `deployProxy` and `upgradeProxy` functions will return instances of [ethers.js contracts](https://docs.ethers.org/v6/api/contract/#Contract), and require [ethers.js contract factories](https://docs.ethers.org/v6/api/contract/#ContractFactory) as arguments. For [beacons](/contracts/5.x/api/proxy#beacon), `deployBeacon` and `upgradeBeacon` will both return an upgradable beacon instance that can be used with a beacon proxy. All deploy and upgrade functions validate that the implementation contract is upgrade-safe, and will fail otherwise.

--- a/content/upgrades-plugins/api-hardhat-upgrades.mdx
+++ b/content/upgrades-plugins/api-hardhat-upgrades.mdx
@@ -6,7 +6,25 @@ title: OpenZeppelin Hardhat Upgrades API
 This is the documentation for Hardhat 3. For Hardhat 2, see the [Hardhat 2 (legacy) API docs](/upgrades-plugins/hardhat-2/api-hardhat-upgrades).
 </Callout>
 
-Both `deployProxy` and `upgradeProxy` functions will return instances of [ethers.js contracts](https://docs.ethers.io/v5/api/contract/contract), and require [ethers.js contract factories](https://docs.ethers.io/v5/api/contract/contract-factory) as arguments. For [beacons](/contracts/5.x/api/proxy#beacon), `deployBeacon` and `upgradeBeacon` will both return an upgradable beacon instance that can be used with a beacon proxy. All deploy and upgrade functions validate that the implementation contract is upgrade-safe, and will fail otherwise.
+Both `deployProxy` and `upgradeProxy` functions will return instances of [ethers.js contracts](https://docs.ethers.org/v6/api/contract/#Contract), and require [ethers.js contract factories](https://docs.ethers.org/v6/api/contract/#ContractFactory) as arguments. For [beacons](/contracts/5.x/api/proxy#beacon), `deployBeacon` and `upgradeBeacon` will both return an upgradable beacon instance that can be used with a beacon proxy. All deploy and upgrade functions validate that the implementation contract is upgrade-safe, and will fail otherwise.
+
+## Setup
+
+In Hardhat 3, all of the functions below are accessed via an `upgradesApi` object created from the `upgrades` factory. Defender-specific functions (`defender.*`) are accessed via `defenderApi` from the `defender` factory. Both factories take a network connection as an argument; share one connection across your operations.
+
+```typescript
+import hre from 'hardhat';
+import { upgrades, defender } from '@openzeppelin/hardhat-upgrades';
+
+const connection = await hre.network.connect();
+const { ethers } = connection;
+const upgradesApi = await upgrades(hre, connection);
+
+// For Defender-specific functions:
+const defenderApi = await defender(hre, connection);
+```
+
+`upgradesApi` exposes every top-level function documented below (e.g. `upgradesApi.deployProxy(...)`). `defenderApi` exposes the same functions plus the `defender.*` functions (e.g. `defenderApi.deployContract(...)`, `defenderApi.proposeUpgradeWithApproval(...)`). The `admin`, `erc1967`, and `beacon` namespaces are accessed as `upgradesApi.admin.*`, `upgradesApi.erc1967.*`, and `upgradesApi.beacon.*`.
 
 ## Common Options
 
@@ -365,19 +383,29 @@ Validates a new implementation contract without deploying it and without actuall
 
 Validate upgrading an existing proxy to a new contract (replace `PROXY_ADDRESS` with the address of your proxy):
 ```ts
-const  ethers, upgrades  = require('hardhat');
+import hre from 'hardhat';
+import { upgrades } from '@openzeppelin/hardhat-upgrades';
+
+const connection = await hre.network.connect();
+const { ethers } = connection;
+const upgradesApi = await upgrades(hre, connection);
 
 const BoxV2 = await ethers.getContractFactory('BoxV2');
-await upgrades.validateUpgrade(PROXY_ADDRESS, BoxV2);
+await upgradesApi.validateUpgrade(PROXY_ADDRESS, BoxV2);
 ```
 
 Validate upgrading between two contract implementations:
 ```ts
-const  ethers, upgrades  = require('hardhat');
+import hre from 'hardhat';
+import { upgrades } from '@openzeppelin/hardhat-upgrades';
+
+const connection = await hre.network.connect();
+const { ethers } = connection;
+const upgradesApi = await upgrades(hre, connection);
 
 const Box = await ethers.getContractFactory('Box');
 const BoxV2 = await ethers.getContractFactory('BoxV2');
-await upgrades.validateUpgrade(Box, BoxV2);
+await upgradesApi.validateUpgrade(Box, BoxV2);
 ```
 
 ## prepareUpgrade
@@ -671,27 +699,25 @@ To use this task, ensure you have hardhat-verify installed:
 npm install --save-dev @nomicfoundation/hardhat-verify
 ```
 
-Then import the `@nomicfoundation/hardhat-verify` plugin along with the `@openzeppelin/hardhat-upgrades` plugin in your Hardhat configuration.
-For example, if you are using JavaScript, import the plugins in `hardhat.config.js`:
-```js
-require("@nomicfoundation/hardhat-verify");
-require("@openzeppelin/hardhat-upgrades");
-```
-Or if you are using TypeScript, import the plugins in `hardhat.config.ts`:
-```ts
-import "@nomicfoundation/hardhat-verify";
-import "@openzeppelin/hardhat-upgrades";
+Then add both `@nomicfoundation/hardhat-verify` and `@openzeppelin/hardhat-upgrades` to the `plugins` array in your `hardhat.config.ts`. The upgrades plugin detects hardhat-verify and automatically extends its `verify` task:
+```typescript
+import { configVariable, defineConfig } from ‘hardhat/config’;
+import hardhatVerify from ‘@nomicfoundation/hardhat-verify’;
+import hardhatUpgrades from ‘@openzeppelin/hardhat-upgrades’;
+
+export default defineConfig({
+  plugins: [hardhatVerify, hardhatUpgrades],
+  verify: {
+    etherscan: {
+      apiKey: configVariable(‘ETHERSCAN_API_KEY’),
+    },
+  },
+});
 ```
 
-Finally, follow [hardhat-verify’s usage documentation](https://hardhat.org/hardhat-runner/plugins/nomicfoundation-hardhat-verify#usage) to configure your Etherscan API key and run the `verify` task from the command line with the proxy address:
+Then run the `verify` task from the command line with the proxy address:
 ```
 npx hardhat verify --network mainnet PROXY_ADDRESS
 ```
-or programmatically using the [`verify:verify` subtask](https://hardhat.org/hardhat-runner/plugins/nomicfoundation-hardhat-verify#using-programmatically):
-```javascript
-await hre.run("verify:verify",
-  address: PROXY_ADDRESS,
-);
-```
 
-Note that you do not need to include constructor arguments when verifying if your implementation contract only uses initializers.  However, if your implementation contract has an actual constructor with arguments (such as to set immutable variables), then include constructor arguments according to the usage information for the [task](https://hardhat.org/hardhat-runner/plugins/nomicfoundation-hardhat-verify#usage) or [subtask](https://hardhat.org/hardhat-runner/plugins/nomicfoundation-hardhat-verify#using-programmatically).
+Note that you do not need to include constructor arguments when verifying if your implementation contract only uses initializers.  However, if your implementation contract has an actual constructor with arguments (such as to set immutable variables), then include constructor arguments according to the usage information for the [task](https://hardhat.org/hardhat-runner/plugins/nomicfoundation-hardhat-verify#usage).

--- a/content/upgrades-plugins/api-hardhat-upgrades.mdx
+++ b/content/upgrades-plugins/api-hardhat-upgrades.mdx
@@ -701,15 +701,15 @@ npm install --save-dev @nomicfoundation/hardhat-verify
 
 Then add both `@nomicfoundation/hardhat-verify` and `@openzeppelin/hardhat-upgrades` to the `plugins` array in your `hardhat.config.ts`. The upgrades plugin detects hardhat-verify and automatically extends its `verify` task:
 ```typescript
-import { configVariable, defineConfig } from ‘hardhat/config’;
-import hardhatVerify from ‘@nomicfoundation/hardhat-verify’;
-import hardhatUpgrades from ‘@openzeppelin/hardhat-upgrades’;
+import { configVariable, defineConfig } from 'hardhat/config';
+import hardhatVerify from '@nomicfoundation/hardhat-verify';
+import hardhatUpgrades from '@openzeppelin/hardhat-upgrades';
 
 export default defineConfig({
   plugins: [hardhatVerify, hardhatUpgrades],
   verify: {
     etherscan: {
-      apiKey: configVariable(‘ETHERSCAN_API_KEY’),
+      apiKey: configVariable('ETHERSCAN_API_KEY'),
     },
   },
 });

--- a/content/upgrades-plugins/api-hardhat-upgrades.mdx
+++ b/content/upgrades-plugins/api-hardhat-upgrades.mdx
@@ -10,13 +10,13 @@ Both `deployProxy` and `upgradeProxy` functions will return instances of [ethers
 
 ## Setup
 
-In Hardhat 3, all of the functions below are accessed via an `upgradesApi` object created from the `upgrades` factory. Defender-specific functions (`defender.*`) are accessed via `defenderApi` from the `defender` factory. Both factories take a network connection as an argument; share one connection across your operations.
+In Hardhat 3, all of the functions below are accessed via an `upgradesApi` object created from the `upgrades` factory. Defender-specific functions (`defender.*`) are accessed via `defenderApi` from the `defender` factory. Both factories take a network connection as an argument; share one connection across your operations. (Or use `hre.network.getOrCreate()`, which reuses a connection per network instead of creating a new one each time.)
 
 ```typescript
 import hre from 'hardhat';
 import { upgrades, defender } from '@openzeppelin/hardhat-upgrades';
 
-const connection = await hre.network.connect();
+const connection = await hre.network.create();
 const { ethers } = connection;
 const upgradesApi = await upgrades(hre, connection);
 
@@ -386,7 +386,7 @@ Validate upgrading an existing proxy to a new contract (replace `PROXY_ADDRESS` 
 import hre from 'hardhat';
 import { upgrades } from '@openzeppelin/hardhat-upgrades';
 
-const connection = await hre.network.connect();
+const connection = await hre.network.create();
 const { ethers } = connection;
 const upgradesApi = await upgrades(hre, connection);
 
@@ -399,7 +399,7 @@ Validate upgrading between two contract implementations:
 import hre from 'hardhat';
 import { upgrades } from '@openzeppelin/hardhat-upgrades';
 
-const connection = await hre.network.connect();
+const connection = await hre.network.create();
 const { ethers } = connection;
 const upgradesApi = await upgrades(hre, connection);
 

--- a/content/upgrades-plugins/defender-deploy.mdx
+++ b/content/upgrades-plugins/defender-deploy.mdx
@@ -2,6 +2,10 @@
 title: OpenZeppelin Defender with Hardhat
 ---
 
+<Callout>
+This page describes usage with Hardhat 2. If you are on Hardhat 3, apply the patterns from [Using with Hardhat](/upgrades-plugins/hardhat-upgrades) (ESM, `defineConfig`, and the `defender(hre, connection)` factory) to the examples below.
+</Callout>
+
 The Hardhat Upgrades package can use [OpenZeppelin Defender](/defender) for deployments instead of ethers.js, which allows for features such as gas pricing estimation, resubmissions, and automated bytecode and source code verification.
 
 ## Configuration

--- a/content/upgrades-plugins/faq.mdx
+++ b/content/upgrades-plugins/faq.mdx
@@ -268,10 +268,10 @@ contract V2 is V1 {
 
 Then when upgrading, call the reinitializer function as part of the upgrade process, for example in Hardhat:
 ```ts
-await upgrades.upgradeProxy(PROXY_ADDRESS, ContractFactoryV2,
+await upgradesApi.upgradeProxy(PROXY_ADDRESS, ContractFactoryV2, {
   call: 'initializeV2',
   unsafeAllow: ['internal-function-storage']
-);
+});
 ```
 or in Foundry:
 ```solidity

--- a/content/upgrades-plugins/faq.mdx
+++ b/content/upgrades-plugins/faq.mdx
@@ -169,7 +169,7 @@ At the moment, the plugins only have partial support for upgradeable contracts l
 
 There are plans to add this functionality in the near future with certain constraints that make the issue easier to address like assuming that the external library’s source code is either present in the codebase or that it’s been deployed and mined so it can be fetched from the blockchain for analysis.
 
-In the meantime, you can deploy upgradeable contracts linked to external libraries by setting the `unsafeAllowLinkedLibraries` flag to true in the `deployProxy` or `upgradeProxy` calls, or including ’external-library-linking'` in the `unsafeAllow` array. Keep in mind the plugins will not verify that the linked libraries are upgrade safe. This has to be done manually for now until the full support for external libraries is implemented.
+In the meantime, you can deploy upgradeable contracts linked to external libraries by setting the `unsafeAllowLinkedLibraries` flag to true in the `deployProxy` or `upgradeProxy` calls, or including `'external-library-linking'` in the `unsafeAllow` array. Keep in mind the plugins will not verify that the linked libraries are upgrade safe. This has to be done manually for now until the full support for external libraries is implemented.
 
 You can follow or contribute to [this issue in GitHub](https://github.com/OpenZeppelin/openzeppelin-upgrades/issues/52).
 

--- a/content/upgrades-plugins/foundry/foundry-upgrades.mdx
+++ b/content/upgrades-plugins/foundry/foundry-upgrades.mdx
@@ -123,12 +123,13 @@ FOUNDRY_OUT=my-output-dir
 
 ### Windows environments
 
-If you are using Windows, set the `OPENZEPPELIN_BASH_PATH` environment variable to the fully qualified path of the `bash` executable.
-For example, if you are using [Git for Windows](https://gitforwindows.org/), add the following line in the `.env` file of your project (using forward slashes):
+If you are using Windows, set the `OPENZEPPELIN_BASH_PATH` environment variable to the fully qualified path of the `bash` executable, using forward slashes. For example, with [Git for Windows](https://gitforwindows.org/):
 
 ```
 OPENZEPPELIN_BASH_PATH="C:/Program Files/Git/bin/bash"
 ```
+
+In a Foundry project, you can set this in your project's `.env` file.
 
 ## Usage
 

--- a/content/upgrades-plugins/foundry/foundry-upgrades.mdx
+++ b/content/upgrades-plugins/foundry/foundry-upgrades.mdx
@@ -65,6 +65,10 @@ Then add the following additional line to `remappings.txt`, in addition to the o
 openzeppelin-foundry-upgrades/=node_modules/@openzeppelin/foundry-upgrades/src/
 ```
 
+<Callout>
+This library can also be used in Hardhat 3 Solidity tests, where the same remapping applies. See [Using with Hardhat — Solidity tests](/upgrades-plugins/hardhat-upgrades#solidity-tests) for the Hardhat configuration and an example.
+</Callout>
+
 #### Soldeer
 
 Follow the steps above, but instead of running `forge install OpenZeppelin/openzeppelin-foundry-upgrades`, use one of the install commands described in https://soldeer.xyz/project/openzeppelin-foundry-upgrades

--- a/content/upgrades-plugins/hardhat-2/api-hardhat-upgrades.mdx
+++ b/content/upgrades-plugins/hardhat-2/api-hardhat-upgrades.mdx
@@ -2,8 +2,8 @@
 title: OpenZeppelin Hardhat Upgrades API
 ---
 
-<Callout>
-This is the documentation for Hardhat 3. For Hardhat 2, see the [Hardhat 2 (legacy) API docs](/upgrades-plugins/hardhat-2/api-hardhat-upgrades).
+<Callout type="warn" title="Outdated Version">
+You're viewing the Hardhat 2 (legacy) documentation. The latest documentation is available for [Hardhat 3](/upgrades-plugins/api-hardhat-upgrades).
 </Callout>
 
 Both `deployProxy` and `upgradeProxy` functions will return instances of [ethers.js contracts](https://docs.ethers.io/v5/api/contract/contract), and require [ethers.js contract factories](https://docs.ethers.io/v5/api/contract/contract-factory) as arguments. For [beacons](/contracts/5.x/api/proxy#beacon), `deployBeacon` and `upgradeBeacon` will both return an upgradable beacon instance that can be used with a beacon proxy. All deploy and upgrade functions validate that the implementation contract is upgrade-safe, and will fail otherwise.

--- a/content/upgrades-plugins/hardhat-2/api-hardhat-upgrades.mdx
+++ b/content/upgrades-plugins/hardhat-2/api-hardhat-upgrades.mdx
@@ -3,7 +3,7 @@ title: OpenZeppelin Hardhat Upgrades API
 ---
 
 <Callout type="warn" title="Outdated Version">
-You're viewing the Hardhat 2 (legacy) documentation. The latest documentation is available for [Hardhat 3](/upgrades-plugins/api-hardhat-upgrades).
+You're viewing the documentation for Hardhat 2. The latest documentation is available for [Hardhat 3](/upgrades-plugins/api-hardhat-upgrades).
 </Callout>
 
 Both `deployProxy` and `upgradeProxy` functions will return instances of [ethers.js contracts](https://docs.ethers.io/v5/api/contract/contract), and require [ethers.js contract factories](https://docs.ethers.io/v5/api/contract/contract-factory) as arguments. For [beacons](/contracts/5.x/api/proxy#beacon), `deployBeacon` and `upgradeBeacon` will both return an upgradable beacon instance that can be used with a beacon proxy. All deploy and upgrade functions validate that the implementation contract is upgrade-safe, and will fail otherwise.

--- a/content/upgrades-plugins/hardhat-2/hardhat-upgrades.mdx
+++ b/content/upgrades-plugins/hardhat-2/hardhat-upgrades.mdx
@@ -15,7 +15,7 @@ Check out the [step by step tutorial](https://forum.openzeppelin.com/t/openzeppe
 ## Installation
 
 ```console
-$ npm install --save-dev @openzeppelin/hardhat-upgrades
+$ npm install --save-dev @openzeppelin/hardhat-upgrades@^3.9.1
 $ npm install --save-dev @nomicfoundation/hardhat-ethers ethers # peer dependencies
 ```
 

--- a/content/upgrades-plugins/hardhat-2/hardhat-upgrades.mdx
+++ b/content/upgrades-plugins/hardhat-2/hardhat-upgrades.mdx
@@ -2,8 +2,8 @@
 title: Using with Hardhat
 ---
 
-<Callout>
-This is the documentation for Hardhat 3. For Hardhat 2, see the [Hardhat 2 (legacy) docs](/upgrades-plugins/hardhat-2/hardhat-upgrades).
+<Callout type="warn" title="Outdated Version">
+You're viewing the Hardhat 2 (legacy) documentation. The latest documentation is available for [Hardhat 3](/upgrades-plugins/hardhat-upgrades).
 </Callout>
 
 This package adds functions to your Hardhat scripts so you can deploy and upgrade proxies for your contracts. Depends on `ethers.js`.

--- a/content/upgrades-plugins/hardhat-2/hardhat-upgrades.mdx
+++ b/content/upgrades-plugins/hardhat-2/hardhat-upgrades.mdx
@@ -3,7 +3,7 @@ title: Using with Hardhat
 ---
 
 <Callout type="warn" title="Outdated Version">
-You're viewing the Hardhat 2 (legacy) documentation. The latest documentation is available for [Hardhat 3](/upgrades-plugins/hardhat-upgrades).
+You're viewing the documentation for Hardhat 2. The latest documentation is available for [Hardhat 3](/upgrades-plugins/hardhat-upgrades).
 </Callout>
 
 This package adds functions to your Hardhat scripts so you can deploy and upgrade proxies for your contracts. Depends on `ethers.js`.

--- a/content/upgrades-plugins/hardhat-upgrades.mdx
+++ b/content/upgrades-plugins/hardhat-upgrades.mdx
@@ -6,10 +6,10 @@ title: Using with Hardhat
 This is the documentation for Hardhat 3. For Hardhat 2, see the [Hardhat 2 (legacy) docs](/upgrades-plugins/hardhat-2/hardhat-upgrades).
 </Callout>
 
-This package adds functions to your Hardhat scripts so you can deploy and upgrade proxies for your contracts. Depends on `ethers.js`.
+This package adds functions to your Hardhat scripts so you can deploy and upgrade proxies for your contracts. Requires `@nomicfoundation/hardhat-ethers`.
 
 <Callout>
-Check out the [step by step tutorial](https://forum.openzeppelin.com/t/openzeppelin-buidler-upgrades-step-by-step-tutorial/3580), showing from creating, testing and deploying, all the way through to upgrading with Gnosis Safe.
+Migrating from Hardhat 2? See the [example projects](https://github.com/OpenZeppelin/openzeppelin-upgrades/tree/master/packages/plugin-hardhat/examples) for complete Transparent, UUPS, and Solidity-test examples using Hardhat 3.
 </Callout>
 
 ## Installation
@@ -19,47 +19,79 @@ $ npm install --save-dev @openzeppelin/hardhat-upgrades
 $ npm install --save-dev @nomicfoundation/hardhat-ethers ethers # peer dependencies
 ```
 
-And register the plugin in your [`hardhat.config.js`](https://hardhat.org/config):
+<Callout>
+Hardhat 3 supports both ethers and viem. This plugin uses `@nomicfoundation/hardhat-ethers` internally and loads it automatically. If your project uses viem, install `@nomicfoundation/hardhat-viem` and add it to your config alongside this plugin.
+</Callout>
 
-```js
-require('@openzeppelin/hardhat-upgrades');
+Register the `@openzeppelin/hardhat-upgrades` plugin in your [`hardhat.config.ts`](https://hardhat.org/config/):
+
+```typescript
+import { defineConfig } from 'hardhat/config';
+import hardhatUpgrades from '@openzeppelin/hardhat-upgrades';
+
+export default defineConfig({
+  plugins: [hardhatUpgrades],
+  // ... rest of config
+});
 ```
+
+If you use the `verify` task, also add `@nomicfoundation/hardhat-verify` to the `plugins` array and configure Hardhat's `verify.etherscan.apiKey` setting.
 
 ## Usage in scripts
 
+**Important:** Create a single network connection and share it across all operations. This ensures operations share the same context and state.
+
 ### Proxies
 
-You can use this plugin in a [Hardhat script](https://hardhat.org/guides/scripts.html) to deploy an upgradeable instance of one of your contracts via the `deployProxy` function:
+You can use this plugin in a [Hardhat script](https://hardhat.org/docs/guides/writing-scripts) to deploy an upgradeable instance of one of your contracts via the `deployProxy` function:
 
-```js
-// scripts/create-box.js
-const  ethers, upgrades  = require("hardhat");
+```typescript
+// scripts/create-box.ts
+import hre from 'hardhat';
+import { upgrades } from '@openzeppelin/hardhat-upgrades';
 
-async function main()
-  const Box = await ethers.getContractFactory("Box");
-  const box = await upgrades.deployProxy(Box, [42]);
+async function main() {
+  const connection = await hre.network.connect();
+  const { ethers } = connection;
+  const upgradesApi = await upgrades(hre, connection);
+
+  const Box = await ethers.getContractFactory('Box');
+  const box = await upgradesApi.deployProxy(Box, [42]);
   await box.waitForDeployment();
-  console.log("Box deployed to:", await box.getAddress());
+  console.log('Box deployed to:', await box.getAddress());
+}
 
-
-main();
+main().catch(err => {
+  console.error(err);
+  process.exit(1);
+});
 ```
 
 This will automatically check that the `Box` contract is upgrade-safe, deploy an implementation contract for the `Box` contract (unless there is one already from a previous deployment), create a proxy (along with a proxy admin if needed), and initialize it by calling `initialize(42)`.
 
-Then, in another script, you can use the `upgradeProxy` function to upgrade the deployed instance to a new version. The new version can be a different contract (such as `BoxV2`), or you can just modify the existing `Box` contract and recompile it - the plugin will note it changed.
+Then, in another script, you can use the `upgradeProxy` function to upgrade the deployed instance to a new version. The new version can be a different contract (such as `BoxV2`), or you can just modify the existing `Box` contract and recompile it — the plugin will note it changed.
 
-```js
-// scripts/upgrade-box.js
-const  ethers, upgrades  = require("hardhat");
+```typescript
+// scripts/upgrade-box.ts
+import hre from 'hardhat';
+import { upgrades } from '@openzeppelin/hardhat-upgrades';
 
-async function main()
-  const BoxV2 = await ethers.getContractFactory("BoxV2");
-  const box = await upgrades.upgradeProxy(BOX_ADDRESS, BoxV2);
-  console.log("Box upgraded");
+const PROXY_ADDRESS = '0x...'; // Replace with your proxy address
 
+async function main() {
+  const connection = await hre.network.connect();
+  const { ethers } = connection;
+  const upgradesApi = await upgrades(hre, connection);
 
-main();
+  const BoxV2 = await ethers.getContractFactory('BoxV2');
+  await upgradesApi.upgradeProxy(PROXY_ADDRESS, BoxV2);
+  console.log('Box upgraded');
+}
+
+main().catch(err => {
+  console.error(err);
+  process.exit(1);
+});
 ```
 
 > Note: While this plugin keeps track of all the implementation contracts you have deployed per network, in order to reuse them and validate storage compatibilities, it does _not_ keep track of the proxies you have deployed. This means that you will need to manually keep track of each deployment address, to supply those to the upgrade function when needed.
@@ -70,86 +102,173 @@ The plugin will take care of comparing `BoxV2` to the previous one to ensure the
 
 You can also use this plugin to deploy an upgradeable beacon for your contract with the `deployBeacon` function, then deploy one or more beacon proxies that point to it by using the `deployBeaconProxy` function.
 
-```js
-// scripts/create-box.js
-const  ethers, upgrades  = require("hardhat");
+```typescript
+// scripts/create-box.ts
+import hre from 'hardhat';
+import { upgrades } from '@openzeppelin/hardhat-upgrades';
 
-async function main()
-  const Box = await ethers.getContractFactory("Box");
+async function main() {
+  const connection = await hre.network.connect();
+  const { ethers } = connection;
+  const upgradesApi = await upgrades(hre, connection);
 
-  const beacon = await upgrades.deployBeacon(Box);
+  const Box = await ethers.getContractFactory('Box');
+
+  const beacon = await upgradesApi.deployBeacon(Box);
   await beacon.waitForDeployment();
-  console.log("Beacon deployed to:", await beacon.getAddress());
+  console.log('Beacon deployed to:', await beacon.getAddress());
 
-  const box = await upgrades.deployBeaconProxy(beacon, Box, [42]);
+  const box = await upgradesApi.deployBeaconProxy(beacon, Box, [42]);
   await box.waitForDeployment();
-  console.log("Box deployed to:", await box.getAddress());
+  console.log('Box deployed to:', await box.getAddress());
+}
 
-
-main();
+main().catch(err => {
+  console.error(err);
+  process.exit(1);
+});
 ```
 
 Then, in another script, you can use the `upgradeBeacon` function to upgrade the beacon to a new version. When the beacon is upgraded, all of the beacon proxies that point to it will use the new contract implementation.
 
-```js
-// scripts/upgrade-box.js
-const  ethers, upgrades  = require("hardhat");
+```typescript
+// scripts/upgrade-box.ts
+import hre from 'hardhat';
+import { upgrades } from '@openzeppelin/hardhat-upgrades';
 
-async function main()
-  const BoxV2 = await ethers.getContractFactory("BoxV2");
+const BEACON_ADDRESS = '0x...'; // Replace with your beacon address
 
-  await upgrades.upgradeBeacon(BEACON_ADDRESS, BoxV2);
-  console.log("Beacon upgraded");
+async function main() {
+  const connection = await hre.network.connect();
+  const { ethers } = connection;
+  const upgradesApi = await upgrades(hre, connection);
 
-  const box = BoxV2.attach(BOX_ADDRESS);
+  const BoxV2 = await ethers.getContractFactory('BoxV2');
+  await upgradesApi.upgradeBeacon(BEACON_ADDRESS, BoxV2);
+  console.log('Beacon upgraded');
+}
 
-
-main();
+main().catch(err => {
+  console.error(err);
+  process.exit(1);
+});
 ```
 
 ## Usage in tests
 
-You can also use the plugin’s functions from your Hardhat tests, in case you want to add tests for upgrading your contracts (which you should!). The API is the same as in scripts.
+You can also use the plugin's functions from your Hardhat tests, in case you want to add tests for upgrading your contracts (which you should!). The API is the same as in scripts.
+
+**Important:** Share a single connection across all tests in a suite. Create the connection once in a `before` / `beforeAll` hook, or at module scope using ESM top-level `await`.
 
 ### Proxies
 
-```js
-const  expect  = require("chai");
+```typescript
+import { expect } from 'chai';
+import hre from 'hardhat';
+import { upgrades } from '@openzeppelin/hardhat-upgrades';
 
-describe("Box", function()
+describe('Box', function () {
+  let upgradesApi;
+  let ethers;
+
+  before(async () => {
+    const connection = await hre.network.connect();
+    ({ ethers } = connection);
+    upgradesApi = await upgrades(hre, connection);
+  });
+
   it('works', async () => {
-    const Box = await ethers.getContractFactory("Box");
-    const BoxV2 = await ethers.getContractFactory("BoxV2");
+    const Box = await ethers.getContractFactory('Box');
+    const BoxV2 = await ethers.getContractFactory('BoxV2');
 
-    const instance = await upgrades.deployProxy(Box, [42]);
-    const upgraded = await upgrades.upgradeProxy(await instance.getAddress(), BoxV2);
+    const instance = await upgradesApi.deployProxy(Box, [42]);
+    const upgraded = await upgradesApi.upgradeProxy(await instance.getAddress(), BoxV2);
 
     const value = await upgraded.value();
     expect(value.toString()).to.equal('42');
-  );
+  });
 });
 ```
 
 ### Beacon proxies
 
-```js
-const  expect  = require("chai");
+```typescript
+import { expect } from 'chai';
+import hre from 'hardhat';
+import { upgrades } from '@openzeppelin/hardhat-upgrades';
 
-describe("Box", function()
+describe('Box', function () {
+  let upgradesApi;
+  let ethers;
+
+  before(async () => {
+    const connection = await hre.network.connect();
+    ({ ethers } = connection);
+    upgradesApi = await upgrades(hre, connection);
+  });
+
   it('works', async () => {
-    const Box = await ethers.getContractFactory("Box");
-    const BoxV2 = await ethers.getContractFactory("BoxV2");
+    const Box = await ethers.getContractFactory('Box');
+    const BoxV2 = await ethers.getContractFactory('BoxV2');
 
-    const beacon = await upgrades.deployBeacon(Box);
-    const instance = await upgrades.deployBeaconProxy(beacon, Box, [42]);
+    const beacon = await upgradesApi.deployBeacon(Box);
+    const instance = await upgradesApi.deployBeaconProxy(beacon, Box, [42]);
 
-    await upgrades.upgradeBeacon(beacon, BoxV2);
+    await upgradesApi.upgradeBeacon(beacon, BoxV2);
     const upgraded = BoxV2.attach(await instance.getAddress());
 
     const value = await upgraded.value();
     expect(value.toString()).to.equal('42');
-  );
+  });
 });
+```
+
+## Solidity tests
+
+Hardhat 3 supports writing tests in Solidity. You can use Solidity to test deployments, upgrades, and upgrade safety via the [`@openzeppelin/foundry-upgrades`](https://github.com/OpenZeppelin/openzeppelin-foundry-upgrades) Solidity library.
+
+For the Solidity API, see [`Upgrades.sol`](/upgrades-plugins/foundry/api/Upgrades) (deployment and upgrade functions) and [`Options.sol`](/upgrades-plugins/foundry/api/Options) (common options).
+
+This section is optional and is only needed if you want Solidity-based tests.
+
+Install:
+
+```console
+$ npm install --save-dev @openzeppelin/foundry-upgrades
+```
+
+Configure your Hardhat config to enable Solidity tests and expose the artifacts directory to FFI:
+
+```typescript
+import { defineConfig } from 'hardhat/config';
+import hardhatUpgrades, { proxyFilesToBuild } from '@openzeppelin/hardhat-upgrades';
+
+if (!process.env.FOUNDRY_OUT) {
+  process.env.FOUNDRY_OUT = 'artifacts/contracts';
+}
+
+export default defineConfig({
+  plugins: [hardhatUpgrades],
+  solidity: {
+    version: '0.8.28',
+    npmFilesToBuild: [...proxyFilesToBuild()],
+  },
+  test: {
+    solidity: {
+      ffi: true,
+      fsPermissions: {
+        readDirectory: ['artifacts/contracts'],
+      },
+    },
+  },
+});
+```
+
+Run `hardhat clean` before running your Solidity tests, or include the `--force` option when running `hardhat compile`. Any previous build artifacts must be cleared first to avoid duplicate contract definitions when the Solidity-based validation reads the build info:
+
+```console
+$ npx hardhat compile --force
+$ npx hardhat test solidity
 ```
 
 ## Usage with Defender

--- a/content/upgrades-plugins/hardhat-upgrades.mdx
+++ b/content/upgrades-plugins/hardhat-upgrades.mdx
@@ -231,6 +231,10 @@ For the Solidity API, see [`Upgrades.sol`](/upgrades-plugins/foundry/api/Upgrade
 
 This section is optional and is only needed if you want Solidity-based tests.
 
+<Callout>
+**Proxy source:** In Solidity tests, proxies are compiled from the `@openzeppelin/contracts` version installed in your project (via `proxyFilesToBuild()` + Hardhat 3's `npmFilesToBuild`). In scripts and JavaScript/TypeScript tests, proxies come from precompiled bytecode bundled with the plugin. Because the two paths rely on independent sources and compilation settings, the resulting proxy bytecode may not be identical.
+</Callout>
+
 Install:
 
 ```console

--- a/content/upgrades-plugins/hardhat-upgrades.mdx
+++ b/content/upgrades-plugins/hardhat-upgrades.mdx
@@ -9,7 +9,7 @@ This is the documentation for Hardhat 3. For Hardhat 2, see the [Hardhat 2 (lega
 This package adds functions to your Hardhat scripts so you can deploy and upgrade proxies for your contracts. Requires `@nomicfoundation/hardhat-ethers`.
 
 <Callout>
-Migrating from Hardhat 2? See the [example projects](https://github.com/OpenZeppelin/openzeppelin-upgrades/tree/master/packages/plugin-hardhat/examples) for complete Transparent, UUPS, and Solidity-test examples using Hardhat 3.
+Migrating from Hardhat 2? See the [Migration Guide](/upgrades-plugins/migrate-from-hardhat-2).
 </Callout>
 
 ## Installation

--- a/content/upgrades-plugins/hardhat-upgrades.mdx
+++ b/content/upgrades-plugins/hardhat-upgrades.mdx
@@ -3,7 +3,7 @@ title: Using with Hardhat
 ---
 
 <Callout>
-This is the documentation for Hardhat 3. For Hardhat 2, see the [Hardhat 2 (legacy) docs](/upgrades-plugins/hardhat-2/hardhat-upgrades).
+This is the documentation for Hardhat 3. For Hardhat 2, see [Using with Hardhat (Hardhat 2)](/upgrades-plugins/hardhat-2/hardhat-upgrades).
 </Callout>
 
 This package adds functions to your Hardhat scripts so you can deploy and upgrade proxies for your contracts. Requires `@nomicfoundation/hardhat-ethers`.

--- a/content/upgrades-plugins/hardhat-upgrades.mdx
+++ b/content/upgrades-plugins/hardhat-upgrades.mdx
@@ -235,10 +235,10 @@ This section is optional and is only needed if you want Solidity-based tests.
 **Proxy source:** In Solidity tests, proxies are compiled from the `@openzeppelin/contracts` version installed in your project (via `proxyFilesToBuild()` + Hardhat 3's `npmFilesToBuild`). In scripts and JavaScript/TypeScript tests, proxies come from precompiled bytecode bundled with the plugin. Because the two paths rely on independent sources and compilation settings, the resulting proxy bytecode may not be identical.
 </Callout>
 
-Install:
+Install the library and `forge-std`:
 
 ```console
-$ npm install --save-dev @openzeppelin/foundry-upgrades
+$ npm install --save-dev @openzeppelin/foundry-upgrades "github:foundry-rs/forge-std#semver:^1.9.5"
 ```
 
 Configure your Hardhat config to enable Solidity tests and expose the artifacts directory to FFI:

--- a/content/upgrades-plugins/hardhat-upgrades.mdx
+++ b/content/upgrades-plugins/hardhat-upgrades.mdx
@@ -39,7 +39,7 @@ If you use the `verify` task, also add `@nomicfoundation/hardhat-verify` to the 
 
 ## Usage in scripts
 
-**Important:** Create a single network connection and share it across all operations. This ensures operations share the same context and state.
+**Important:** Create a single network connection and share it across all operations. This ensures operations share the same context and state. (Or use `hre.network.getOrCreate()`, which reuses a connection per network instead of creating a new one each time.)
 
 ### Proxies
 
@@ -51,7 +51,7 @@ import hre from 'hardhat';
 import { upgrades } from '@openzeppelin/hardhat-upgrades';
 
 async function main() {
-  const connection = await hre.network.connect();
+  const connection = await hre.network.create();
   const { ethers } = connection;
   const upgradesApi = await upgrades(hre, connection);
 
@@ -79,7 +79,7 @@ import { upgrades } from '@openzeppelin/hardhat-upgrades';
 const PROXY_ADDRESS = '0x...'; // Replace with your proxy address
 
 async function main() {
-  const connection = await hre.network.connect();
+  const connection = await hre.network.create();
   const { ethers } = connection;
   const upgradesApi = await upgrades(hre, connection);
 
@@ -108,7 +108,7 @@ import hre from 'hardhat';
 import { upgrades } from '@openzeppelin/hardhat-upgrades';
 
 async function main() {
-  const connection = await hre.network.connect();
+  const connection = await hre.network.create();
   const { ethers } = connection;
   const upgradesApi = await upgrades(hre, connection);
 
@@ -139,7 +139,7 @@ import { upgrades } from '@openzeppelin/hardhat-upgrades';
 const BEACON_ADDRESS = '0x...'; // Replace with your beacon address
 
 async function main() {
-  const connection = await hre.network.connect();
+  const connection = await hre.network.create();
   const { ethers } = connection;
   const upgradesApi = await upgrades(hre, connection);
 
@@ -172,7 +172,7 @@ describe('Box', function () {
   let ethers;
 
   before(async () => {
-    const connection = await hre.network.connect();
+    const connection = await hre.network.create();
     ({ ethers } = connection);
     upgradesApi = await upgrades(hre, connection);
   });
@@ -202,7 +202,7 @@ describe('Box', function () {
   let ethers;
 
   before(async () => {
-    const connection = await hre.network.connect();
+    const connection = await hre.network.create();
     ({ ethers } = connection);
     upgradesApi = await upgrades(hre, connection);
   });

--- a/content/upgrades-plugins/hardhat-upgrades.mdx
+++ b/content/upgrades-plugins/hardhat-upgrades.mdx
@@ -268,6 +268,36 @@ export default defineConfig({
 });
 ```
 
+Add a `remappings.txt` at your project root so the library's imports resolve to the npm package's source:
+
+```
+openzeppelin-foundry-upgrades/=node_modules/@openzeppelin/foundry-upgrades/src/
+```
+
+Write your Solidity tests using the `Upgrades` library, the same way you would in a Foundry project. The imports match the [Foundry Upgrades API](/upgrades-plugins/foundry/api/Upgrades):
+
+```solidity
+// test/MyContract.t.sol
+import { Test } from "forge-std/Test.sol";
+import { Upgrades } from "openzeppelin-foundry-upgrades/Upgrades.sol";
+
+import { MyContract } from "../contracts/MyContract.sol";
+
+contract MyContractTest is Test {
+    function testDeploy() public {
+        address proxy = Upgrades.deployTransparentProxy(
+            "contracts/MyContract.sol:MyContract",
+            msg.sender,
+            abi.encodeCall(MyContract.initialize, (42))
+        );
+
+        assertEq(MyContract(proxy).value(), 42);
+    }
+}
+```
+
+Deploy and upgrade calls work the same as in a standalone Foundry project, including the upgrade safety checks that run automatically. See [Using with Foundry](/upgrades-plugins/foundry/foundry-upgrades#examples) for deploy and upgrade examples.
+
 Run `hardhat clean` before running your Solidity tests, or include the `--force` option when running `hardhat compile`. Any previous build artifacts must be cleared first to avoid duplicate contract definitions when the Solidity-based validation reads the build info:
 
 ```console

--- a/content/upgrades-plugins/migrate-from-hardhat-2.mdx
+++ b/content/upgrades-plugins/migrate-from-hardhat-2.mdx
@@ -1,0 +1,225 @@
+---
+title: Migrating from Hardhat 2
+---
+
+<Callout>
+**Prerequisite:** Migrate your Hardhat project to Hardhat 3 first. See the [official Hardhat 3 migration guide](https://hardhat.org/docs/migrate-from-hardhat2).
+</Callout>
+
+## Breaking Changes
+
+1. **No automatic `hre.upgrades`** - Must call factory function explicitly
+2. **Factory functions are async** - Require `await` and network connection
+3. **Import changes** - Import factory functions, not just the plugin
+4. **Updated peerDependencies** - `hardhat` and `@nomicfoundation/hardhat-ethers` peer dependency versions have been updated for Hardhat 3.
+
+## Install Dependencies
+
+If upgrading from a previous version, ensure these packages are in your `devDependencies`:
+
+```bash
+npm install --save-dev hardhat @nomicfoundation/hardhat-ethers
+```
+
+<Callout>
+**Using viem?** You can install both `@nomicfoundation/hardhat-ethers` and `@nomicfoundation/hardhat-viem`. The upgrades plugin uses ethers internally; your own scripts and tests can still use viem.
+</Callout>
+
+## Migration
+
+### Update Config
+
+In Hardhat 3, plugins must be explicitly added to the `plugins` array in your config:
+
+**Before (Hardhat 2):**
+```typescript
+import '@openzeppelin/hardhat-upgrades';
+```
+
+**After (Hardhat 3):**
+```typescript
+import { defineConfig } from 'hardhat/config';
+import hardhatUpgrades from '@openzeppelin/hardhat-upgrades';
+
+export default defineConfig({
+  plugins: [hardhatUpgrades],
+  // ... rest of config
+});
+```
+
+If you use the `verify` task, also add `@nomicfoundation/hardhat-verify` and configure Hardhat's `verify.etherscan.apiKey` setting:
+
+```typescript
+import { configVariable, defineConfig } from 'hardhat/config';
+import hardhatVerify from '@nomicfoundation/hardhat-verify';
+import hardhatUpgrades from '@openzeppelin/hardhat-upgrades';
+
+export default defineConfig({
+  plugins: [hardhatVerify, hardhatUpgrades],
+  verify: {
+    etherscan: {
+      apiKey: configVariable('ETHERSCAN_API_KEY'),
+    },
+  },
+});
+```
+
+### Update Imports
+
+**Before:**
+```typescript
+import '@openzeppelin/hardhat-upgrades';
+```
+
+**After:**
+```typescript
+import { upgrades, defender } from '@openzeppelin/hardhat-upgrades';
+```
+
+All functions are now exported by the API. Import `upgrades` for standard functions, or `defender` for Defender-specific functions.
+
+### Update Usage
+
+**Before:**
+```typescript
+await hre.upgrades.deployProxy(MyContract, []);
+```
+
+**After:**
+```typescript
+const connection = await hre.network.connect();
+const upgradesApi = await upgrades(hre, connection);
+await upgradesApi.deployProxy(MyContract, []);
+```
+
+<Callout>
+**Important:**
+- Both `upgrades` and `defender` receive `hre` and `connection` as parameters: `upgrades(hre, connection)` or `defender(hre, connection)`
+- Share the connection across multiple operations; do not create a new one each time
+- In tests, create the connection once in a `before` block or use top-level await (ESM)
+</Callout>
+
+## Examples
+
+### Scripts
+
+```typescript
+import hre from 'hardhat';
+import { upgrades } from '@openzeppelin/hardhat-upgrades';
+
+async function main() {
+  const connection = await hre.network.connect();
+  const { ethers } = connection;
+  const upgradesApi = await upgrades(hre, connection);
+  
+  const MyContract = await ethers.getContractFactory('MyContract');
+  const proxy = await upgradesApi.deployProxy(MyContract, []);
+  
+  const MyContractV2 = await ethers.getContractFactory('MyContractV2');
+  await upgradesApi.upgradeProxy(proxy, MyContractV2);
+}
+
+main();
+```
+
+### Tasks
+
+```typescript
+import { task } from 'hardhat/config';
+import { upgrades } from '@openzeppelin/hardhat-upgrades';
+
+task('deploy', async (args, hre) => {
+  const connection = await hre.network.connect();
+  const { ethers } = connection;
+  const upgradesApi = await upgrades(hre, connection);
+  const MyContract = await ethers.getContractFactory('MyContract');
+  await upgradesApi.deployProxy(MyContract, []);
+});
+```
+
+### Tests
+
+<Callout>
+**Important:** In Hardhat 3, `ethers` comes from the connection, not `hre.ethers`. Share the connection across all tests in a suite.
+</Callout>
+
+**Before (Hardhat 2):**
+```typescript
+import hre from 'hardhat';
+import '@openzeppelin/hardhat-upgrades';
+
+describe('MyContract', () => {
+  it('should deploy', async () => {
+    const MyContract = await hre.ethers.getContractFactory('MyContract');
+    const proxy = await hre.upgrades.deployProxy(MyContract, []);
+  });
+});
+```
+
+**After (Hardhat 3) - with `before` hook:**
+```typescript
+import hre from 'hardhat';
+import { upgrades } from '@openzeppelin/hardhat-upgrades';
+
+describe('MyContract', () => {
+  let upgradesApi;
+  let ethers;
+  
+  before(async () => {
+    const connection = await hre.network.connect();
+    ({ ethers } = connection);
+    upgradesApi = await upgrades(hre, connection);
+  });
+
+  it('should deploy', async () => {
+    const MyContract = await ethers.getContractFactory('MyContract');
+    const proxy = await upgradesApi.deployProxy(MyContract, []);
+  });
+});
+```
+
+**After (Hardhat 3) - with ESM top-level await:**
+```typescript
+import hre from 'hardhat';
+import { upgrades, defender } from '@openzeppelin/hardhat-upgrades';
+
+const connection = await hre.network.connect();
+const { ethers } = connection;
+const upgradesApi = await upgrades(hre, connection);
+const defenderApi = await defender(hre, connection);
+
+describe('MyContract', () => {
+  it('should deploy', async () => {
+    const MyContract = await ethers.getContractFactory('MyContract');
+    const proxy = await upgradesApi.deployProxy(MyContract, []);
+  });
+});
+```
+
+Note: Both `upgrades` and `defender` receive `hre` and `connection` as parameters.
+
+## Verify Task (Optional)
+
+If your Hardhat config file's `verify.etherscan.apiKey` setting uses `configVariable('ETHERSCAN_API_KEY')`, set `ETHERSCAN_API_KEY` before running Hardhat (or use a provider such as `@nomicfoundation/hardhat-keystore`):
+
+```bash
+ETHERSCAN_API_KEY=... npx hardhat verify --network mainnet PROXY_ADDRESS
+```
+
+The upgrades plugin extends hardhat-verify's `verify` task for proxy addresses.
+
+Note that you do not need to include constructor arguments when verifying if your implementation contract only uses initializers. However, if your implementation contract has an actual constructor with arguments (such as to set immutable variables), then include constructor arguments according to [Hardhat's documentation for verifying a contract](https://hardhat.org/docs/guides/smart-contract-verification#verifying-a-contract).
+
+For Solidity test setup in Hardhat 3 (including use of `@openzeppelin/foundry-upgrades`), see [Solidity tests](/upgrades-plugins/hardhat-upgrades#solidity-tests).
+
+## Checklist
+
+- Install `@nomicfoundation/hardhat-ethers` — required even if your project uses viem (install both if needed)
+- Add `hardhatUpgrades` to `plugins` in `hardhat.config.ts`
+- If using `verify`, add `hardhatVerify` to `plugins`, install `@nomicfoundation/hardhat-verify`, and configure Hardhat's `verify.etherscan.apiKey` setting
+- Replace `import '@openzeppelin/hardhat-upgrades'` → `import { upgrades, defender } from '@openzeppelin/hardhat-upgrades'` in scripts/tests
+- Add `const connection = await hre.network.connect();` (share connection across operations, don't create new ones)
+- Replace `hre.ethers` → `ethers` from connection (`const { ethers } = connection`)
+- Replace `hre.upgrades.method()` → call methods from `const upgradesApi = await upgrades(hre, connection)`
+- Replace `hre.defender.method()` → call methods from `const defenderApi = await defender(hre, connection)`
+- Update all scripts, tasks, and tests

--- a/content/upgrades-plugins/migrate-from-hardhat-2.mdx
+++ b/content/upgrades-plugins/migrate-from-hardhat-2.mdx
@@ -87,7 +87,7 @@ await hre.upgrades.deployProxy(MyContract, []);
 
 **After:**
 ```typescript
-const connection = await hre.network.connect();
+const connection = await hre.network.create();
 const upgradesApi = await upgrades(hre, connection);
 await upgradesApi.deployProxy(MyContract, []);
 ```
@@ -95,7 +95,7 @@ await upgradesApi.deployProxy(MyContract, []);
 <Callout>
 **Important:**
 - Both `upgrades` and `defender` receive `hre` and `connection` as parameters: `upgrades(hre, connection)` or `defender(hre, connection)`
-- Share the connection across multiple operations; do not create a new one each time
+- Share the connection across multiple operations; do not create a new one each time (or use `hre.network.getOrCreate()`, which reuses a connection per network)
 - In tests, create the connection once in a `before` block or use top-level await (ESM)
 </Callout>
 
@@ -108,7 +108,7 @@ import hre from 'hardhat';
 import { upgrades } from '@openzeppelin/hardhat-upgrades';
 
 async function main() {
-  const connection = await hre.network.connect();
+  const connection = await hre.network.create();
   const { ethers } = connection;
   const upgradesApi = await upgrades(hre, connection);
   
@@ -129,7 +129,7 @@ import { task } from 'hardhat/config';
 import { upgrades } from '@openzeppelin/hardhat-upgrades';
 
 task('deploy', async (args, hre) => {
-  const connection = await hre.network.connect();
+  const connection = await hre.network.create();
   const { ethers } = connection;
   const upgradesApi = await upgrades(hre, connection);
   const MyContract = await ethers.getContractFactory('MyContract');
@@ -166,7 +166,7 @@ describe('MyContract', () => {
   let ethers;
   
   before(async () => {
-    const connection = await hre.network.connect();
+    const connection = await hre.network.create();
     ({ ethers } = connection);
     upgradesApi = await upgrades(hre, connection);
   });
@@ -183,7 +183,7 @@ describe('MyContract', () => {
 import hre from 'hardhat';
 import { upgrades, defender } from '@openzeppelin/hardhat-upgrades';
 
-const connection = await hre.network.connect();
+const connection = await hre.network.create();
 const { ethers } = connection;
 const upgradesApi = await upgrades(hre, connection);
 const defenderApi = await defender(hre, connection);
@@ -218,7 +218,7 @@ For Solidity test setup in Hardhat 3 (including use of `@openzeppelin/foundry-up
 - Add `hardhatUpgrades` to `plugins` in `hardhat.config.ts`
 - If using `verify`, add `hardhatVerify` to `plugins`, install `@nomicfoundation/hardhat-verify`, and configure Hardhat's `verify.etherscan.apiKey` setting
 - Replace `import '@openzeppelin/hardhat-upgrades'` → `import { upgrades, defender } from '@openzeppelin/hardhat-upgrades'` in scripts/tests
-- Add `const connection = await hre.network.connect();` (share connection across operations, don't create new ones)
+- Add `const connection = await hre.network.create();` (share connection across operations, don't create new ones)
 - Replace `hre.ethers` → `ethers` from connection (`const { ethers } = connection`)
 - Replace `hre.upgrades.method()` → call methods from `const upgradesApi = await upgrades(hre, connection)`
 - Replace `hre.defender.method()` → call methods from `const defenderApi = await defender(hre, connection)`

--- a/content/upgrades-plugins/migrate-from-hardhat-2.mdx
+++ b/content/upgrades-plugins/migrate-from-hardhat-2.mdx
@@ -198,6 +198,8 @@ describe('MyContract', () => {
 
 Note: Both `upgrades` and `defender` receive `hre` and `connection` as parameters.
 
+Hardhat 3 also supports tests written in Solidity. See [Solidity tests](/upgrades-plugins/hardhat-upgrades#solidity-tests) for setup with `@openzeppelin/foundry-upgrades`.
+
 ## Verify Task (Optional)
 
 If your Hardhat config file's `verify.etherscan.apiKey` setting uses `configVariable('ETHERSCAN_API_KEY')`, set `ETHERSCAN_API_KEY` before running Hardhat (or use a provider such as `@nomicfoundation/hardhat-keystore`):
@@ -209,8 +211,6 @@ ETHERSCAN_API_KEY=... npx hardhat verify --network mainnet PROXY_ADDRESS
 The upgrades plugin extends hardhat-verify's `verify` task for proxy addresses.
 
 Note that you do not need to include constructor arguments when verifying if your implementation contract only uses initializers. However, if your implementation contract has an actual constructor with arguments (such as to set immutable variables), then include constructor arguments according to [Hardhat's documentation for verifying a contract](https://hardhat.org/docs/guides/smart-contract-verification#verifying-a-contract).
-
-For Solidity test setup in Hardhat 3 (including use of `@openzeppelin/foundry-upgrades`), see [Solidity tests](/upgrades-plugins/hardhat-upgrades#solidity-tests).
 
 ## Checklist
 

--- a/src/navigation/ethereum-evm.json
+++ b/src/navigation/ethereum-evm.json
@@ -659,7 +659,7 @@
 				"name": "Using with Hardhat",
 				"index": {
 					"type": "page",
-					"name": "Overview",
+					"name": "Hardhat 3",
 					"url": "/upgrades-plugins/hardhat-upgrades"
 				},
 				"children": [
@@ -667,6 +667,11 @@
 						"type": "page",
 						"name": "Network Files",
 						"url": "/upgrades-plugins/network-files"
+					},
+					{
+						"type": "page",
+						"name": "Hardhat 2 (legacy)",
+						"url": "/upgrades-plugins/hardhat-2/hardhat-upgrades"
 					}
 				]
 			},
@@ -695,9 +700,20 @@
 				"name": "API Reference"
 			},
 			{
-				"type": "page",
+				"type": "folder",
 				"name": "Hardhat Upgrades API",
-				"url": "/upgrades-plugins/api-hardhat-upgrades"
+				"index": {
+					"type": "page",
+					"name": "Hardhat 3",
+					"url": "/upgrades-plugins/api-hardhat-upgrades"
+				},
+				"children": [
+					{
+						"type": "page",
+						"name": "Hardhat 2 (legacy)",
+						"url": "/upgrades-plugins/hardhat-2/api-hardhat-upgrades"
+					}
+				]
 			},
 			{
 				"type": "folder",

--- a/src/navigation/ethereum-evm.json
+++ b/src/navigation/ethereum-evm.json
@@ -659,7 +659,7 @@
 				"name": "Using with Hardhat",
 				"index": {
 					"type": "page",
-					"name": "Hardhat 3",
+					"name": "Overview",
 					"url": "/upgrades-plugins/hardhat-upgrades"
 				},
 				"children": [
@@ -672,11 +672,6 @@
 						"type": "page",
 						"name": "Migrating from Hardhat 2",
 						"url": "/upgrades-plugins/migrate-from-hardhat-2"
-					},
-					{
-						"type": "page",
-						"name": "Hardhat 2 (legacy)",
-						"url": "/upgrades-plugins/hardhat-2/hardhat-upgrades"
 					}
 				]
 			},
@@ -705,20 +700,9 @@
 				"name": "API Reference"
 			},
 			{
-				"type": "folder",
+				"type": "page",
 				"name": "Hardhat Upgrades API",
-				"index": {
-					"type": "page",
-					"name": "Hardhat 3",
-					"url": "/upgrades-plugins/api-hardhat-upgrades"
-				},
-				"children": [
-					{
-						"type": "page",
-						"name": "Hardhat 2 (legacy)",
-						"url": "/upgrades-plugins/hardhat-2/api-hardhat-upgrades"
-					}
-				]
+				"url": "/upgrades-plugins/api-hardhat-upgrades"
 			},
 			{
 				"type": "folder",
@@ -755,6 +739,26 @@
 				"type": "page",
 				"name": "Upgrades Core & CLI",
 				"url": "/upgrades-plugins/api-core"
+			},
+			{
+				"type": "separator",
+				"name": "Previous Versions"
+			},
+			{
+				"type": "folder",
+				"name": "Hardhat 2",
+				"children": [
+					{
+						"type": "page",
+						"name": "Using with Hardhat",
+						"url": "/upgrades-plugins/hardhat-2/hardhat-upgrades"
+					},
+					{
+						"type": "page",
+						"name": "Hardhat Upgrades API",
+						"url": "/upgrades-plugins/hardhat-2/api-hardhat-upgrades"
+					}
+				]
 			}
 		]
 	},

--- a/src/navigation/ethereum-evm.json
+++ b/src/navigation/ethereum-evm.json
@@ -670,6 +670,11 @@
 					},
 					{
 						"type": "page",
+						"name": "Migrating from Hardhat 2",
+						"url": "/upgrades-plugins/migrate-from-hardhat-2"
+					},
+					{
+						"type": "page",
 						"name": "Hardhat 2 (legacy)",
 						"url": "/upgrades-plugins/hardhat-2/hardhat-upgrades"
 					}


### PR DESCRIPTION
### Summary

Adds Hardhat 3 documentation for the Hardhat Upgrades plugin (`@openzeppelin/hardhat-upgrades` 4.0.0, to be released). The existing Hardhat 2 docs are preserved as legacy under `/upgrades-plugins/hardhat-2/*` with an "Outdated Version" banner. Pre-existing URLs (`/upgrades-plugins/hardhat-upgrades`, `/upgrades-plugins/api-hardhat-upgrades`) remain live and now describe Hardhat 3 — no redirects. Also adds a migration guide to `/upgrades-plugins/migrate-from-hardhat-2` and adds nav entries.

### Type of Change

- [x] New documentation
- [x] Documentation update/revision
- [x] Restructure/reorganize content
- [x] Update API documentation

### Related Issues

https://github.com/OpenZeppelin/openzeppelin-upgrades/issues/1191
https://github.com/OpenZeppelin/openzeppelin-upgrades/pull/1241
https://github.com/OpenZeppelin/openzeppelin-foundry-upgrades/pull/121

### Checklist

- [x] Build succeeds locally with `pnpm run build`
- [x] Lint is successful when running `pnpm run check`
- [x] Docs follow [OpenZeppelin Documentation Standards](https://github.com/OpenZeppelin/docs/blob/main/STANDARDS.md)

### Additional Notes

- Only the Hardhat-specific pages are versioned to support both Hardhat 3 and 2.  Other pages in the Upgrades section (e.g. Foundry and core) remain unversioned since the latest versions of those are intended to remain backwards compatible.
