### PR TITLE
Hardhat Upgrades: clarify ethers vs viem requirements

### DIFF
--- a/content/upgrades-plugins/hardhat-upgrades.mdx
+++ b/content/upgrades-plugins/hardhat-upgrades.mdx
@@ -20,7 +20,7 @@ $ npm install --save-dev @nomicfoundation/hardhat-ethers ethers # peer dependenc
 ```
 
 <Callout>
-Hardhat 3 supports both ethers and viem. This plugin uses `@nomicfoundation/hardhat-ethers` internally and loads it automatically. If your project uses viem, install `@nomicfoundation/hardhat-viem` and add it to your config alongside this plugin.
+Hardhat 3 supports both ethers and viem. This plugin uses `@nomicfoundation/hardhat-ethers` internally and loads it automatically. If your project uses viem, install `@nomicfoundation/hardhat-viem` and add it to your config alongside this plugin: your own scripts and tests can use viem, while the plugin's functions take ethers contract factories from `connection.ethers` and return ethers contracts.
 </Callout>
 
 Register the `@openzeppelin/hardhat-upgrades` plugin in your [`hardhat.config.ts`](https://hardhat.org/config/):

--- a/content/upgrades-plugins/migrate-from-hardhat-2.mdx
+++ b/content/upgrades-plugins/migrate-from-hardhat-2.mdx
@@ -22,7 +22,7 @@ npm install --save-dev hardhat @nomicfoundation/hardhat-ethers
 ```
 
 <Callout>
-**Using viem?** You can install both `@nomicfoundation/hardhat-ethers` and `@nomicfoundation/hardhat-viem`. The upgrades plugin uses ethers internally; your own scripts and tests can still use viem.
+**Using viem?** You can install both `@nomicfoundation/hardhat-ethers` and `@nomicfoundation/hardhat-viem`. The upgrades plugin uses ethers internally; your own scripts and tests can still use viem. Note that the plugin's functions take ethers contract factories and return ethers contracts, so use `connection.ethers` when calling them.
 </Callout>
 
 ## Migration


### PR DESCRIPTION
The functions of `@openzeppelin/hardhat-upgrades` take ethers contract factories and return ethers contracts, so projects that otherwise use viem still use `connection.ethers` when calling the plugin. Adds one sentence to each of the two viem callouts in the Hardhat Upgrades docs to clarify this; no other changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)