### PR TITLE
docs: remove Telegram contact links across Monitor and Relayer docs

### DIFF
--- a/content/monitor/1.0.x/contribution.mdx
+++ b/content/monitor/1.0.x/contribution.mdx
@@ -267,7 +267,7 @@ Reviewers should focus on:
 
 If your PR isn’t getting attention:
 
-* Contact the team on [Telegram](https://t.me/openzeppelin_tg/4)
+* Open a discussion on [GitHub Discussions](https://github.com/OpenZeppelin/openzeppelin-monitor/discussions)
 * Ensure your PR has appropriate labels
 * Keep PRs focused and reasonably sized
 
@@ -293,7 +293,7 @@ Contributors must follow the [Code of Conduct](https://github.com/OpenZeppelin/o
 
 * ***GitHub Discussions***: For questions and community interaction
 * ***Issues***: For bug reports and feature requests
-* ***Telegram***: [Join our community chat](https://t.me/openzeppelin_tg/4)
+* ***Contact***: [Get in touch via our website](https://www.openzeppelin.com/contact)
 * ***Good First Issues***: [Find beginner-friendly issues](https://github.com/openzeppelin/openzeppelin-monitor/issues?q=is%3Aissue+is%3Aopen+label%3Agood-first-issue)
 
 ### Additional Resources

--- a/content/monitor/1.0.x/contribution.mdx
+++ b/content/monitor/1.0.x/contribution.mdx
@@ -267,7 +267,7 @@ Reviewers should focus on:
 
 If your PR isn’t getting attention:
 
-* Open a discussion on [GitHub Discussions](https://github.com/OpenZeppelin/openzeppelin-monitor/discussions)
+* Tag a maintainer on your PR to request a review
 * Ensure your PR has appropriate labels
 * Keep PRs focused and reasonably sized
 

--- a/content/monitor/1.0.x/index.mdx
+++ b/content/monitor/1.0.x/index.mdx
@@ -1427,7 +1427,7 @@ The monitor implements a comprehensive error handling system with rich context a
 
 ## Support
 
-For support or inquiries, contact us on [Telegram](https://t.me/openzeppelin_tg/4).
+For support or inquiries, [contact us](https://www.openzeppelin.com/contact).
 
 Have feature requests or want to contribute? Join our community on [GitHub](https://github.com/OpenZeppelin/openzeppelin-monitor/)
 

--- a/content/monitor/1.1.x/contribution.mdx
+++ b/content/monitor/1.1.x/contribution.mdx
@@ -299,7 +299,7 @@ Reviewers should focus on:
 
 If your PR isn’t getting attention:
 
-* Open a discussion on [GitHub Discussions](https://github.com/OpenZeppelin/openzeppelin-monitor/discussions)
+* Tag a maintainer on your PR to request a review
 * Ensure your PR has appropriate labels
 * Keep PRs focused and reasonably sized
 

--- a/content/monitor/1.1.x/contribution.mdx
+++ b/content/monitor/1.1.x/contribution.mdx
@@ -299,7 +299,7 @@ Reviewers should focus on:
 
 If your PR isn’t getting attention:
 
-* Contact the team on [Telegram](https://t.me/openzeppelin_tg/4)
+* Open a discussion on [GitHub Discussions](https://github.com/OpenZeppelin/openzeppelin-monitor/discussions)
 * Ensure your PR has appropriate labels
 * Keep PRs focused and reasonably sized
 
@@ -325,7 +325,7 @@ Contributors must follow the [Code of Conduct](https://github.com/OpenZeppelin/o
 
 * ***GitHub Discussions***: For questions and community interaction
 * ***Issues***: For bug reports and feature requests
-* ***Telegram***: [Join our community chat](https://t.me/openzeppelin_tg/4)
+* ***Contact***: [Get in touch via our website](https://www.openzeppelin.com/contact)
 * ***Good First Issues***: [Find beginner-friendly issues](https://github.com/openzeppelin/openzeppelin-monitor/issues?q=is%3Aissue+is%3Aopen+label%3Agood-first-issue)
 
 ### Additional Resources

--- a/content/monitor/1.1.x/index.mdx
+++ b/content/monitor/1.1.x/index.mdx
@@ -1522,7 +1522,7 @@ The monitor implements a comprehensive error handling system with rich context a
 
 ## Support
 
-For support or inquiries, contact us on [Telegram](https://t.me/openzeppelin_tg/4).
+For support or inquiries, [contact us](https://www.openzeppelin.com/contact).
 
 Have feature requests or want to contribute? Join our community on [GitHub](https://github.com/OpenZeppelin/openzeppelin-monitor/)
 

--- a/content/monitor/1.2.x/contribution.mdx
+++ b/content/monitor/1.2.x/contribution.mdx
@@ -310,7 +310,7 @@ Reviewers should focus on:
 
 If your PR isn’t getting attention:
 
-* Open a discussion on [GitHub Discussions](https://github.com/OpenZeppelin/openzeppelin-monitor/discussions)
+* Tag a maintainer on your PR to request a review
 * Ensure your PR has appropriate labels
 * Keep PRs focused and reasonably sized
 

--- a/content/monitor/1.2.x/contribution.mdx
+++ b/content/monitor/1.2.x/contribution.mdx
@@ -310,7 +310,7 @@ Reviewers should focus on:
 
 If your PR isn’t getting attention:
 
-* Contact the team on [Telegram](https://t.me/openzeppelin_tg/4)
+* Open a discussion on [GitHub Discussions](https://github.com/OpenZeppelin/openzeppelin-monitor/discussions)
 * Ensure your PR has appropriate labels
 * Keep PRs focused and reasonably sized
 
@@ -336,7 +336,7 @@ Contributors must follow the [Code of Conduct](https://github.com/OpenZeppelin/o
 
 * ***GitHub Discussions***: For questions and community interaction
 * ***Issues***: For bug reports and feature requests
-* ***Telegram***: [Join our community chat](https://t.me/openzeppelin_tg/4)
+* ***Contact***: [Get in touch via our website](https://www.openzeppelin.com/contact)
 * ***Good First Issues***: [Find beginner-friendly issues](https://github.com/openzeppelin/openzeppelin-monitor/issues?q=is%3Aissue+is%3Aopen+label%3Agood-first-issue)
 
 ### Additional Resources

--- a/content/monitor/1.2.x/index.mdx
+++ b/content/monitor/1.2.x/index.mdx
@@ -1771,7 +1771,7 @@ The monitor implements a comprehensive error handling system with rich context a
 
 ## Support
 
-For support or inquiries, contact us on [Telegram](https://t.me/openzeppelin_tg/4).
+For support or inquiries, [contact us](https://www.openzeppelin.com/contact).
 
 Have feature requests or want to contribute? Join our community on [GitHub](https://github.com/OpenZeppelin/openzeppelin-monitor/)
 

--- a/content/monitor/1.3.x/contribution.mdx
+++ b/content/monitor/1.3.x/contribution.mdx
@@ -310,7 +310,7 @@ Reviewers should focus on:
 
 If your PR isn’t getting attention:
 
-* Open a discussion on [GitHub Discussions](https://github.com/OpenZeppelin/openzeppelin-monitor/discussions)
+* Tag a maintainer on your PR to request a review
 * Ensure your PR has appropriate labels
 * Keep PRs focused and reasonably sized
 

--- a/content/monitor/1.3.x/contribution.mdx
+++ b/content/monitor/1.3.x/contribution.mdx
@@ -310,7 +310,7 @@ Reviewers should focus on:
 
 If your PR isn’t getting attention:
 
-* Contact the team on [Telegram](https://t.me/openzeppelin_tg/4)
+* Open a discussion on [GitHub Discussions](https://github.com/OpenZeppelin/openzeppelin-monitor/discussions)
 * Ensure your PR has appropriate labels
 * Keep PRs focused and reasonably sized
 
@@ -336,7 +336,7 @@ Contributors must follow the [Code of Conduct](https://github.com/OpenZeppelin/o
 
 * ***GitHub Discussions***: For questions and community interaction
 * ***Issues***: For bug reports and feature requests
-* ***Telegram***: [Join our community chat](https://t.me/openzeppelin_tg/4)
+* ***Contact***: [Get in touch via our website](https://www.openzeppelin.com/contact)
 * ***Good First Issues***: [Find beginner-friendly issues](https://github.com/openzeppelin/openzeppelin-monitor/issues?q=is%3Aissue+is%3Aopen+label%3Agood-first-issue)
 
 ### Additional Resources

--- a/content/monitor/1.3.x/index.mdx
+++ b/content/monitor/1.3.x/index.mdx
@@ -1771,7 +1771,7 @@ The monitor implements a comprehensive error handling system with rich context a
 
 ## Support
 
-For support or inquiries, contact us on [Telegram](https://t.me/openzeppelin_tg/4).
+For support or inquiries, [contact us](https://www.openzeppelin.com/contact).
 
 Have feature requests or want to contribute? Join our community on [GitHub](https://github.com/OpenZeppelin/openzeppelin-monitor/)
 

--- a/content/monitor/contribution.mdx
+++ b/content/monitor/contribution.mdx
@@ -310,7 +310,7 @@ Reviewers should focus on:
 
 If your PR isn’t getting attention:
 
-* Open a discussion on [GitHub Discussions](https://github.com/OpenZeppelin/openzeppelin-monitor/discussions)
+* Tag a maintainer on your PR to request a review
 * Ensure your PR has appropriate labels
 * Keep PRs focused and reasonably sized
 

--- a/content/monitor/contribution.mdx
+++ b/content/monitor/contribution.mdx
@@ -310,7 +310,7 @@ Reviewers should focus on:
 
 If your PR isn’t getting attention:
 
-* Contact the team on [Telegram](https://t.me/openzeppelin_tg/4)
+* Open a discussion on [GitHub Discussions](https://github.com/OpenZeppelin/openzeppelin-monitor/discussions)
 * Ensure your PR has appropriate labels
 * Keep PRs focused and reasonably sized
 
@@ -336,7 +336,7 @@ Contributors must follow the [Code of Conduct](https://github.com/OpenZeppelin/o
 
 * ***GitHub Discussions***: For questions and community interaction
 * ***Issues***: For bug reports and feature requests
-* ***Telegram***: [Join our community chat](https://t.me/openzeppelin_tg/4)
+* ***Contact***: [Get in touch via our website](https://www.openzeppelin.com/contact)
 * ***Good First Issues***: [Find beginner-friendly issues](https://github.com/openzeppelin/openzeppelin-monitor/issues?q=is%3Aissue+is%3Aopen+label%3Agood-first-issue)
 
 ### Additional Resources

--- a/content/monitor/index.mdx
+++ b/content/monitor/index.mdx
@@ -1771,7 +1771,7 @@ The monitor implements a comprehensive error handling system with rich context a
 
 ## Support
 
-For support or inquiries, contact us on [Telegram](https://t.me/openzeppelin_tg/4).
+For support or inquiries, [contact us](https://www.openzeppelin.com/contact).
 
 Have feature requests or want to contribute? Join our community on [GitHub](https://github.com/OpenZeppelin/openzeppelin-monitor/)
 

--- a/content/relayer/1.0.x/index.mdx
+++ b/content/relayer/1.0.x/index.mdx
@@ -327,7 +327,7 @@ The OpenZeppelin Relayer is designed to function as a backend service and is not
 
 ## Support
 
-For support or inquiries, contact us on [Telegram](https://t.me/openzeppelin_tg/2).
+For support or inquiries, [contact us](https://www.openzeppelin.com/contact).
 
 ## License
 This project is licensed under the GNU Affero General Public License v3.0 - see the LICENSE file for details.

--- a/content/relayer/1.0.x/solana.mdx
+++ b/content/relayer/1.0.x/solana.mdx
@@ -207,7 +207,7 @@ See [API Reference](/relayer/1.0.x/api_reference) and [SDK examples, window=_bla
 
 ## Support
 
-For help, join our [Telegram](https://t.me/openzeppelin_tg/2) or open an issue on GitHub.
+For help, open an issue on [GitHub](https://github.com/OpenZeppelin/openzeppelin-relayer/issues) or [contact us](https://www.openzeppelin.com/contact).
 
 ## License
 

--- a/content/relayer/1.1.x/evm.mdx
+++ b/content/relayer/1.1.x/evm.mdx
@@ -297,7 +297,7 @@ Enable metrics and monitor:
 
 For help with EVM integration:
 
-* Join our [Telegram](https://t.me/openzeppelin_tg/2) community
+* [Contact us](https://www.openzeppelin.com/contact) for general support
 * Open an issue on our [GitHub repository](https://github.com/OpenZeppelin/openzeppelin-relayer)
 * Check our [comprehensive documentation](https://docs.openzeppelin.com/relayer)
 

--- a/content/relayer/1.1.x/index.mdx
+++ b/content/relayer/1.1.x/index.mdx
@@ -326,7 +326,7 @@ The OpenZeppelin Relayer is designed to function as a backend service and is not
 
 ## Support
 
-For support or inquiries, contact us on [Telegram](https://t.me/openzeppelin_tg/2).
+For support or inquiries, [contact us](https://www.openzeppelin.com/contact).
 
 ## License
 This project is licensed under the GNU Affero General Public License v3.0 - see the LICENSE file for details.

--- a/content/relayer/1.1.x/solana.mdx
+++ b/content/relayer/1.1.x/solana.mdx
@@ -213,7 +213,7 @@ See [API Reference](/relayer/1.1.x/api) and [SDK examples](https://github.com/Op
 
 ## Support
 
-For help, join our [Telegram](https://t.me/openzeppelin_tg/2) or open an issue on GitHub.
+For help, open an issue on [GitHub](https://github.com/OpenZeppelin/openzeppelin-relayer/issues) or [contact us](https://www.openzeppelin.com/contact).
 
 ## License
 

--- a/content/relayer/1.1.x/stellar.mdx
+++ b/content/relayer/1.1.x/stellar.mdx
@@ -324,7 +324,7 @@ Soroban operations support different authorization modes:
 
 ## Support
 
-For help, join our [Telegram](https://t.me/openzeppelin_tg/2) or open an issue on GitHub.
+For help, open an issue on [GitHub](https://github.com/OpenZeppelin/openzeppelin-relayer/issues) or [contact us](https://www.openzeppelin.com/contact).
 
 ## License
 

--- a/content/relayer/1.2.x/evm.mdx
+++ b/content/relayer/1.2.x/evm.mdx
@@ -302,7 +302,7 @@ Enable metrics and monitor:
 
 For help with EVM integration:
 
-* Join our [Telegram](https://t.me/openzeppelin_tg/2) community
+* [Contact us](https://www.openzeppelin.com/contact) for general support
 * Open an issue on our [GitHub repository](https://github.com/OpenZeppelin/openzeppelin-relayer)
 * Check our [comprehensive documentation](https://docs.openzeppelin.com/relayer)
 

--- a/content/relayer/1.2.x/index.mdx
+++ b/content/relayer/1.2.x/index.mdx
@@ -340,7 +340,7 @@ The OpenZeppelin Relayer is designed to function as a backend service and is not
 
 ## Support
 
-For support or inquiries, contact us on [Telegram](https://t.me/openzeppelin_tg/2).
+For support or inquiries, [contact us](https://www.openzeppelin.com/contact).
 
 ## License
 This project is licensed under the GNU Affero General Public License v3.0 - see the LICENSE file for details.

--- a/content/relayer/1.2.x/solana.mdx
+++ b/content/relayer/1.2.x/solana.mdx
@@ -311,7 +311,7 @@ For complete REST API examples with both options, see the [SDK Solana examples](
 
 ## Support
 
-For help, join our [Telegram](https://t.me/openzeppelin_tg/2) or open an issue on GitHub.
+For help, open an issue on [GitHub](https://github.com/OpenZeppelin/openzeppelin-relayer/issues) or [contact us](https://www.openzeppelin.com/contact).
 
 ## License
 

--- a/content/relayer/1.2.x/stellar.mdx
+++ b/content/relayer/1.2.x/stellar.mdx
@@ -413,7 +413,7 @@ For complete examples:
 
 ## Support
 
-For help, join our [Telegram](https://t.me/openzeppelin_tg/2) or open an issue on GitHub.
+For help, open an issue on [GitHub](https://github.com/OpenZeppelin/openzeppelin-relayer/issues) or [contact us](https://www.openzeppelin.com/contact).
 
 ## License
 

--- a/content/relayer/1.3.x/evm.mdx
+++ b/content/relayer/1.3.x/evm.mdx
@@ -302,7 +302,7 @@ Enable metrics and monitor:
 
 For help with EVM integration:
 
-* Join our [Telegram](https://t.me/openzeppelin_tg/2) community
+* [Contact us](https://www.openzeppelin.com/contact) for general support
 * Open an issue on our [GitHub repository](https://github.com/OpenZeppelin/openzeppelin-relayer)
 * Check our [comprehensive documentation](https://docs.openzeppelin.com/relayer)
 

--- a/content/relayer/1.3.x/index.mdx
+++ b/content/relayer/1.3.x/index.mdx
@@ -341,7 +341,7 @@ The OpenZeppelin Relayer is designed to function as a backend service and is not
 
 ## Support
 
-For support or inquiries, contact us on [Telegram](https://t.me/openzeppelin_tg/2).
+For support or inquiries, [contact us](https://www.openzeppelin.com/contact).
 
 ## License
 This project is licensed under the GNU Affero General Public License v3.0 - see the LICENSE file for details.

--- a/content/relayer/1.3.x/solana.mdx
+++ b/content/relayer/1.3.x/solana.mdx
@@ -342,7 +342,7 @@ For complete REST API examples with both options, see the [SDK Solana examples](
 
 ## Support
 
-For help, join our [Telegram](https://t.me/openzeppelin_tg/2) or open an issue on GitHub.
+For help, open an issue on [GitHub](https://github.com/OpenZeppelin/openzeppelin-relayer/issues) or [contact us](https://www.openzeppelin.com/contact).
 
 ## License
 

--- a/content/relayer/1.3.x/stellar.mdx
+++ b/content/relayer/1.3.x/stellar.mdx
@@ -555,7 +555,7 @@ For complete examples:
 
 ## Support
 
-For help, join our [Telegram](https://t.me/openzeppelin_tg/2) or open an issue on GitHub.
+For help, open an issue on [GitHub](https://github.com/OpenZeppelin/openzeppelin-relayer/issues) or [contact us](https://www.openzeppelin.com/contact).
 
 ## License
 

--- a/content/relayer/1.4.x/evm.mdx
+++ b/content/relayer/1.4.x/evm.mdx
@@ -313,7 +313,7 @@ Enable metrics and monitor:
 
 For help with EVM integration:
 
-- Join our [Telegram](https://t.me/openzeppelin_tg/2) community
+- [Contact us](https://www.openzeppelin.com/contact) for general support
 - Open an issue on our [GitHub repository](https://github.com/OpenZeppelin/openzeppelin-relayer)
 - Check our [comprehensive documentation](https://docs.openzeppelin.com/relayer)
 

--- a/content/relayer/1.4.x/index.mdx
+++ b/content/relayer/1.4.x/index.mdx
@@ -341,7 +341,7 @@ The OpenZeppelin Relayer is designed to function as a backend service and is not
 
 ## Support
 
-For support or inquiries, contact us on [Telegram](https://t.me/openzeppelin_tg/2).
+For support or inquiries, [contact us](https://www.openzeppelin.com/contact).
 
 ## License
 This project is licensed under the GNU Affero General Public License v3.0 - see the LICENSE file for details.

--- a/content/relayer/1.4.x/solana.mdx
+++ b/content/relayer/1.4.x/solana.mdx
@@ -342,7 +342,7 @@ For complete REST API examples with both options, see the [SDK Solana examples](
 
 ## Support
 
-For help, join our [Telegram](https://t.me/openzeppelin_tg/2) or open an issue on GitHub.
+For help, open an issue on [GitHub](https://github.com/OpenZeppelin/openzeppelin-relayer/issues) or [contact us](https://www.openzeppelin.com/contact).
 
 ## License
 

--- a/content/relayer/1.4.x/stellar.mdx
+++ b/content/relayer/1.4.x/stellar.mdx
@@ -555,7 +555,7 @@ For complete examples:
 
 ## Support
 
-For help, join our [Telegram](https://t.me/openzeppelin_tg/2) or open an issue on GitHub.
+For help, open an issue on [GitHub](https://github.com/OpenZeppelin/openzeppelin-relayer/issues) or [contact us](https://www.openzeppelin.com/contact).
 
 ## License
 

--- a/content/relayer/1.4.x/zama-fhevm.mdx
+++ b/content/relayer/1.4.x/zama-fhevm.mdx
@@ -152,4 +152,4 @@ The example contract is deployed from [Zama's fhevm-hardhat-template](https://gi
 
 ## Support
 
-For help, join our [Telegram](https://t.me/openzeppelin_tg/2) or open an issue on GitHub.
+For help, open an issue on [GitHub](https://github.com/OpenZeppelin/openzeppelin-relayer/issues) or [contact us](https://www.openzeppelin.com/contact).

--- a/content/relayer/1.5.x/evm.mdx
+++ b/content/relayer/1.5.x/evm.mdx
@@ -313,7 +313,7 @@ Enable metrics and monitor:
 
 For help with EVM integration:
 
-- Join our [Telegram](https://t.me/openzeppelin_tg/2) community
+- [Contact us](https://www.openzeppelin.com/contact) for general support
 - Open an issue on our [GitHub repository](https://github.com/OpenZeppelin/openzeppelin-relayer)
 - Check our [comprehensive documentation](https://docs.openzeppelin.com/relayer)
 

--- a/content/relayer/1.5.x/guides/stellar-relayer-aws-operator-guide.mdx
+++ b/content/relayer/1.5.x/guides/stellar-relayer-aws-operator-guide.mdx
@@ -4,9 +4,7 @@ title: 'Hosted Stellar Relayer on AWS: Operator Deployment Guide'
 
 A step-by-step guide for infrastructure teams deploying a hosted Stellar Relayer service on AWS that mirrors OpenZeppelin's existing production setup.
 
-**Audience:** infrastructure operators who have run production AWS workloads but are new to OpenZeppelin's relayer stack.
-
-**Outcome:** a hosted Stellar Channels service in your own AWS account capable of serving the same workload profile OpenZeppelin currently runs (roughly 2M+ transactions per day across roughly 2,500 relayers).
+It uses Terraform to spin up the full infrastructure in your own AWS account.
 
 For the GCP deployment, see the [GCP Operator Deployment Guide](/relayer/1.5.x/guides/stellar-relayer-gcp-operator-guide).
 

--- a/content/relayer/1.5.x/index.mdx
+++ b/content/relayer/1.5.x/index.mdx
@@ -341,7 +341,7 @@ The OpenZeppelin Relayer is designed to function as a backend service and is not
 
 ## Support
 
-For support or inquiries, contact us on [Telegram](https://t.me/openzeppelin_tg/2).
+For support or inquiries, [contact us](https://www.openzeppelin.com/contact).
 
 ## License
 This project is licensed under the GNU Affero General Public License v3.0 - see the LICENSE file for details.

--- a/content/relayer/1.5.x/solana.mdx
+++ b/content/relayer/1.5.x/solana.mdx
@@ -342,7 +342,7 @@ For complete REST API examples with both options, see the [SDK Solana examples](
 
 ## Support
 
-For help, join our [Telegram](https://t.me/openzeppelin_tg/2) or open an issue on GitHub.
+For help, open an issue on [GitHub](https://github.com/OpenZeppelin/openzeppelin-relayer/issues) or [contact us](https://www.openzeppelin.com/contact).
 
 ## License
 

--- a/content/relayer/1.5.x/stellar.mdx
+++ b/content/relayer/1.5.x/stellar.mdx
@@ -555,7 +555,7 @@ For complete examples:
 
 ## Support
 
-For help, join our [Telegram](https://t.me/openzeppelin_tg/2) or open an issue on GitHub.
+For help, open an issue on [GitHub](https://github.com/OpenZeppelin/openzeppelin-relayer/issues) or [contact us](https://www.openzeppelin.com/contact).
 
 ## License
 

--- a/content/relayer/1.5.x/zama-fhevm.mdx
+++ b/content/relayer/1.5.x/zama-fhevm.mdx
@@ -152,4 +152,4 @@ The example contract is deployed from [Zama's fhevm-hardhat-template](https://gi
 
 ## Support
 
-For help, join our [Telegram](https://t.me/openzeppelin_tg/2) or open an issue on GitHub.
+For help, open an issue on [GitHub](https://github.com/OpenZeppelin/openzeppelin-relayer/issues) or [contact us](https://www.openzeppelin.com/contact).

--- a/content/relayer/evm.mdx
+++ b/content/relayer/evm.mdx
@@ -313,7 +313,7 @@ Enable metrics and monitor:
 
 For help with EVM integration:
 
-- Join our [Telegram](https://t.me/openzeppelin_tg/2) community
+- [Contact us](https://www.openzeppelin.com/contact) for general support
 - Open an issue on our [GitHub repository](https://github.com/OpenZeppelin/openzeppelin-relayer)
 - Check our [comprehensive documentation](https://docs.openzeppelin.com/relayer)
 

--- a/content/relayer/guides/stellar-relayer-aws-operator-guide.mdx
+++ b/content/relayer/guides/stellar-relayer-aws-operator-guide.mdx
@@ -4,9 +4,7 @@ title: 'Hosted Stellar Relayer on AWS: Operator Deployment Guide'
 
 A step-by-step guide for infrastructure teams deploying a hosted Stellar Relayer service on AWS that mirrors OpenZeppelin's existing production setup.
 
-**Audience:** infrastructure operators who have run production AWS workloads but are new to OpenZeppelin's relayer stack.
-
-**Outcome:** a hosted Stellar Channels service in your own AWS account capable of serving the same workload profile OpenZeppelin currently runs (roughly 2M+ transactions per day across roughly 2,500 relayers).
+It uses Terraform to spin up the full infrastructure in your own AWS account.
 
 For the GCP deployment, see the [GCP Operator Deployment Guide](/relayer/guides/stellar-relayer-gcp-operator-guide).
 

--- a/content/relayer/index.mdx
+++ b/content/relayer/index.mdx
@@ -341,7 +341,7 @@ The OpenZeppelin Relayer is designed to function as a backend service and is not
 
 ## Support
 
-For support or inquiries, contact us on [Telegram](https://t.me/openzeppelin_tg/2).
+For support or inquiries, [contact us](https://www.openzeppelin.com/contact).
 
 ## License
 This project is licensed under the GNU Affero General Public License v3.0 - see the LICENSE file for details.

--- a/content/relayer/solana.mdx
+++ b/content/relayer/solana.mdx
@@ -342,7 +342,7 @@ For complete REST API examples with both options, see the [SDK Solana examples](
 
 ## Support
 
-For help, join our [Telegram](https://t.me/openzeppelin_tg/2) or open an issue on GitHub.
+For help, open an issue on [GitHub](https://github.com/OpenZeppelin/openzeppelin-relayer/issues) or [contact us](https://www.openzeppelin.com/contact).
 
 ## License
 

--- a/content/relayer/stellar.mdx
+++ b/content/relayer/stellar.mdx
@@ -555,7 +555,7 @@ For complete examples:
 
 ## Support
 
-For help, join our [Telegram](https://t.me/openzeppelin_tg/2) or open an issue on GitHub.
+For help, open an issue on [GitHub](https://github.com/OpenZeppelin/openzeppelin-relayer/issues) or [contact us](https://www.openzeppelin.com/contact).
 
 ## License
 

--- a/content/relayer/zama-fhevm.mdx
+++ b/content/relayer/zama-fhevm.mdx
@@ -152,4 +152,4 @@ The example contract is deployed from [Zama's fhevm-hardhat-template](https://gi
 
 ## Support
 
-For help, join our [Telegram](https://t.me/openzeppelin_tg/2) or open an issue on GitHub.
+For help, open an issue on [GitHub](https://github.com/OpenZeppelin/openzeppelin-relayer/issues) or [contact us](https://www.openzeppelin.com/contact).

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,5 +1,5 @@
 import { HomeLayout } from "fumadocs-ui/layouts/home";
-import { ArrowDown, SendIcon } from "lucide-react";
+import { ArrowDown } from "lucide-react";
 import { Footer } from "@/components/footer";
 import {
 	BannerCard,
@@ -304,19 +304,12 @@ export default function HomePage() {
 						</p>
 					</div>
 
-					<div className="grid grid-cols-1 md:grid-cols-2 gap-4 sm:gap-5">
+					<div className="grid grid-cols-1 gap-4 sm:gap-5">
 						<CommunityCard
 							href="https://forum.openzeppelin.com/"
 							icon={<AnnotationDotsIcon className="h-6 w-6 sm:h-8 sm:w-8" />}
 							title="Forum"
 							description="Engage in technical deep-dives and architectural discussions. Get detailed answers, share your implementations, and learn from experienced developers building in production."
-						/>
-
-						<CommunityCard
-							href="https://t.me/openzeppelin_tg"
-							icon={<SendIcon className="h-6 w-6 sm:h-8 sm:w-8" />}
-							title="Telegram"
-							description="Get quick help and connect with the community in real-time. Ask questions, share updates, and stay informed about the latest OpenZeppelin developments and announcements."
 						/>
 					</div>
 				</div>


### PR DESCRIPTION
## Summary

Replaces all Telegram contact links (`t.me/openzeppelin_tg`) in the Monitor and Relayer documentation with appropriate alternatives. Also a small intro "copy" change for Stellar AWS operator guide.

## Type of Change
- [x] Documentation update

## What

Across Monitor (latest + 1.0.x–1.3.x) and Relayer (latest + 1.0.x–1.5.x):

- **Generic support sections** (`index.mdx`) → [`contact us`](https://www.openzeppelin.com/contact)
- **Contribution "Getting Reviews" nudge** (`contribution.mdx`) → GitHub Discussions
- **Community support list entry** (`contribution.mdx`) → link to openzeppelin.com/contact
- **evm.mdx support bullet** → link to openzeppelin.com/contact
- **solana/stellar/zama support lines** → GitHub Issues + openzeppelin.com/contact

39 files changed, 44 substitutions. Telegram as a **product feature** (notification channel setup, Defender bot config, architecture diagrams) is untouched.

## Why

The Telegram groups are no longer the right inroad for developer support. `openzeppelin.com/contact` is the current official channel for general inquiries.

## Related Issues

N/A