### PR TITLE
ci: drop hard-pinned pnpm version in docgen workflows

### DIFF
--- a/.github/workflows/generate-api-docs-community-contracts.yml
+++ b/.github/workflows/generate-api-docs-community-contracts.yml
@@ -55,8 +55,6 @@ jobs:
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
-        with:
-          version: 10.17.1
 
       - name: Setup Node.js
         uses: actions/setup-node@v4

--- a/.github/workflows/generate-api-docs-confidential-contracts.yml
+++ b/.github/workflows/generate-api-docs-confidential-contracts.yml
@@ -46,8 +46,6 @@ jobs:
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
-        with:
-          version: 10.17.1
 
       - name: Setup Node.js
         uses: actions/setup-node@v4

--- a/.github/workflows/generate-api-docs-contracts.yml
+++ b/.github/workflows/generate-api-docs-contracts.yml
@@ -46,8 +46,6 @@ jobs:
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
-        with:
-          version: 10.17.1
 
       - name: Setup Node.js
         uses: actions/setup-node@v4


### PR DESCRIPTION
## Summary

- The three `generate-api-docs-*.yml` workflows hard-pin `pnpm/action-setup@v4` to `version: 10.17.1`, but #165 bumped `package.json#packageManager` to `pnpm@11.1.0`. The setup action enforces consistency between the two and fails with `ERR_PNPM_BAD_PM_VERSION` (see [run 25941406850](https://github.com/OpenZeppelin/docs/actions/runs/25941406850)).
- Removing the `version:` input lets the action resolve the version from `package.json#packageManager`, matching what `lint.yml` already does. Future pnpm bumps via `package.json` won't require touching workflow files.

## Test plan

- [ ] Re-run **Generate API Docs - Community Contracts** via `workflow_dispatch` on this branch; confirm the **Setup pnpm** step succeeds.
- [ ] Re-run **Generate API Docs - Contracts** and **Generate API Docs - Confidential Contracts** to verify the same.

🤖 Generated with [Claude Code](https://claude.com/claude-code)