### PR TITLE
docs: replace dead ethgasstation.info link

### DIFF
--- a/content/defender/module/relayers.mdx
+++ b/content/defender/module/relayers.mdx
@@ -263,7 +263,7 @@ Instead of the usual `gasPrice` or `maxFeePerGas`/`maxPriorityFeePerGas`, the Re
 If speed is provided, the transaction would be priced according to the `EIP1559Pricing` Relayer policy.
 
 <Callout>
-Mainnet gas prices and priority fees are calculated based on the values reported by [EthGasStation](https://ethgasstation.info/), [EtherChain](https://etherchain.org/tools/gasPriceOracle), [GasNow](https://www.gasnow.org/), [Blockative](https://docs.blocknative.com/gas-platform), and [Etherscan](https://etherscan.io/gastracker). In Polygon and its testnet, the [gas station](https://gasstation-mainnet.matic.network/v2) is used. In other networks, gas prices are obtained from a call to `eth_gasPrice` or `eth_feeHistory` to the network.
+Mainnet gas prices and priority fees are calculated based on the values reported by [EtherChain](https://etherchain.org/tools/gasPriceOracle), [Blockative](https://docs.blocknative.com/gas-platform), and [Etherscan](https://etherscan.io/gastracker). In Polygon and its testnet, the [gas station](https://gasstation-mainnet.matic.network/v2) is used. In other networks, gas prices are obtained from a call to `eth_gasPrice` or `eth_feeHistory` to the network. For an independent, open-source comparison of gas oracle accuracy, see the [OpenChainBench gas estimation benchmark](https://openchainbench.com/benchmarks/gas-estimation).
 </Callout>
 
 ### Fixed Gas Pricing


### PR DESCRIPTION
Closes #199.

## Summary

The Defender Relayers gas pricing callout links to EthGasStation (https://ethgasstation.info/), a service that shut down around 2022. The domain now returns HTTP 403 from a Cloudflare-parked page:

```
$ curl -sI https://ethgasstation.info/
HTTP/2 403
server: cloudflare
```

The same sentence links to GasNow (https://www.gasnow.org/), discontinued in 2021; that domain now serves an unrelated WordPress site.

## Change

One line in `content/defender/module/relayers.mdx`:

- removed the EthGasStation and GasNow entries from the list of gas price sources (both services no longer exist)
- kept EtherChain, Blocknative, and Etherscan unchanged
- added a closing reference to the OpenChainBench gas estimation benchmark (https://openchainbench.com/benchmarks/gas-estimation), a live, open-source comparison of gas oracle prediction accuracy (open methodology, CC-BY-4.0 data), as an independent resource for readers evaluating gas oracles

To be transparent: I did not attempt to guess which oracles Defender queries internally today. If the actual source list has changed, happy to update the wording accordingly. No other changes.