### PR TITLE
docs: AI-discoverability polish for contracts-sui landing

### DIFF
--- a/content/contracts-sui/index.mdx
+++ b/content/contracts-sui/index.mdx
@@ -39,15 +39,15 @@ import { latestStable } from "./latest-versions.js";
 
 <Cards>
   <Card href={`/contracts-sui/${latestStable}/api/access`} title="Access">
-    Explore the complete access API, including its functions, types, and events.
+    Explore the complete access API, including its functions, types, events, and errors.
   </Card>
   <Card href={`/contracts-sui/${latestStable}/api/fixed-point`} title="Fixed-Point Math">
-    Explore the complete fixed-point math API, including its types and functions.
+    Explore the complete fixed-point math API, including its types, functions, and errors.
   </Card>
   <Card href={`/contracts-sui/${latestStable}/api/math`} title="Integer Math">
-    Explore the complete integer math API, including its functions and types.
+    Explore the complete integer math API, including its functions, types, and errors.
   </Card>
   <Card href={`/contracts-sui/${latestStable}/api/utils`} title="Utilities">
-    Explore the complete utilities API, including the rate limiter types and functions.
+    Explore the complete utilities API, including the rate limiter types, functions, and errors.
   </Card>
 </Cards>

--- a/content/contracts-sui/index.mdx
+++ b/content/contracts-sui/index.mdx
@@ -4,10 +4,10 @@ title: Contracts for Sui
 
 import { latestStable } from "./latest-versions.js";
 
-**OpenZeppelin Contracts for Sui** is a Move library for building secure applications on Sui with production-oriented access and math primitives.
+**OpenZeppelin Contracts for Sui** is a library of secure, audited, production-ready Move modules for building applications on Sui.
 
 <Callout type="info">
-**Using this library with an AI agent?** Start from [`llms.txt`](https://github.com/OpenZeppelin/contracts-sui/blob/main/llms.txt) — a machine-readable entry point to every package, its examples, API reference, and MVR install snippet.
+**Using this library with an AI agent?** Start from [`llms.txt`](https://raw.githubusercontent.com/OpenZeppelin/contracts-sui/main/llms.txt) — a machine-readable entry point to every package, its examples, API reference, and MVR install snippet.
 </Callout>
 
 ## Getting Started
@@ -21,27 +21,33 @@ import { latestStable } from "./latest-versions.js";
 ## Packages
 
 <Cards>
-  <Card href={`/contracts-sui/${latestStable}/math`} title="Integer Math">
-    Deterministic integer arithmetic with explicit rounding, overflow-safe `mul_div`/`mul_shr`, and decimal scaling helpers.
+  <Card href={`/contracts-sui/${latestStable}/access`} title="Access">
+    Role-based authorization and ownership-transfer policies for privileged protocol operations.
   </Card>
   <Card href={`/contracts-sui/${latestStable}/fixed-point`} title="Fixed-Point Math">
     9-decimal fixed-point types (`UD30x9`, `SD29x9`) for prices, fees, rates, and signed balance deltas.
   </Card>
-  <Card href={`/contracts-sui/${latestStable}/access`} title="Access">
-    Role-based authorization and ownership-transfer policies for privileged protocol operations.
+  <Card href={`/contracts-sui/${latestStable}/math`} title="Integer Math">
+    Overflow-safe integer arithmetic with explicit rounding and decimal scaling helpers.
+  </Card>
+  <Card href={`/contracts-sui/${latestStable}/utils`} title="Utilities">
+    Embeddable rate limiters for throttling on-chain actions.
   </Card>
 </Cards>
 
 ## API Reference
 
 <Cards>
-  <Card href={`/contracts-sui/${latestStable}/api/math`} title="Integer Math">
-    Explore the complete integer math API, including all functions and types.
+  <Card href={`/contracts-sui/${latestStable}/api/access`} title="Access">
+    Explore the complete access API, including its functions, types, and events.
   </Card>
   <Card href={`/contracts-sui/${latestStable}/api/fixed-point`} title="Fixed-Point Math">
-    Explore the complete fixed-point math API, including the `UD30x9` and `SD29x9` types and their arithmetic, comparison, and conversion modules.
+    Explore the complete fixed-point math API, including its types and functions.
   </Card>
-  <Card href={`/contracts-sui/${latestStable}/api/access`} title="Access">
-    Explore the complete access API reference, including module-level functions, core types, emitted events, and expected error conditions for integration.
+  <Card href={`/contracts-sui/${latestStable}/api/math`} title="Integer Math">
+    Explore the complete integer math API, including its functions and types.
+  </Card>
+  <Card href={`/contracts-sui/${latestStable}/api/utils`} title="Utilities">
+    Explore the complete utilities API, including the rate limiter types and functions.
   </Card>
 </Cards>

--- a/content/contracts-sui/index.mdx
+++ b/content/contracts-sui/index.mdx
@@ -1,10 +1,9 @@
 ---
 title: Contracts for Sui
+description: OpenZeppelin Contracts for Sui is a library of secure, audited, production-ready Move modules for building applications on Sui.
 ---
 
 import { latestStable } from "./latest-versions.js";
-
-**OpenZeppelin Contracts for Sui** is a library of secure, audited, production-ready Move modules for building applications on Sui.
 
 <Callout type="info">
 **Using this library with an AI agent?** Start from [`llms.txt`](https://raw.githubusercontent.com/OpenZeppelin/contracts-sui/main/llms.txt) — a machine-readable entry point to every package, its examples, API reference, and MVR install snippet.

--- a/public/llms.txt
+++ b/public/llms.txt
@@ -304,18 +304,24 @@ Each ecosystem section lists the smart-contract libraries and language-specific 
 
 ## Sui
 
-- [Getting Started](https://docs.openzeppelin.com/contracts-sui)
+- [Getting Started](https://docs.openzeppelin.com/contracts-sui): OpenZeppelin Contracts for Sui is a library of secure, audited, production-ready Move modules for building applications on Sui
 
 ### Sui Contracts
 
 - [Overview](https://docs.openzeppelin.com/contracts-sui/1.x)
-- [Learn — Overview](https://docs.openzeppelin.com/contracts-sui/1.x/learn)
-- [Learn — Math Walkthrough](https://docs.openzeppelin.com/contracts-sui/1.x/learn/math-walkthrough)
-- [Learn — Access Walkthrough](https://docs.openzeppelin.com/contracts-sui/1.x/learn/access-walkthrough)
+- [Learn — Role Based Access Control](https://docs.openzeppelin.com/contracts-sui/1.x/guides/access-control)
 - [Packages — Integer Math](https://docs.openzeppelin.com/contracts-sui/1.x/math)
-- [Packages — Access](https://docs.openzeppelin.com/contracts-sui/1.x/access)
+- [Packages — Fixed-Point Math](https://docs.openzeppelin.com/contracts-sui/1.x/fixed-point)
+- [Packages — Access — Overview](https://docs.openzeppelin.com/contracts-sui/1.x/access)
+- [Packages — Access — RBAC](https://docs.openzeppelin.com/contracts-sui/1.x/access-control)
+- [Packages — Access — Two-Step Transfer](https://docs.openzeppelin.com/contracts-sui/1.x/two-step-transfer)
+- [Packages — Access — Delayed Transfer](https://docs.openzeppelin.com/contracts-sui/1.x/delayed-transfer)
+- [Packages — Utils — Overview](https://docs.openzeppelin.com/contracts-sui/1.x/utils)
+- [Packages — Utils — Rate Limiter](https://docs.openzeppelin.com/contracts-sui/1.x/rate-limiter)
 - [API Reference — Integer Math](https://docs.openzeppelin.com/contracts-sui/1.x/api/math)
+- [API Reference — Fixed-Point Math](https://docs.openzeppelin.com/contracts-sui/1.x/api/fixed-point)
 - [API Reference — Access](https://docs.openzeppelin.com/contracts-sui/1.x/api/access)
+- [API Reference — Utils](https://docs.openzeppelin.com/contracts-sui/1.x/api/utils)
 
 ## Midnight
 


### PR DESCRIPTION
AI-discoverability polish for the Contracts for Sui docs landing.

**Landing (`content/contracts-sui/index.mdx`):**
- llms.txt callout → **raw** (agents get clean text, not the GitHub HTML wrapper).
- Added a page `description` (renders as lead + meta for crawlers/agents); removed the now-redundant intro paragraph.
- Cards (Packages + API Reference): alphabetical, added the missing **Utilities** card, button-length descriptions; API cards mention error conditions.

**Root `public/llms.txt`:**
- Regenerated the **Sui section only** (was stale): adds Fixed-Point Math + Utils (Packages + API), Access subpages, updated Learn, and picks up the new page description. Other products untouched.

Scope: existing/published packages (access, fixed-point, integer-math, utils).