### PR TITLE
docs: redirect Telegram group references to forum and GitHub

### DIFF
--- a/content/monitor/1.0.x/contribution.mdx
+++ b/content/monitor/1.0.x/contribution.mdx
@@ -267,7 +267,7 @@ Reviewers should focus on:
 
 If your PR isn’t getting attention:
 
-* Contact the team on [Telegram](https://t.me/openzeppelin_tg/4)
+* Tag a maintainer in a comment or post on the [OpenZeppelin Forum](https://forum.openzeppelin.com/)
 * Ensure your PR has appropriate labels
 * Keep PRs focused and reasonably sized
 
@@ -293,7 +293,6 @@ Contributors must follow the [Code of Conduct](https://github.com/OpenZeppelin/o
 
 * ***GitHub Discussions***: For questions and community interaction
 * ***Issues***: For bug reports and feature requests
-* ***Telegram***: [Join our community chat](https://t.me/openzeppelin_tg/4)
 * ***Good First Issues***: [Find beginner-friendly issues](https://github.com/openzeppelin/openzeppelin-monitor/issues?q=is%3Aissue+is%3Aopen+label%3Agood-first-issue)
 
 ### Additional Resources

--- a/content/monitor/1.0.x/index.mdx
+++ b/content/monitor/1.0.x/index.mdx
@@ -1427,7 +1427,7 @@ The monitor implements a comprehensive error handling system with rich context a
 
 ## Support
 
-For support or inquiries, contact us on [Telegram](https://t.me/openzeppelin_tg/4).
+For support or inquiries, ask on the [OpenZeppelin Forum](https://forum.openzeppelin.com/) or open an issue on [GitHub](https://github.com/OpenZeppelin/openzeppelin-monitor/issues).
 
 Have feature requests or want to contribute? Join our community on [GitHub](https://github.com/OpenZeppelin/openzeppelin-monitor/)
 

--- a/content/monitor/1.1.x/contribution.mdx
+++ b/content/monitor/1.1.x/contribution.mdx
@@ -299,7 +299,7 @@ Reviewers should focus on:
 
 If your PR isn’t getting attention:
 
-* Contact the team on [Telegram](https://t.me/openzeppelin_tg/4)
+* Tag a maintainer in a comment or post on the [OpenZeppelin Forum](https://forum.openzeppelin.com/)
 * Ensure your PR has appropriate labels
 * Keep PRs focused and reasonably sized
 
@@ -325,7 +325,6 @@ Contributors must follow the [Code of Conduct](https://github.com/OpenZeppelin/o
 
 * ***GitHub Discussions***: For questions and community interaction
 * ***Issues***: For bug reports and feature requests
-* ***Telegram***: [Join our community chat](https://t.me/openzeppelin_tg/4)
 * ***Good First Issues***: [Find beginner-friendly issues](https://github.com/openzeppelin/openzeppelin-monitor/issues?q=is%3Aissue+is%3Aopen+label%3Agood-first-issue)
 
 ### Additional Resources

--- a/content/monitor/1.1.x/index.mdx
+++ b/content/monitor/1.1.x/index.mdx
@@ -1522,7 +1522,7 @@ The monitor implements a comprehensive error handling system with rich context a
 
 ## Support
 
-For support or inquiries, contact us on [Telegram](https://t.me/openzeppelin_tg/4).
+For support or inquiries, ask on the [OpenZeppelin Forum](https://forum.openzeppelin.com/) or open an issue on [GitHub](https://github.com/OpenZeppelin/openzeppelin-monitor/issues).
 
 Have feature requests or want to contribute? Join our community on [GitHub](https://github.com/OpenZeppelin/openzeppelin-monitor/)
 

--- a/content/monitor/1.2.x/contribution.mdx
+++ b/content/monitor/1.2.x/contribution.mdx
@@ -310,7 +310,7 @@ Reviewers should focus on:
 
 If your PR isn’t getting attention:
 
-* Contact the team on [Telegram](https://t.me/openzeppelin_tg/4)
+* Tag a maintainer in a comment or post on the [OpenZeppelin Forum](https://forum.openzeppelin.com/)
 * Ensure your PR has appropriate labels
 * Keep PRs focused and reasonably sized
 
@@ -336,7 +336,6 @@ Contributors must follow the [Code of Conduct](https://github.com/OpenZeppelin/o
 
 * ***GitHub Discussions***: For questions and community interaction
 * ***Issues***: For bug reports and feature requests
-* ***Telegram***: [Join our community chat](https://t.me/openzeppelin_tg/4)
 * ***Good First Issues***: [Find beginner-friendly issues](https://github.com/openzeppelin/openzeppelin-monitor/issues?q=is%3Aissue+is%3Aopen+label%3Agood-first-issue)
 
 ### Additional Resources

--- a/content/monitor/1.2.x/index.mdx
+++ b/content/monitor/1.2.x/index.mdx
@@ -1771,7 +1771,7 @@ The monitor implements a comprehensive error handling system with rich context a
 
 ## Support
 
-For support or inquiries, contact us on [Telegram](https://t.me/openzeppelin_tg/4).
+For support or inquiries, ask on the [OpenZeppelin Forum](https://forum.openzeppelin.com/) or open an issue on [GitHub](https://github.com/OpenZeppelin/openzeppelin-monitor/issues).
 
 Have feature requests or want to contribute? Join our community on [GitHub](https://github.com/OpenZeppelin/openzeppelin-monitor/)
 

--- a/content/monitor/1.3.x/contribution.mdx
+++ b/content/monitor/1.3.x/contribution.mdx
@@ -310,7 +310,7 @@ Reviewers should focus on:
 
 If your PR isn’t getting attention:
 
-* Contact the team on [Telegram](https://t.me/openzeppelin_tg/4)
+* Tag a maintainer in a comment or post on the [OpenZeppelin Forum](https://forum.openzeppelin.com/)
 * Ensure your PR has appropriate labels
 * Keep PRs focused and reasonably sized
 
@@ -336,7 +336,6 @@ Contributors must follow the [Code of Conduct](https://github.com/OpenZeppelin/o
 
 * ***GitHub Discussions***: For questions and community interaction
 * ***Issues***: For bug reports and feature requests
-* ***Telegram***: [Join our community chat](https://t.me/openzeppelin_tg/4)
 * ***Good First Issues***: [Find beginner-friendly issues](https://github.com/openzeppelin/openzeppelin-monitor/issues?q=is%3Aissue+is%3Aopen+label%3Agood-first-issue)
 
 ### Additional Resources

--- a/content/monitor/1.3.x/index.mdx
+++ b/content/monitor/1.3.x/index.mdx
@@ -1771,7 +1771,7 @@ The monitor implements a comprehensive error handling system with rich context a
 
 ## Support
 
-For support or inquiries, contact us on [Telegram](https://t.me/openzeppelin_tg/4).
+For support or inquiries, ask on the [OpenZeppelin Forum](https://forum.openzeppelin.com/) or open an issue on [GitHub](https://github.com/OpenZeppelin/openzeppelin-monitor/issues).
 
 Have feature requests or want to contribute? Join our community on [GitHub](https://github.com/OpenZeppelin/openzeppelin-monitor/)
 

--- a/content/monitor/contribution.mdx
+++ b/content/monitor/contribution.mdx
@@ -310,7 +310,7 @@ Reviewers should focus on:
 
 If your PR isn’t getting attention:
 
-* Contact the team on [Telegram](https://t.me/openzeppelin_tg/4)
+* Tag a maintainer in a comment or post on the [OpenZeppelin Forum](https://forum.openzeppelin.com/)
 * Ensure your PR has appropriate labels
 * Keep PRs focused and reasonably sized
 
@@ -336,7 +336,6 @@ Contributors must follow the [Code of Conduct](https://github.com/OpenZeppelin/o
 
 * ***GitHub Discussions***: For questions and community interaction
 * ***Issues***: For bug reports and feature requests
-* ***Telegram***: [Join our community chat](https://t.me/openzeppelin_tg/4)
 * ***Good First Issues***: [Find beginner-friendly issues](https://github.com/openzeppelin/openzeppelin-monitor/issues?q=is%3Aissue+is%3Aopen+label%3Agood-first-issue)
 
 ### Additional Resources

--- a/content/monitor/index.mdx
+++ b/content/monitor/index.mdx
@@ -1771,7 +1771,7 @@ The monitor implements a comprehensive error handling system with rich context a
 
 ## Support
 
-For support or inquiries, contact us on [Telegram](https://t.me/openzeppelin_tg/4).
+For support or inquiries, ask on the [OpenZeppelin Forum](https://forum.openzeppelin.com/) or open an issue on [GitHub](https://github.com/OpenZeppelin/openzeppelin-monitor/issues).
 
 Have feature requests or want to contribute? Join our community on [GitHub](https://github.com/OpenZeppelin/openzeppelin-monitor/)
 

--- a/content/relayer/1.0.x/index.mdx
+++ b/content/relayer/1.0.x/index.mdx
@@ -327,7 +327,7 @@ The OpenZeppelin Relayer is designed to function as a backend service and is not
 
 ## Support
 
-For support or inquiries, contact us on [Telegram](https://t.me/openzeppelin_tg/2).
+For support or inquiries, ask on the [OpenZeppelin Forum](https://forum.openzeppelin.com/) or open an issue on [GitHub](https://github.com/OpenZeppelin/openzeppelin-relayer/issues).
 
 ## License
 This project is licensed under the GNU Affero General Public License v3.0 - see the LICENSE file for details.

--- a/content/relayer/1.0.x/solana.mdx
+++ b/content/relayer/1.0.x/solana.mdx
@@ -207,7 +207,7 @@ See [API Reference](/relayer/1.0.x/api_reference) and [SDK examples, window=_bla
 
 ## Support
 
-For help, join our [Telegram](https://t.me/openzeppelin_tg/2) or open an issue on GitHub.
+For help, ask on the [OpenZeppelin Forum](https://forum.openzeppelin.com/) or open an issue on GitHub.
 
 ## License
 

--- a/content/relayer/1.1.x/evm.mdx
+++ b/content/relayer/1.1.x/evm.mdx
@@ -297,7 +297,7 @@ Enable metrics and monitor:
 
 For help with EVM integration:
 
-* Join our [Telegram](https://t.me/openzeppelin_tg/2) community
+* Ask on the [OpenZeppelin Forum](https://forum.openzeppelin.com/)
 * Open an issue on our [GitHub repository](https://github.com/OpenZeppelin/openzeppelin-relayer)
 * Check our [comprehensive documentation](https://docs.openzeppelin.com/relayer)
 

--- a/content/relayer/1.1.x/index.mdx
+++ b/content/relayer/1.1.x/index.mdx
@@ -326,7 +326,7 @@ The OpenZeppelin Relayer is designed to function as a backend service and is not
 
 ## Support
 
-For support or inquiries, contact us on [Telegram](https://t.me/openzeppelin_tg/2).
+For support or inquiries, ask on the [OpenZeppelin Forum](https://forum.openzeppelin.com/) or open an issue on [GitHub](https://github.com/OpenZeppelin/openzeppelin-relayer/issues).
 
 ## License
 This project is licensed under the GNU Affero General Public License v3.0 - see the LICENSE file for details.

--- a/content/relayer/1.1.x/solana.mdx
+++ b/content/relayer/1.1.x/solana.mdx
@@ -213,7 +213,7 @@ See [API Reference](/relayer/1.1.x/api) and [SDK examples](https://github.com/Op
 
 ## Support
 
-For help, join our [Telegram](https://t.me/openzeppelin_tg/2) or open an issue on GitHub.
+For help, ask on the [OpenZeppelin Forum](https://forum.openzeppelin.com/) or open an issue on GitHub.
 
 ## License
 

--- a/content/relayer/1.1.x/stellar.mdx
+++ b/content/relayer/1.1.x/stellar.mdx
@@ -324,7 +324,7 @@ Soroban operations support different authorization modes:
 
 ## Support
 
-For help, join our [Telegram](https://t.me/openzeppelin_tg/2) or open an issue on GitHub.
+For help, ask on the [OpenZeppelin Forum](https://forum.openzeppelin.com/) or open an issue on GitHub.
 
 ## License
 

--- a/content/relayer/1.2.x/evm.mdx
+++ b/content/relayer/1.2.x/evm.mdx
@@ -302,7 +302,7 @@ Enable metrics and monitor:
 
 For help with EVM integration:
 
-* Join our [Telegram](https://t.me/openzeppelin_tg/2) community
+* Ask on the [OpenZeppelin Forum](https://forum.openzeppelin.com/)
 * Open an issue on our [GitHub repository](https://github.com/OpenZeppelin/openzeppelin-relayer)
 * Check our [comprehensive documentation](https://docs.openzeppelin.com/relayer)
 

--- a/content/relayer/1.2.x/index.mdx
+++ b/content/relayer/1.2.x/index.mdx
@@ -340,7 +340,7 @@ The OpenZeppelin Relayer is designed to function as a backend service and is not
 
 ## Support
 
-For support or inquiries, contact us on [Telegram](https://t.me/openzeppelin_tg/2).
+For support or inquiries, ask on the [OpenZeppelin Forum](https://forum.openzeppelin.com/) or open an issue on [GitHub](https://github.com/OpenZeppelin/openzeppelin-relayer/issues).
 
 ## License
 This project is licensed under the GNU Affero General Public License v3.0 - see the LICENSE file for details.

--- a/content/relayer/1.2.x/solana.mdx
+++ b/content/relayer/1.2.x/solana.mdx
@@ -311,7 +311,7 @@ For complete REST API examples with both options, see the [SDK Solana examples](
 
 ## Support
 
-For help, join our [Telegram](https://t.me/openzeppelin_tg/2) or open an issue on GitHub.
+For help, ask on the [OpenZeppelin Forum](https://forum.openzeppelin.com/) or open an issue on GitHub.
 
 ## License
 

--- a/content/relayer/1.2.x/stellar.mdx
+++ b/content/relayer/1.2.x/stellar.mdx
@@ -413,7 +413,7 @@ For complete examples:
 
 ## Support
 
-For help, join our [Telegram](https://t.me/openzeppelin_tg/2) or open an issue on GitHub.
+For help, ask on the [OpenZeppelin Forum](https://forum.openzeppelin.com/) or open an issue on GitHub.
 
 ## License
 

--- a/content/relayer/1.3.x/evm.mdx
+++ b/content/relayer/1.3.x/evm.mdx
@@ -302,7 +302,7 @@ Enable metrics and monitor:
 
 For help with EVM integration:
 
-* Join our [Telegram](https://t.me/openzeppelin_tg/2) community
+* Ask on the [OpenZeppelin Forum](https://forum.openzeppelin.com/)
 * Open an issue on our [GitHub repository](https://github.com/OpenZeppelin/openzeppelin-relayer)
 * Check our [comprehensive documentation](https://docs.openzeppelin.com/relayer)
 

--- a/content/relayer/1.3.x/index.mdx
+++ b/content/relayer/1.3.x/index.mdx
@@ -341,7 +341,7 @@ The OpenZeppelin Relayer is designed to function as a backend service and is not
 
 ## Support
 
-For support or inquiries, contact us on [Telegram](https://t.me/openzeppelin_tg/2).
+For support or inquiries, ask on the [OpenZeppelin Forum](https://forum.openzeppelin.com/) or open an issue on [GitHub](https://github.com/OpenZeppelin/openzeppelin-relayer/issues).
 
 ## License
 This project is licensed under the GNU Affero General Public License v3.0 - see the LICENSE file for details.

--- a/content/relayer/1.3.x/solana.mdx
+++ b/content/relayer/1.3.x/solana.mdx
@@ -342,7 +342,7 @@ For complete REST API examples with both options, see the [SDK Solana examples](
 
 ## Support
 
-For help, join our [Telegram](https://t.me/openzeppelin_tg/2) or open an issue on GitHub.
+For help, ask on the [OpenZeppelin Forum](https://forum.openzeppelin.com/) or open an issue on GitHub.
 
 ## License
 

--- a/content/relayer/1.3.x/stellar.mdx
+++ b/content/relayer/1.3.x/stellar.mdx
@@ -555,7 +555,7 @@ For complete examples:
 
 ## Support
 
-For help, join our [Telegram](https://t.me/openzeppelin_tg/2) or open an issue on GitHub.
+For help, ask on the [OpenZeppelin Forum](https://forum.openzeppelin.com/) or open an issue on GitHub.
 
 ## License
 

--- a/content/relayer/1.4.x/evm.mdx
+++ b/content/relayer/1.4.x/evm.mdx
@@ -313,7 +313,7 @@ Enable metrics and monitor:
 
 For help with EVM integration:
 
-- Join our [Telegram](https://t.me/openzeppelin_tg/2) community
+- Ask on the [OpenZeppelin Forum](https://forum.openzeppelin.com/)
 - Open an issue on our [GitHub repository](https://github.com/OpenZeppelin/openzeppelin-relayer)
 - Check our [comprehensive documentation](https://docs.openzeppelin.com/relayer)
 

--- a/content/relayer/1.4.x/index.mdx
+++ b/content/relayer/1.4.x/index.mdx
@@ -341,7 +341,7 @@ The OpenZeppelin Relayer is designed to function as a backend service and is not
 
 ## Support
 
-For support or inquiries, contact us on [Telegram](https://t.me/openzeppelin_tg/2).
+For support or inquiries, ask on the [OpenZeppelin Forum](https://forum.openzeppelin.com/) or open an issue on [GitHub](https://github.com/OpenZeppelin/openzeppelin-relayer/issues).
 
 ## License
 This project is licensed under the GNU Affero General Public License v3.0 - see the LICENSE file for details.

--- a/content/relayer/1.4.x/solana.mdx
+++ b/content/relayer/1.4.x/solana.mdx
@@ -342,7 +342,7 @@ For complete REST API examples with both options, see the [SDK Solana examples](
 
 ## Support
 
-For help, join our [Telegram](https://t.me/openzeppelin_tg/2) or open an issue on GitHub.
+For help, ask on the [OpenZeppelin Forum](https://forum.openzeppelin.com/) or open an issue on GitHub.
 
 ## License
 

--- a/content/relayer/1.4.x/stellar.mdx
+++ b/content/relayer/1.4.x/stellar.mdx
@@ -555,7 +555,7 @@ For complete examples:
 
 ## Support
 
-For help, join our [Telegram](https://t.me/openzeppelin_tg/2) or open an issue on GitHub.
+For help, ask on the [OpenZeppelin Forum](https://forum.openzeppelin.com/) or open an issue on GitHub.
 
 ## License
 

--- a/content/relayer/1.4.x/zama-fhevm.mdx
+++ b/content/relayer/1.4.x/zama-fhevm.mdx
@@ -152,4 +152,4 @@ The example contract is deployed from [Zama's fhevm-hardhat-template](https://gi
 
 ## Support
 
-For help, join our [Telegram](https://t.me/openzeppelin_tg/2) or open an issue on GitHub.
+For help, ask on the [OpenZeppelin Forum](https://forum.openzeppelin.com/) or open an issue on GitHub.

--- a/content/relayer/evm.mdx
+++ b/content/relayer/evm.mdx
@@ -313,7 +313,7 @@ Enable metrics and monitor:
 
 For help with EVM integration:
 
-- Join our [Telegram](https://t.me/openzeppelin_tg/2) community
+- Ask on the [OpenZeppelin Forum](https://forum.openzeppelin.com/)
 - Open an issue on our [GitHub repository](https://github.com/OpenZeppelin/openzeppelin-relayer)
 - Check our [comprehensive documentation](https://docs.openzeppelin.com/relayer)
 

--- a/content/relayer/index.mdx
+++ b/content/relayer/index.mdx
@@ -341,7 +341,7 @@ The OpenZeppelin Relayer is designed to function as a backend service and is not
 
 ## Support
 
-For support or inquiries, contact us on [Telegram](https://t.me/openzeppelin_tg/2).
+For support or inquiries, ask on the [OpenZeppelin Forum](https://forum.openzeppelin.com/) or open an issue on [GitHub](https://github.com/OpenZeppelin/openzeppelin-relayer/issues).
 
 ## License
 This project is licensed under the GNU Affero General Public License v3.0 - see the LICENSE file for details.

--- a/content/relayer/solana.mdx
+++ b/content/relayer/solana.mdx
@@ -342,7 +342,7 @@ For complete REST API examples with both options, see the [SDK Solana examples](
 
 ## Support
 
-For help, join our [Telegram](https://t.me/openzeppelin_tg/2) or open an issue on GitHub.
+For help, ask on the [OpenZeppelin Forum](https://forum.openzeppelin.com/) or open an issue on GitHub.
 
 ## License
 

--- a/content/relayer/stellar.mdx
+++ b/content/relayer/stellar.mdx
@@ -555,7 +555,7 @@ For complete examples:
 
 ## Support
 
-For help, join our [Telegram](https://t.me/openzeppelin_tg/2) or open an issue on GitHub.
+For help, ask on the [OpenZeppelin Forum](https://forum.openzeppelin.com/) or open an issue on GitHub.
 
 ## License
 

--- a/content/relayer/zama-fhevm.mdx
+++ b/content/relayer/zama-fhevm.mdx
@@ -152,4 +152,4 @@ The example contract is deployed from [Zama's fhevm-hardhat-template](https://gi
 
 ## Support
 
-For help, join our [Telegram](https://t.me/openzeppelin_tg/2) or open an issue on GitHub.
+For help, ask on the [OpenZeppelin Forum](https://forum.openzeppelin.com/) or open an issue on GitHub.

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,5 +1,5 @@
 import { HomeLayout } from "fumadocs-ui/layouts/home";
-import { ArrowDown, SendIcon } from "lucide-react";
+import { ArrowDown, GithubIcon } from "lucide-react";
 import { Footer } from "@/components/footer";
 import {
 	BannerCard,
@@ -313,10 +313,10 @@ export default function HomePage() {
 						/>
 
 						<CommunityCard
-							href="https://t.me/openzeppelin_tg"
-							icon={<SendIcon className="h-6 w-6 sm:h-8 sm:w-8" />}
-							title="Telegram"
-							description="Get quick help and connect with the community in real-time. Ask questions, share updates, and stay informed about the latest OpenZeppelin developments and announcements."
+							href="https://github.com/OpenZeppelin"
+							icon={<GithubIcon className="h-6 w-6 sm:h-8 sm:w-8" />}
+							title="GitHub"
+							description="Browse our repositories, file issues, and open discussions. Report bugs, request features, or jump into the code across OpenZeppelin libraries and tools."
 						/>
 					</div>
 				</div>


### PR DESCRIPTION
## Summary
- Strips every link to the OpenZeppelin Telegram community group (`t.me/openzeppelin_tg`) across Monitor and Relayer docs.
- Reroutes readers to the OpenZeppelin Forum and the relevant product GitHub repos so they don't land on a dead endpoint after the group is discontinued.
- Swaps the home page Telegram Community Card for a GitHub card pointing to `github.com/OpenZeppelin`.

## Surfaces touched
- Home page Community & Support section (`src/app/page.tsx`): Telegram card replaced with a GitHub card.
- Monitor docs (`content/monitor/**`, all versions 1.0.x through 1.3.x and unversioned):
  - `index.mdx` "For support or inquiries" line points to the forum and the `openzeppelin-monitor` issues page.
  - `contribution.mdx` Getting Reviews bullet rewritten to tag a maintainer via comment or the forum.
  - `contribution.mdx` Getting Help: the Telegram bullet is dropped (GitHub Discussions + Issues bullets already cover community support).
- Relayer docs (`content/relayer/**`, all versions 1.0.x through 1.4.x and unversioned): Support sections in `index`, `evm`, `stellar`, `solana`, and `zama-fhevm` point to the forum and the `openzeppelin-relayer` issues page.

## Intentionally preserved (product feature, NOT the group chat)
- Telegram-as-notification-channel docs in `content/monitor/architecture.mdx` and the configuration tables in `content/monitor/index.mdx` (`trigger_type`, `api.telegram.org`, `chat_id`, message templates).
- Defender notification settings that list Telegram as a delivery platform.
- `public/defender/manage-notify-telegram.png` screenshot.

This is a community-group cleanup, not a product capability change.

## Companion PR
The site-wide banner removal is split out into a separate PR so it can ship independently: #171.