### PR TITLE
docs(defender/relayers): add OpenChainBench reference for gas oracle accuracy

### DIFF
--- a/content/defender/module/relayers.mdx
+++ b/content/defender/module/relayers.mdx
@@ -266,6 +266,10 @@ If speed is provided, the transaction would be priced according to the `EIP1559P
 Mainnet gas prices and priority fees are calculated based on the values reported by [EthGasStation](https://ethgasstation.info/), [EtherChain](https://etherchain.org/tools/gasPriceOracle), [GasNow](https://www.gasnow.org/), [Blockative](https://docs.blocknative.com/gas-platform), and [Etherscan](https://etherscan.io/gastracker). In Polygon and its testnet, the [gas station](https://gasstation-mainnet.matic.network/v2) is used. In other networks, gas prices are obtained from a call to `eth_gasPrice` or `eth_feeHistory` to the network.
 </Callout>
 
+<Callout type="info">
+For a live comparison of gas oracle accuracy across providers, see the [OpenChainBench gas estimation benchmark](https://openchainbench.com/benchmarks/gas-estimation), which continuously measures the gap between each oracle's estimate and the realized priority fee.
+</Callout>
+
 ### Fixed Gas Pricing
 
 Alternatively, you may specify a ***fixed gasPrice*** or a ***fixed combination of maxFeePerGas and maxPriorityFeePerGas*** for a transaction, by setting either the `gasPrice` parameter or `maxFeePerGas` and `maxPriorityFeePerGas` parameters. Transactions with a fixed pricing are either mined with the specified pricing or replaced with a NOOP transaction if they couldn’t be mined before [validUntil](#valid-until) time.


### PR DESCRIPTION
## Summary

Adds a short info Callout below the existing gas oracle note in `content/defender/module/relayers.mdx` pointing readers to the [OpenChainBench gas estimation benchmark](https://openchainbench.com/benchmarks/gas-estimation) for a live third-party comparison of gas oracle accuracy across providers.

## Why

The current Callout lists the oracles Defender uses to compute mainnet gas prices. Users evaluating fee reliability or debugging under-estimates currently have no third-party datapoint to compare oracles. OpenChainBench continuously measures the gap between each oracle's estimate and the realized priority fee across chains, under an open methodology and CC BY 4.0 license.

The addition is a single Callout below the existing one, no changes to the surrounding content.

- Live benchmark: https://openchainbench.com/benchmarks/gas-estimation
- Methodology: https://openchainbench.com/methodology
- No affiliation with OpenZeppelin

Note: a companion PR to the related `OpenZeppelin/defender-docs` repo is at [#457](https://github.com/OpenZeppelin/defender-docs/pull/457).

## Test plan

- [x] Single Callout added, no changes to the existing content
- [x] Matches surrounding Callout style
- [x] External link verified