### PR TITLE
docs: link contracts-sui llms.txt for AI integrators

### DIFF
--- a/content/contracts-sui/index.mdx
+++ b/content/contracts-sui/index.mdx
@@ -6,6 +6,10 @@ import { latestStable } from "./latest-versions.js";
 
 **OpenZeppelin Contracts for Sui** is a Move library for building secure applications on Sui with production-oriented access and math primitives.
 
+<Callout type="info">
+**Using these contracts with an AI agent?** Start from [`llms.txt`](https://github.com/OpenZeppelin/contracts-sui/blob/main/llms.txt) — a machine-readable entry point to every package, its examples, API reference, and MVR install snippet.
+</Callout>
+
 ## Getting Started
 
 <Cards>

--- a/content/contracts-sui/index.mdx
+++ b/content/contracts-sui/index.mdx
@@ -7,7 +7,7 @@ import { latestStable } from "./latest-versions.js";
 **OpenZeppelin Contracts for Sui** is a Move library for building secure applications on Sui with production-oriented access and math primitives.
 
 <Callout type="info">
-**Using these contracts with an AI agent?** Start from [`llms.txt`](https://github.com/OpenZeppelin/contracts-sui/blob/main/llms.txt) — a machine-readable entry point to every package, its examples, API reference, and MVR install snippet.
+**Using this library with an AI agent?** Start from [`llms.txt`](https://github.com/OpenZeppelin/contracts-sui/blob/main/llms.txt) — a machine-readable entry point to every package, its examples, API reference, and MVR install snippet.
 </Callout>
 
 ## Getting Started


### PR DESCRIPTION
## What

Adds a short callout near the top of the **Contracts for Sui** docs landing (`content/contracts-sui/index.mdx`) pointing AI coding agents at the canonical [`llms.txt`](https://github.com/OpenZeppelin/contracts-sui/blob/main/llms.txt):

> **Using this library with an AI agent?** Start from `llms.txt` — a machine-readable entry point to every package, its examples, API reference, and MVR install snippet.

## Why

`llms.txt` ([llmstxt.org](https://llmstxt.org/)) is the machine-readable discovery file AI coding agents read to find a project's authoritative sources. It lives in the contracts-sui repo as the single source of truth; the page links to it (not a copy) so it stays drift-free. The page's "Open in Claude" button feeds this landing to Claude, so the link reaches Claude too.

Closes part 2 of OpenZeppelin/contracts-sui#396.