### PR TITLE
docgen: support hardhat3-style branches in injectTemplates

### DIFF
--- a/docgen/config-md.mjs
+++ b/docgen/config-md.mjs
@@ -1,0 +1,20 @@
+import path from 'path';
+import fs from 'fs';
+
+/** @type import('solidity-docgen/dist/config').UserConfig */
+export default {
+  outputDir: 'docs/modules/api/pages',
+  templates: 'docs/templates',
+  exclude: ['mocks'],
+  pageExtension: '.mdx',
+  pages: (_, file, config) => {
+    const sourcesDir = path.resolve(config.root, config.sourcesDir);
+    let dir = path.resolve(config.root, file.absolutePath);
+    while (dir.startsWith(sourcesDir)) {
+      dir = path.dirname(dir);
+      if (fs.existsSync(path.join(dir, 'README.adoc'))) {
+        return path.relative(sourcesDir, dir) + config.pageExtension;
+      }
+    }
+  },
+};

--- a/docgen/templates-md/contract.hbs
+++ b/docgen/templates-md/contract.hbs
@@ -1,10 +1,10 @@
-{{reset-function-counts}}<a id="{{anchor}}"></a>
+{{resetFunctionCounts}}<a id="{{anchor}}"></a>
 
 <div style=\{{marginTop: "4em"}} className="w-full flex flex-row items-center justify-between">
 
 ## `{{{name}}}` 
 
-<a target="_blank" style=\{{marginTop: "1.5em"}} href="https://github.com/OpenZeppelin/openzeppelin-contracts/blob/v{{oz-version}}/{{__item_context.file.absolutePath}}">
+<a target="_blank" style=\{{marginTop: "1.5em"}} href="https://github.com/OpenZeppelin/openzeppelin-contracts/blob/v{{ozVersion}}/{{__item_context.file.absolutePath}}">
 <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-github-icon lucide-github"><path d="M15 22v-4a4.8 4.8 0 0 0-1-3.5c3 0 6-2 6-5.5.08-1.25-.27-2.48-1-3.5.28-1.15.28-2.35 0-3.5 0 0-1 0-3 1.5-2.64-.5-5.36-.5-8 0C6 2 5 2 5 2c-.3 1.15-.3 2.35 0 3.5A5.403 5.403 0 0 0 4 9c0 3.5 3 5.5 6 5.5-.39.49-.68 1.05-.85 1.65-.17.6-.22 1.23-.15 1.85v4"/><path d="M9 18c-4.51 2-5-2-7-2"/></svg>
 </a>
 
@@ -14,7 +14,7 @@
 import "@openzeppelin/{{__item_context.file.absolutePath}}";
 ```
 
-{{{process-natspec natspec.dev}}}
+{{{processNatspec natspec.dev}}}
 
 {{#if modifiers}}
 <div className="bg-secondary p-4 rounded-md mb-6">
@@ -28,11 +28,11 @@ import "@openzeppelin/{{__item_context.file.absolutePath}}";
 {{/if}}
 
 
-{{#if has-functions}}
+{{#if hasFunctions}}
 <div className="bg-secondary p-4 rounded-md mb-6">
 <h3 style=\{{ marginTop: "0"}}>Functions</h3>
 <div className="font-mono">
-{{#each inherited-functions}}
+{{#each inheritedFunctions}}
 {{#if @first}}
 {{#each functions}}
 - [{{{name}}}({{names params}})](#{{anchor}})
@@ -54,7 +54,7 @@ import "@openzeppelin/{{__item_context.file.absolutePath}}";
 </div>
 {{/if}}
 
-{{#if has-events}}
+{{#if hasEvents}}
 <div className="bg-secondary p-4 rounded-md mb-6">
 <h3 style=\{{ marginTop: "0"}}>Events</h3>
 <div className="font-mono">
@@ -80,7 +80,7 @@ import "@openzeppelin/{{__item_context.file.absolutePath}}";
 </div>
 {{/if}}
 
-{{#if has-errors}}
+{{#if hasErrors}}
 <div className="bg-secondary p-4 rounded-md mb-6">
 <h3 style=\{{ marginTop: "0"}}>Errors</h3>
 <div className="font-mono">
@@ -111,7 +111,7 @@ import "@openzeppelin/{{__item_context.file.absolutePath}}";
 
 <div className="border rounded-md mb-4">
 <div className="bg-secondary flex w-full justify-between px-4">
-<p className="font-bold text-sm font-mono">{{{name}}}({{typed-params params}})</p>
+<p className="font-bold text-sm font-mono">{{{name}}}({{typedParams params}})</p>
 <div className="flex flex-row items-center gap-2">
 <p className="font-light text-sm">{{visibility}}</p>
 <a className="peer" data-card href="#{{anchor}}">#</a>
@@ -120,7 +120,7 @@ import "@openzeppelin/{{__item_context.file.absolutePath}}";
 
 <div className="px-4">
 
-{{{process-natspec natspec.dev}}}
+{{{processNatspec natspec.dev}}}
 
 </div>
 </div>
@@ -132,7 +132,7 @@ import "@openzeppelin/{{__item_context.file.absolutePath}}";
 
 <div className="border rounded-md mb-4">
 <div className="bg-secondary flex w-full justify-between px-4">
-<p className="font-bold text-sm font-mono">{{{name}}}({{typed-params params}}){{#if returns2}} → {{typed-params returns2}}{{/if}}</p>
+<p className="font-bold text-sm font-mono">{{{name}}}({{typedParams params}}){{#if returns2}} → {{typedParams returns2}}{{/if}}</p>
 <div className="flex flex-row items-center gap-2">
 <p className="font-light text-sm">{{visibility}}</p>
 <a className="peer" data-card href="#{{anchor}}">#</a>
@@ -140,7 +140,7 @@ import "@openzeppelin/{{__item_context.file.absolutePath}}";
 </div>
 <div className="px-4">
 
-{{{process-natspec natspec.dev}}}
+{{{processNatspec natspec.dev}}}
 
 </div>
 </div>
@@ -152,7 +152,7 @@ import "@openzeppelin/{{__item_context.file.absolutePath}}";
 
 <div className="border rounded-md mb-4">
 <div className="bg-secondary flex w-full justify-between px-4">
-<p className="font-bold text-sm font-mono">{{{name}}}({{typed-params params}})</p>
+<p className="font-bold text-sm font-mono">{{{name}}}({{typedParams params}})</p>
 <div className="flex flex-row items-center gap-2">
 <p className="font-light text-sm">event</p>
 <a className="peer" data-card href="#{{anchor}}">#</a>
@@ -161,7 +161,7 @@ import "@openzeppelin/{{__item_context.file.absolutePath}}";
 
 <div className="px-4">
 
-{{{process-natspec natspec.dev}}}
+{{{processNatspec natspec.dev}}}
 
 </div>
 </div>
@@ -172,7 +172,7 @@ import "@openzeppelin/{{__item_context.file.absolutePath}}";
 
 <div className="border rounded-md mb-4">
 <div className="bg-secondary flex w-full justify-between px-4">
-<p className="font-bold text-sm font-mono">{{{name}}}({{typed-params params}})</p>
+<p className="font-bold text-sm font-mono">{{{name}}}({{typedParams params}})</p>
 <div className="flex flex-row items-center gap-2">
 <p className="font-light text-sm">error</p>
 <a className="peer" data-card href="#{{anchor}}">#</a>
@@ -180,7 +180,7 @@ import "@openzeppelin/{{__item_context.file.absolutePath}}";
 </div>
 <div className="px-4">
 
-{{{process-natspec natspec.dev}}}
+{{{processNatspec natspec.dev}}}
 
 </div>
 </div>

--- a/docgen/templates-md/helpers.js
+++ b/docgen/templates-md/helpers.js
@@ -321,12 +321,23 @@ function cleanupContent(content) {
     // xref:api:filename.adoc#anchor[text] -> [text](apiDocsBase/filename#anchor)
     .replace(/xref:api:([^[]+)\.adoc(?:#([^[]*))?\[([^\]]*)\]/g, (_, file, anchor, text) =>
       `[${text}](${apiDocsBase}/${file}${anchor ? '#' + anchor : ''})`)
-    // xref:module::filename.adoc[text] -> [text](docsBase/module/filename)
-    // Modules like "learn" are relative to the product docs base, not site root
-    .replace(/xref:([a-z-]+)::([^[]+)\.adoc(?:#([^[]*))?\[([^\]]*)\]/g, (_, mod, file, anchor, text) => {
-      // upgrades-plugins is a separate product at site root
-      const base = mod === 'upgrades-plugins' ? '' : docsBase;
-      return `[${text}](${base}/${mod}/${file}${anchor ? '#' + anchor : ''})`;
+    // xref:module::filename.adoc[text] -> [text](base/filename)
+    // `learn` is version-independent (only lives under /contracts/5.x/learn);
+    // separate products live at the site root; everything else hangs off the
+    // per-version product docs base. Keep in sync with scripts/convert-adoc.js.
+    .replace(/xref:([a-z-]+)::([^[]+)\.adoc(?:#([^[]*))?\[([^\]]*)\]/g, (match, mod, file, anchor, text) => {
+      const moduleBases = {
+        contracts: docsBase,
+        'community-contracts': '/community-contracts',
+        'confidential-contracts': '/confidential-contracts',
+        'upgrades-plugins': '/upgrades-plugins',
+        defender: '/defender',
+        learn: '/contracts/5.x/learn',
+      };
+      const base = moduleBases[mod];
+      if (base === undefined) return match;
+      const prefix = mod === 'learn' ? '' : `/${mod}`; // `learn`'s base already includes the module segment
+      return `[${text}](${base}${prefix}/${file}${anchor ? '#' + anchor : ''})`;
     })
     // xref:filename.adoc#anchor[text] -> [text](apiDocsBase/filename#anchor) (bare, within API context)
     .replace(/xref:([^:[\s]+)\.adoc(?:#([^[]*))?\[([^\]]*)\]/g, (_, file, anchor, text) =>

--- a/docgen/templates-md/helpers.js
+++ b/docgen/templates-md/helpers.js
@@ -6,9 +6,9 @@ const os = require('os');
 
 const API_DOCS_PATH = 'contracts/5.x/api';
 
-module.exports['oz-version'] = () => version;
+module.exports.ozVersion = () => version;
 
-module.exports['readme-path'] = opts => {
+module.exports.readmePath = opts => {
   const pageId = opts.data.root.id;
   const basePath = pageId.replace(/\.(adoc|mdx)$/, '');
   return 'contracts/' + basePath + '/README.adoc';
@@ -31,7 +31,7 @@ module.exports.names = params => params?.map(p => p.name).join(', ');
 // Simple function counter for unique IDs
 const functionNameCounts = {};
 
-module.exports['simple-id'] = function (name) {
+module.exports.simpleId = function (name) {
   if (!functionNameCounts[name]) {
     functionNameCounts[name] = 1;
     return name;
@@ -41,7 +41,7 @@ module.exports['simple-id'] = function (name) {
   }
 };
 
-module.exports['reset-function-counts'] = function () {
+module.exports.resetFunctionCounts = function () {
   Object.keys(functionNameCounts).forEach(key => delete functionNameCounts[key]);
   return '';
 };
@@ -52,13 +52,13 @@ module.exports.eq = (a, b) => a === b;
 // import specifier for non-`contracts` packages, where the file is published
 // at the package root (e.g. @openzeppelin/community-contracts/account/X.sol)
 // but the source lives at contracts/account/X.sol in the repo.
-module.exports['strip-contracts-prefix'] = function (p) {
+module.exports.stripContractsPrefix = function (p) {
   return typeof p === 'string' ? p.replace(/^contracts\//, '') : p;
 };
-module.exports['starts-with'] = (str, prefix) => str && str.startsWith(prefix);
+module.exports.startsWith = (str, prefix) => str && str.startsWith(prefix);
 
 // Process natspec content with {REF} and link replacement
-module.exports['process-natspec'] = function (natspec, opts) {
+module.exports.processNatspec = function (natspec, opts) {
   if (!natspec) return '';
 
   const currentPage = opts.data.root.__item_context?.page || opts.data.root.id;
@@ -68,7 +68,7 @@ module.exports['process-natspec'] = function (natspec, opts) {
   return processCallouts(processed); // Add callout processing at the end
 };
 
-module.exports['typed-params'] = params => {
+module.exports.typedParams = params => {
   return params?.map(p => `${p.type}${p.indexed ? ' indexed' : ''}${p.name ? ' ' + p.name : ''}`).join(', ');
 };
 
@@ -497,7 +497,7 @@ module.exports.description = opts => {
   return `Smart contract ${dirName.replace('-', ' ')} utilities and implementations`;
 };
 
-module.exports['with-prelude'] = opts => {
+module.exports.withPrelude = opts => {
   const currentPage = opts.data.root.id;
   const links = getAllLinks(opts.data.site.items, currentPage);
   const contents = opts.fn();

--- a/docgen/templates-md/page.hbs
+++ b/docgen/templates-md/page.hbs
@@ -3,9 +3,9 @@ title: "{{title}}"
 description: "{{description}}"
 ---
 
-{{#with-prelude}}
-{{readme (readme-path)}}
-{{/with-prelude}}
+{{#withPrelude}}
+{{readme (readmePath)}}
+{{/withPrelude}}
 
 {{#each items}}
 {{>contract}}

--- a/docgen/templates-md/properties.js
+++ b/docgen/templates-md/properties.js
@@ -44,24 +44,24 @@ module.exports.inheritance = function ({ item, build }) {
     .filter((c, i) => c.name !== 'Context' || i === 0);
 };
 
-module.exports['has-functions'] = function ({ item }) {
+module.exports.hasFunctions = function ({ item }) {
   return item.inheritance && item.inheritance.some(c => c.functions.length > 0);
 };
 
-module.exports['has-events'] = function ({ item }) {
+module.exports.hasEvents = function ({ item }) {
   return item.inheritance && item.inheritance.some(c => c.events.length > 0);
 };
 
-module.exports['has-errors'] = function ({ item }) {
+module.exports.hasErrors = function ({ item }) {
   return item.inheritance && item.inheritance.some(c => c.errors.length > 0);
 };
 
-module.exports['internal-variables'] = function ({ item }) {
+module.exports.internalVariables = function ({ item }) {
   return item.variables ? item.variables.filter(({ visibility }) => visibility === 'internal') : [];
 };
 
-module.exports['has-internal-variables'] = function ({ item }) {
-  return module.exports['internal-variables']({ item }).length > 0;
+module.exports.hasInternalVariables = function ({ item }) {
+  return module.exports.internalVariables({ item }).length > 0;
 };
 
 module.exports.functions = function ({ item }) {
@@ -79,7 +79,7 @@ module.exports.returns2 = function ({ item }) {
   }
 };
 
-module.exports['inherited-functions'] = function ({ item }) {
+module.exports.inheritedFunctions = function ({ item }) {
   const { inheritance } = item;
   if (!inheritance) return [];
 

--- a/scripts/convert-adoc.js
+++ b/scripts/convert-adoc.js
@@ -125,8 +125,11 @@ async function convertAdocFiles(directory, apiRoute = "contracts/5.x/api") {
 			// after the steps above. Map them to absolute site paths per module.
 			// Drop trailing /index for index pages so the URL resolves to the
 			// section root rather than the literal /index slug.
+			// Keep in sync with docgen/templates-md/helpers.js. `learn` is
+			// version-independent and lives at a fixed path; `contracts` follows
+			// the per-version guide route derived from apiRoute.
 			const moduleBases = {
-				contracts: "/contracts/5.x",
+				contracts: `/${guideRoute}`,
 				"community-contracts": "/community-contracts",
 				"confidential-contracts": "/confidential-contracts",
 				"upgrades-plugins": "/upgrades-plugins",

--- a/scripts/generate-api-docs.js
+++ b/scripts/generate-api-docs.js
@@ -143,13 +143,8 @@ const PROPERTY_EXPORTS = [
 	"returns2", "inheritedFunctions",
 ];
 
-function tsShim(varName, sourcePath, exports) {
-	return [
-		`import ${varName} from '${sourcePath}';`,
-		"",
-		...exports.map(e => `export const ${e} = ${varName}.${e};`),
-		"",
-	].join("\n");
+function tsShim(sourcePath, exports) {
+	return `export { ${exports.join(", ")} } from "${sourcePath}";\n`;
 }
 
 async function injectTemplates(tempDir, options) {
@@ -161,11 +156,7 @@ async function injectTemplates(tempDir, options) {
 
 	// Detect new layout (hardhat3-style): docs/config.mjs + docs/templates/.
 	// Legacy layout uses docs/config.js + docs/templates-md/.
-	let newLayout = false;
-	try {
-		await fs.access(path.join(tempDir, "docs", "config.mjs"));
-		newLayout = true;
-	} catch {}
+	const newLayout = await fs.access(path.join(tempDir, "docs", "config.mjs")).then(() => true, () => false);
 
 	const templatesTarget = path.join(
 		tempDir,
@@ -224,12 +215,12 @@ async function injectTemplates(tempDir, options) {
 		await fs.writeFile(propertiesCjsPath, propertiesSource, "utf8");
 		await fs.writeFile(
 			path.join(templatesTarget, "helpers.ts"),
-			tsShim("h", "./helpers.cjs", HELPER_EXPORTS),
+			tsShim("./helpers.cjs", HELPER_EXPORTS),
 			"utf8",
 		);
 		await fs.writeFile(
 			path.join(templatesTarget, "properties.ts"),
-			tsShim("p", "./properties.cjs", PROPERTY_EXPORTS),
+			tsShim("./properties.cjs", PROPERTY_EXPORTS),
 			"utf8",
 		);
 	}

--- a/scripts/generate-api-docs.js
+++ b/scripts/generate-api-docs.js
@@ -126,6 +126,32 @@ function derivePackageName(repoName) {
 	return withoutPrefix;
 }
 
+// Helpers and properties exported by templates-md/{helpers,properties}.js,
+// used to generate ESM shim files when injecting into the new layout. The
+// hardhat3-style docgen plugin only loads helpers.ts/properties.ts via
+// `await import()`, so it needs real named exports — kebab-case CJS keys
+// don't survive ESM interop.
+const HELPER_EXPORTS = [
+	"ozVersion", "readmePath", "readme", "names", "simpleId",
+	"resetFunctionCounts", "eq", "stripContractsPrefix", "startsWith",
+	"processNatspec", "typedParams", "slug", "title", "description",
+	"withPrelude",
+];
+const PROPERTY_EXPORTS = [
+	"anchor", "fullname", "inheritance", "hasFunctions", "hasEvents",
+	"hasErrors", "internalVariables", "hasInternalVariables", "functions",
+	"returns2", "inheritedFunctions",
+];
+
+function tsShim(varName, sourcePath, exports) {
+	return [
+		`import ${varName} from '${sourcePath}';`,
+		"",
+		...exports.map(e => `export const ${e} = ${varName}.${e};`),
+		"",
+	].join("\n");
+}
+
 async function injectTemplates(tempDir, options) {
 	const { contractsRepo, contractsBranch, apiOutputDir } = options;
 	const repoInfo = extractRepoInfo(contractsRepo);
@@ -133,24 +159,84 @@ async function injectTemplates(tempDir, options) {
 
 	console.log("📋 Injecting canonical MDX templates...");
 
-	const templatesTarget = path.join(tempDir, "docs", "templates-md");
-	// Overwrite the cloned repo's docs/config.js with our canonical config.
-	// The cloned repo's hardhat config and prepare-docs.sh scripts both load
-	// `./docs/config`, so this single overwrite covers both paths without
-	// needing a separate config-md.js write or a hardhat-config regex patch.
-	const configTarget = path.join(tempDir, "docs", "config.js");
+	// Detect new layout (hardhat3-style): docs/config.mjs + docs/templates/.
+	// Legacy layout uses docs/config.js + docs/templates-md/.
+	let newLayout = false;
+	try {
+		await fs.access(path.join(tempDir, "docs", "config.mjs"));
+		newLayout = true;
+	} catch {}
 
+	const templatesTarget = path.join(
+		tempDir,
+		"docs",
+		newLayout ? "templates" : "templates-md",
+	);
+	const configTarget = path.join(
+		tempDir,
+		"docs",
+		newLayout ? "config.mjs" : "config.js",
+	);
+	const configSource = path.join(
+		DOCGEN_DIR,
+		newLayout ? "config-md.mjs" : "config-md.js",
+	);
+
+	if (newLayout) {
+		console.log("  ✓ Detected new layout (config.mjs + docs/templates/)");
+	}
+
+	// Wipe target templates dir to avoid stale files from the cloned repo
+	// (e.g. the hardhat3 branch's helpers.ts/properties.ts/contract.hbs).
+	await fs.rm(templatesTarget, { recursive: true, force: true });
 	await fs.mkdir(templatesTarget, { recursive: true });
 	await copyDirRecursive(
 		path.join(DOCGEN_DIR, "templates-md"),
 		templatesTarget,
 	);
 
-	await fs.copyFile(path.join(DOCGEN_DIR, "config-md.js"), configTarget);
+	await fs.copyFile(configSource, configTarget);
 
-	// Customize API_DOCS_PATH in helpers.js (URL path = file path minus content/)
+	// The new plugin loads helpers via `require.resolve(dir + '/helpers.ts')`
+	// and `await import(...)` — only `.ts` is searched and only ESM named
+	// function exports are picked up. Rename our CJS .js files to .cjs and
+	// emit thin .ts shims that re-export each function.
+	const helpersFileName = newLayout ? "helpers.cjs" : "helpers.js";
+	const propertiesFileName = newLayout ? "properties.cjs" : "properties.js";
+	if (newLayout) {
+		await fs.rename(
+			path.join(templatesTarget, "helpers.js"),
+			path.join(templatesTarget, helpersFileName),
+		);
+		await fs.rename(
+			path.join(templatesTarget, "properties.js"),
+			path.join(templatesTarget, propertiesFileName),
+		);
+		// `require('./helpers')` in properties.cjs no longer resolves once
+		// the file is renamed (Node's CJS resolver does not search for
+		// `.cjs` by default). Patch the import to use the explicit name.
+		const propertiesCjsPath = path.join(templatesTarget, propertiesFileName);
+		let propertiesSource = await fs.readFile(propertiesCjsPath, "utf8");
+		propertiesSource = propertiesSource.replace(
+			/require\(['"]\.\/helpers['"]\)/g,
+			"require('./helpers.cjs')",
+		);
+		await fs.writeFile(propertiesCjsPath, propertiesSource, "utf8");
+		await fs.writeFile(
+			path.join(templatesTarget, "helpers.ts"),
+			tsShim("h", "./helpers.cjs", HELPER_EXPORTS),
+			"utf8",
+		);
+		await fs.writeFile(
+			path.join(templatesTarget, "properties.ts"),
+			tsShim("p", "./properties.cjs", PROPERTY_EXPORTS),
+			"utf8",
+		);
+	}
+
+	// Customize API_DOCS_PATH in helpers (URL path = file path minus content/)
 	const apiDocsPath = apiOutputDir.replace(/^content\//, "");
-	const helpersPath = path.join(templatesTarget, "helpers.js");
+	const helpersPath = path.join(templatesTarget, helpersFileName);
 	let helpers = await fs.readFile(helpersPath, "utf8");
 	helpers = helpers.replace(
 		/const API_DOCS_PATH = ['"][^'"]+['"]/,
@@ -173,7 +259,7 @@ async function injectTemplates(tempDir, options) {
 	// /blob/v0.0.1/... when community-contracts package.json has a placeholder
 	// version that doesn't correspond to an actual tag.
 	contract = contract.replace(
-		/blob\/v\{\{oz-version\}\}/g,
+		/blob\/v\{\{ozVersion\}\}/g,
 		`blob/${contractsBranch}`,
 	);
 
@@ -182,11 +268,11 @@ async function injectTemplates(tempDir, options) {
 	// (npm package is `@openzeppelin/contracts`, file path keeps the prefix).
 	// For other packages (community-contracts, confidential-contracts), the
 	// npm package is published with `contracts/` as the package root, so the
-	// import skips that prefix — strip it via the strip-contracts-prefix helper.
+	// import skips that prefix via the stripContractsPrefix helper.
 	if (packageName !== "contracts") {
 		contract = contract.replace(
 			/import "@openzeppelin\/\{\{__item_context\.file\.absolutePath\}\}";/g,
-			`import "@openzeppelin/${packageName}/{{strip-contracts-prefix __item_context.file.absolutePath}}";`,
+			`import "@openzeppelin/${packageName}/{{stripContractsPrefix __item_context.file.absolutePath}}";`,
 		);
 	}
 	await fs.writeFile(contractPath, contract, "utf8");


### PR DESCRIPTION
## Summary

The docgen-pipeline (#140) assumed a Hardhat 2 / `solidity-docgen` source repo: `docs/config.js`, `docs/templates-md/`, kebab-case helpers, all CJS. The [hardhat3 branch of openzeppelin-contracts](https://github.com/OpenZeppelin/openzeppelin-contracts/tree/hardhat3) ships an in-tree docgen plugin that:

- reads `docs/config.mjs` (ESM, loaded via `import()` in `prepare-docs.sh`)
- looks for templates in `docs/templates/`
- defaults to `pageExtension: '.adoc'`
- loads helpers only from `helpers.ts` / `properties.ts` via `await import()` — and only picks up ESM **named function exports**

Result on [run 26575968521](https://github.com/OpenZeppelin/docs/actions/runs/26575968521): our injection wrote `docs/config.js` and `docs/templates-md/`, both silently ignored. The plugin ran with the source repo's own AsciiDoc templates, copied `.adoc` files into `content/contracts/latest/api/`, fumadocs couldn't route them, and every guide xref into the API 404'd — 200 errors in `next-validate-link`.

### What this PR does

- **Sniff the layout in `injectTemplates`**. If the cloned repo has `docs/config.mjs`, treat it as the new layout; otherwise fall through to the legacy code path unchanged.
- **For the new layout**:
  - Overwrite `docs/config.mjs` with `docgen/config-md.mjs` (forces `pageExtension: '.mdx'` and `templates: 'docs/templates'`).
  - Wipe and re-populate `docs/templates/`, renaming `helpers.js` / `properties.js` to `.cjs` (the hardhat3 branch sets `\"type\": \"module\"` so plain `.js` would be treated as ESM and our `module.exports` would break). Patch the internal `require('./helpers')` in `properties.cjs` accordingly.
  - Emit thin ESM shim files `helpers.ts` / `properties.ts` that re-export each function — the new plugin's loader only walks `.ts` named exports.
- **Rename kebab-case helpers** (`oz-version`, `has-functions`, `typed-params`, …) to camelCase across templates and helpers/properties modules. ESM named exports can't carry hyphens, and Handlebars is name-agnostic, so this is transparent to solidity-docgen on older tags.

### Verified locally

Ran the updated `generate-api-docs.js` against the hardhat3 branch end to end (`hardhat docgen` + `convert-adoc.js` + `pnpm run lint:links`). 200 → **1** broken link. The residual is a pre-existing EIP712 NatSpec xref to `/<base>/learn/upgrading-smart-contracts` that also fails today on `content/contracts/5.x/` — unrelated to this change.

### Test plan

- [ ] Re-run **Generate API Docs - Contracts** with `tag_name: hardhat3` and `trigger_type: commit`; confirm the validate step is clean (or only flags the EIP712 learn-module xref).
- [ ] Re-run **Generate API Docs - Contracts** with default `tag_name: v5.6.1`; confirm legacy path still works.
- [ ] Spot-check the resulting PR against the live site: anchors like `/contracts/latest/api/access#AccessManager-RoleRevoked-uint64-address-` resolve.

🤖 Generated with [Claude Code](https://claude.com/claude-code)