### PR TITLE
add Allowance docs

### DIFF
--- a/content/contracts-sui/1.x/allowance.mdx
+++ b/content/contracts-sui/1.x/allowance.mdx
@@ -1,0 +1,52 @@
+---
+title: Allowance
+---
+
+<Callout type="warn">
+The example code snippets used in this guide are experimental and have not been audited. They simply help exemplify usage of the OpenZeppelin Sui Package.
+</Callout>
+
+The `openzeppelin_allowance` package provides cap-keyed, multi-coin spending allowances for Sui Move protocols. A shared, untyped `Vault` escrows funds for any number of coin types, an `OwnerCap` controls the pool and the budgets, and each `SpenderCap` draws against per-`(cap, coin)` budgets with optional expiry.
+
+Use this package when a protocol or keeper custodies a user's `SpenderCap` and spends on their behalf within the owner's budget, without the user signing each spend; the same primitive also covers subscription pulls and per-partner budgets across coin types.
+
+## Usage
+
+There are two ways to pull the package into your project. Pick whichever fits how much you want to own the code.
+
+### Git dependency
+
+Add the dependency in `Move.toml`, pinned to a git revision (the package is not yet on the Move Registry):
+
+```toml
+[dependencies]
+openzeppelin_allowance = { git = "https://github.com/OpenZeppelin/contracts-sui.git", subdir = "contracts/allowance", rev = "v1.4.0" }
+```
+
+### Copy the source
+
+Alternatively, copy [`spend_vault.move`](https://github.com/OpenZeppelin/contracts-sui/blob/v1.4.0/contracts/allowance/sources/spend_vault.move) directly into your package's `sources/` (renaming the module addresses to your own package). You then fully own the code, free to trim, fork, or extend, at the cost of tracking upstream fixes yourself.
+
+### Import
+
+Once the package is available, import the module:
+
+```move
+use openzeppelin_allowance::spend_vault::{Self, Vault, OwnerCap, SpenderCap};
+```
+
+## Modules
+
+<Cards>
+  <Card href="/contracts-sui/1.x/spend-vault" title="Spend Vault">
+    Cap-keyed, multi-coin allowance ledger over an escrowed shared vault, with per-`(cap, coin)` budgets, expiries, suspension, revocation, and unconditional owner exit.
+  </Card>
+</Cards>
+
+## Next steps
+
+- [Spend Vault](/contracts-sui/1.x/spend-vault) for the module guide and key concepts.
+- [Integrating into a protocol](/contracts-sui/1.x/spend-vault#integrating-into-a-protocol) to custody a user's cap and spend on their behalf under the owner's budget.
+- [Security considerations](/contracts-sui/1.x/spend-vault#security-considerations) for bearer-cap custody, budget-ceiling, and teardown caveats.
+- [Allowance API reference](/contracts-sui/1.x/api/allowance) for function signatures, events, and errors.
+- [Delegated Spending](/contracts-sui/1.x/guides/delegated-spending) for the end-to-end tutorial.

--- a/content/contracts-sui/1.x/api/allowance.mdx
+++ b/content/contracts-sui/1.x/api/allowance.mdx
@@ -1,0 +1,615 @@
+---
+title: Allowance API Reference
+---
+
+This page documents the public API of `openzeppelin_allowance` for OpenZeppelin Contracts for Sui `v1.x`.
+
+### `spend_vault` [toc] [#spend_vault]
+
+<APIGithubLinkHeader
+  moduleName="spend_vault"
+  link="https://github.com/OpenZeppelin/contracts-sui/blob/v1.4.0/contracts/allowance/sources/spend_vault.move"
+/>
+
+```move
+use openzeppelin_allowance::spend_vault;
+```
+
+Cap-keyed, multi-coin allowance primitive. A shared, untyped `Vault` holds funds for any number of coin types and a ledger of per-`(cap, coin)` budgets. The funds are not a struct field: each coin type's pool lives as an object-owned address balance at the vault's id address, deposited permissionlessly and drawn through `spend<T>` (spender) or `withdraw<T>`/`withdraw_all<T>` (owner). The coin dimension of every grant is the `T` supplied at the call site, resolved against a `BudgetKey { cap_id, coin_type }` ledger key.
+
+Because `Vault` has `key` only (no `drop`), the transaction that calls `new` must consume the fresh vault: `share` it as a shared object or `destroy` it, with all same-PTB funding, minting, and granting preceding `share`. A shared vault can still be `destroy`ed later, so the full shape is `new -> destroy` (abandoned at creation) or `new -> share -> ... -> destroy` (shared, then torn down). One `OwnerCap` exists per vault for its whole life (`new` mints it, `destroy` consumes it); transferring it is owner rotation. Budgets are ceilings, not reservations: grants may sum over the pool, and competing spenders are resolved by consensus sequencing.
+
+<Callout type="warn">
+`SpenderCap` is a bearer instrument: `spend<T>` is cap-gated, never sender-gated, so whoever presents the cap draws against every `(cap, coin)` budget it keys; any custody layer must add its own sender gate before borrowing the cap. `destroy` does not drain the pool: it deletes the ledger and both UIDs, and any funds still in the vault's address balances strand permanently. For the full validate-then-sender-gate custody recipe, see the module page's [Integrating into a protocol](/contracts-sui/1.x/spend-vault#integrating-into-a-protocol) section and the [Delegated Spending tutorial](/contracts-sui/1.x/guides/delegated-spending).
+</Callout>
+
+Types
+
+- [`Vault`](#spend_vault-Vault)
+- [`BudgetKey`](#spend_vault-BudgetKey)
+- [`OwnerCap`](#spend_vault-OwnerCap)
+- [`SpenderCap`](#spend_vault-SpenderCap)
+- [`Allowance`](#spend_vault-Allowance)
+
+Functions
+
+- [`new(ctx)`](#spend_vault-new)
+- [`share(v)`](#spend_vault-share)
+- [`destroy(v, cap, ctx)`](#spend_vault-destroy)
+- [`deposit(v, c, ctx)`](#spend_vault-deposit)
+- [`deposit_balance(v, b, ctx)`](#spend_vault-deposit_balance)
+- [`mint_cap(v, cap, ctx)`](#spend_vault-mint_cap)
+- [`set_allowance(v, cap, cap_id, new_amount, new_expires_at_ms, expected, clock, ctx)`](#spend_vault-set_allowance)
+- [`spend(v, cap, amount, clock, ctx)`](#spend_vault-spend)
+- [`revoke(v, cap, cap_id, ctx)`](#spend_vault-revoke)
+- [`revoke_all(v, cap, cap_id, ctx)`](#spend_vault-revoke_all)
+- [`renounce(v, cap, ctx)`](#spend_vault-renounce)
+- [`delete_orphaned_cap(cap)`](#spend_vault-delete_orphaned_cap)
+- [`squash(v, c, ctx)`](#spend_vault-squash)
+- [`withdraw(v, cap, amount, ctx)`](#spend_vault-withdraw)
+- [`withdraw_all(v, cap, root, ctx)`](#spend_vault-withdraw_all)
+- [`allowance(v, cap_id)`](#spend_vault-allowance)
+- [`spendable_now(v, root, cap_id, clock)`](#spend_vault-spendable_now)
+- [`expiry(v, cap_id)`](#spend_vault-expiry)
+- [`contains(v, cap_id)`](#spend_vault-contains)
+- [`balance_value(v, root)`](#spend_vault-balance_value)
+- [`granted_coin_types(v)`](#spend_vault-granted_coin_types)
+- [`owner_cap_vault_id(cap)`](#spend_vault-owner_cap_vault_id)
+- [`spender_cap_vault_id(cap)`](#spend_vault-spender_cap_vault_id)
+
+Events
+
+- [`VaultCreated`](#spend_vault-VaultCreated)
+- [`Deposited`](#spend_vault-Deposited)
+- [`Squashed`](#spend_vault-Squashed)
+- [`SpenderCapMinted`](#spend_vault-SpenderCapMinted)
+- [`AllowanceSet`](#spend_vault-AllowanceSet)
+- [`Spent`](#spend_vault-Spent)
+- [`Revoked`](#spend_vault-Revoked)
+- [`Renounced`](#spend_vault-Renounced)
+- [`Withdrawn`](#spend_vault-Withdrawn)
+- [`VaultDestroyed`](#spend_vault-VaultDestroyed)
+- [`CapDeleted`](#spend_vault-CapDeleted)
+
+Errors
+
+- [`EWrongOwnerCap`](#spend_vault-EWrongOwnerCap)
+- [`EWrongVault`](#spend_vault-EWrongVault)
+- [`ENoAllowance`](#spend_vault-ENoAllowance)
+- [`EAllowanceExpired`](#spend_vault-EAllowanceExpired)
+- [`EAllowanceExceeded`](#spend_vault-EAllowanceExceeded)
+- [`EZeroAmount`](#spend_vault-EZeroAmount)
+- [`EExpiryInPast`](#spend_vault-EExpiryInPast)
+- [`EUnexpectedAllowance`](#spend_vault-EUnexpectedAllowance)
+
+#### Types [!toc] [#spend_vault-Types]
+
+<APIItem
+  functionSignature="struct Vault has key { id: UID, allowances: LinkedTable<BudgetKey, Allowance>, granted_coin_types: VecSet<TypeName> }"
+  id="spend_vault-Vault"
+  kind="struct"
+>
+Shared, untyped escrow plus per-`(cap, coin)` allowance ledger. One vault holds any number of coin types. The creating transaction must consume the fresh vault with `share` or `destroy`, and a shared vault can still be `destroy`ed later at teardown; the `key`-only ability set (no `store`, no `drop`) protects `id` (the spend authority over the address balances) and forces teardown through `destroy`.
+
+The pool is not a struct field: per-coin funds live as object-owned address balances at the vault's id address, readable via [`balance_value`](#spend_vault-balance_value). `allowances` is a `LinkedTable` so drains recover per-entry storage rebates.
+
+`granted_coin_types` is the owner-writable enumeration handle iterated by `revoke_all` and `renounce`. It is written only by a `set_allowance` call that creates an entry (permissionless deposits cannot grow it) and it grows only: `revoke<T>` never prunes `T`. It is not the drain-before-destroy list; enumerate pool coin types off-chain with `suix_getAllBalances`.
+</APIItem>
+
+<APIItem
+  functionSignature="struct BudgetKey has copy, drop, store { cap_id: ID, coin_type: TypeName }"
+  id="spend_vault-BudgetKey"
+  kind="struct"
+>
+Composite ledger key: one entry per `(cap, coin type)`. `coin_type` is always `type_name::with_defining_ids<T>()`.
+</APIItem>
+
+<APIItem
+  functionSignature="struct OwnerCap has key, store { id: UID, vault_id: ID }"
+  id="spend_vault-OwnerCap"
+  kind="struct"
+>
+Owner authority for exactly one vault. Exactly one `OwnerCap` exists per vault for its whole life: `new` mints it, `destroy` consumes it. `vault_id` is set at `new` and never rewritten; transferring the cap is owner rotation. It gates `mint_cap`, `set_allowance`, `revoke`, `revoke_all`, `withdraw`/`withdraw_all` over every coin, and `destroy`.
+</APIItem>
+
+<APIItem
+  functionSignature="struct SpenderCap has key, store { id: UID, vault_id: ID }"
+  id="spend_vault-SpenderCap"
+  kind="struct"
+>
+Spend authority. A bearer instrument: whoever presents `&SpenderCap` to `spend<T>` holds the full authority of every `(cap, coin)` budget it keys, so a leaked cap exposes the sum across coins. Untyped: no phantom type, no coin field; the coin dimension is the `T` at the `spend<T>` call site.
+
+`vault_id` is set at `mint_cap` and never rewritten; the binding survives every transfer, wrap, or table embedding. Protocols accepting a user's cap must validate it via [`spender_cap_vault_id`](#spend_vault-spender_cap_vault_id) before taking custody.
+</APIItem>
+
+<APIItem
+  functionSignature="struct Allowance has drop, store { remaining: u64, expires_at_ms: u64 }"
+  id="spend_vault-Allowance"
+  kind="struct"
+>
+Private ledger entry for one `(cap, coin)` grant, and the single source of truth for its state (the cap carries no budget).
+
+`remaining`: `u64::MAX` is the unlimited sentinel (never decremented); `0` is a live-but-suspended entry; anything else is the raw drawable budget. `expires_at_ms`: `u64::MAX` is the no-expiry sentinel; any finite value must be strictly in the future at `set_allowance` time. Both sentinels are tested by equality only: a deliberate finite grant of exactly `u64::MAX` is unrepresentable, and off-chain volume math must exclude it.
+</APIItem>
+
+#### Functions [!toc] [#spend_vault-Functions]
+
+<APIItem
+  functionSignature="new(ctx: &mut TxContext) -> (Vault, OwnerCap)"
+  id="spend_vault-new"
+  kind="public"
+>
+Creates an untyped multi-coin `Vault` and its sole vault-bound `OwnerCap`, both returned by value so the enclosing PTB decides every destination. `Vault` has no `drop`: the transaction fails unless it is consumed by `share` or `destroy` in the same transaction. One PTB can compose full setup: `new` → `deposit<T>` → `mint_cap` → `set_allowance<T>` → `share` → transfer the owner cap.
+
+Emits `VaultCreated` with the vault id, owner cap id, and `ctx.sender()` as `creator`.
+</APIItem>
+
+<APIItem
+  functionSignature="share(v: Vault)"
+  id="spend_vault-share"
+  kind="public"
+>
+Shares the vault (`transfer::share_object`). Must run in the same transaction as `new`, after every same-PTB funding, minting, and granting step; the vault is only addressable as a shared input in later transactions.
+</APIItem>
+
+<APIItem
+  functionSignature="destroy(v: Vault, cap: OwnerCap, ctx: &mut TxContext)"
+  id="spend_vault-destroy"
+  kind="public"
+>
+Terminal owner exit. Drains every ledger entry (recovering each storage rebate), drops `granted_coin_types`, and deletes both the vault and owner cap UIDs. Unconditional on ledger state: no live, suspended, or unlimited grant can block it, and there is no on-chain guard against destroying a still-funded vault.
+
+Aborts with `EWrongOwnerCap` if `cap.vault_id` does not match the vault.
+
+Emits `VaultDestroyed`.
+
+<Callout type="warn">
+`destroy` does not drain the pool. Funds still sitting in the vault's address balances strand permanently once the UID is deleted. Drain first, in a prior transaction: enumerate coin types off-chain with `suix_getAllBalances`, `squash<T>` any loose coins, `withdraw_all<T>` each type, wait one checkpoint and re-check, then destroy. See the [Spend Vault guide](/contracts-sui/1.x/spend-vault) for the full drain ritual.
+</Callout>
+</APIItem>
+
+<APIItem
+  functionSignature="deposit<T>(v: &Vault, c: Coin<T>, ctx: &mut TxContext)"
+  id="spend_vault-deposit"
+  kind="public"
+>
+Deposits a `Coin<T>` into the vault's `T` pool. Thin wrapper over `deposit_balance` (`c.into_balance()`). Permissionless, and confers no rights: no ledger entry, no claim, no refund path. Note that permissionless deposits can re-arm live allowances after a `withdraw_all`-as-freeze; the durable kill is `revoke_all` or `destroy`.
+
+Aborts with `EZeroAmount` if `c.value() == 0`.
+
+Emits `Deposited`.
+</APIItem>
+
+<APIItem
+  functionSignature="deposit_balance<T>(v: &Vault, b: Balance<T>, ctx: &mut TxContext)"
+  id="spend_vault-deposit_balance"
+  kind="public"
+>
+`Balance<T>`-native ingress, symmetric to the `Balance<T>` egress of `spend`/`withdraw`/`withdraw_all`; sends the balance to the vault's id address. Permissionless and rights-free, like `deposit`.
+
+Aborts with `EZeroAmount` if `b.value() == 0`.
+
+Emits `Deposited` with `ctx.sender()` as `depositor`.
+
+<Callout>
+Anyone can also fund the vault without this module via `sui::balance::send_funds(bal, object::id_address(v))`. Those funds are identically spendable and withdrawable but emit no `Deposited` event; event-only indexers will miss them.
+</Callout>
+</APIItem>
+
+<APIItem
+  functionSignature="mint_cap(v: &Vault, cap: &OwnerCap, ctx: &mut TxContext) -> SpenderCap"
+  id="spend_vault-mint_cap"
+  kind="public"
+>
+Mints a bare, untyped `SpenderCap` bound to this vault, returned by value: no budget, no ledger entry, no coin type. Grant budgets afterwards with `set_allowance<T>` keyed by the cap's object id; the id is stable for the cap's whole life, so protocols can embed the cap and owners can re-budget it without re-registration.
+
+Aborts with `EWrongOwnerCap` if `cap.vault_id` does not match the vault.
+
+Emits `SpenderCapMinted`.
+</APIItem>
+
+<APIItem
+  functionSignature="set_allowance<T>(v: &mut Vault, cap: &OwnerCap, cap_id: ID, new_amount: u64, new_expires_at_ms: u64, expected: Option<u64>, clock: &Clock, ctx: &mut TxContext)"
+  id="spend_vault-set_allowance"
+  kind="public"
+>
+Upserts the `(cap_id, T)` budget: creates the entry if absent (recording `T` in `granted_coin_types`), otherwise overwrites `remaining` and `expires_at_ms` in place; the cap object, its id, and any embeddings are untouched. Re-setting overwrites, never adds; two summing budgets require two caps.
+
+`new_amount == 0` suspends the entry without removing it (never aborts `EZeroAmount`); `u64::MAX` is the unlimited sentinel. `new_expires_at_ms` must be `u64::MAX` (no expiry) or strictly in the future; setting a fresh future expiry on an expired entry revives it in place.
+
+`expected` is an optional compare-and-set guard on the raw `remaining`: `Some(e)` proceeds only if the entry exists and `remaining == e` (`0` and `u64::MAX` are legal match targets); `Some` on an absent entry aborts; `None` is unconditional. Derive `e` from an earlier read (off-chain or a previous transaction) so a spend sequenced after that read aborts this write instead of being clobbered. A read in the same transaction cannot serve as a guard: the shared vault is locked for the whole transaction, so a same-transaction `allowance<T>` value trivially matches and the write always proceeds. The CAS guards `remaining` only; the upsert always overwrites `expires_at_ms` too, so a budget-only update must re-read the current expiry via `expiry<T>` and pass it back, or it silently overwrites it.
+
+Checks run in deterministic order: owner gate → expiry validity → CAS.
+
+Aborts with `EWrongOwnerCap` if `cap.vault_id` does not match the vault.
+
+Aborts with `EExpiryInPast` if `new_expires_at_ms` is finite and `<= clock.timestamp_ms()`.
+
+Aborts with `EUnexpectedAllowance` if `expected` is `Some(e)` and the entry is absent or its raw `remaining != e`.
+
+Emits `AllowanceSet` with `cas_was_provided` and `was_created` flags.
+
+<Callout type="warn">
+`cap_id` is an unvalidated bare `ID`: it is never checked against a live `SpenderCap`. A mistyped id silently creates a phantom budget (`AllowanceSet { was_created: true }`, success-shaped) and permanently adds `T` to `granted_coin_types` if `T` was not already granted. On a known update, confirm `was_created == false` in the event, or preflight with `contains<T>`.
+</Callout>
+</APIItem>
+
+<APIItem
+  functionSignature="spend<T>(v: &mut Vault, cap: &SpenderCap, amount: u64, clock: &Clock, ctx: &mut TxContext) -> Balance<T>"
+  id="spend_vault-spend"
+  kind="public"
+>
+Draws exactly `amount` of `T` against the presented `&SpenderCap`. Cap-gated, never sender-gated: any transaction context spends identically, and `ctx.sender()` feeds only the `Spent.caller` attribution field. Exact-amount-or-abort: on any abort the pool and ledger are bit-identical to the pre-call state. The `u64::MAX` unlimited sentinel is never decremented. Spending a budget down to `0` leaves the entry in place (suspended); removal happens only via `revoke`, `revoke_all`, `renounce`, or `destroy`.
+
+The commit order is: decrement the budget, then withdraw from the vault's address balance and redeem. The pool is deliberately not pre-checked: a pool-short redeem fails at execution (see the callout below) and Move's atomic revert rolls the decrement back.
+
+The module abort order below is deterministic and is an integrator ABI; match on it: `EWrongVault` → `ENoAllowance` → `EAllowanceExpired` → `EZeroAmount` → `EAllowanceExceeded`.
+
+The returned `Balance<T>` has no `drop`; consume it in the same PTB:
+
+```move
+let bal = vault.spend<SUI>(&cap, amount, clock, ctx);
+transfer::public_transfer(bal.into_coin(ctx), ctx.sender());
+```
+
+Aborts with `EWrongVault` if `cap.vault_id` does not match the vault.
+
+Aborts with `ENoAllowance` if no `(cap, T)` ledger entry exists.
+
+Aborts with `EAllowanceExpired` if the entry has a finite expiry and `clock.timestamp_ms() >= expires_at_ms` (closed boundary: a spend in the exact expiry millisecond fails).
+
+Aborts with `EZeroAmount` if `amount == 0`.
+
+Aborts with `EAllowanceExceeded` if `remaining` is finite and `amount > remaining` (including suspended-at-zero entries, for any positive amount).
+
+Emits `Spent` strictly after the redeem succeeds, with `remaining` as the raw post-call value (still `u64::MAX` for unlimited grants).
+
+<Callout>
+Two framework failure modes follow the module aborts: `EObjectFundsWithdrawNotEnabled` (Move abort code 3 in `sui::funds_accumulator`) if the `enable_object_funds_withdraw` protocol feature is off, and the `InsufficientFundsForWithdraw` execution status when the vault's live `T` balance is below `amount` at redeem time. The latter is not a matchable Move abort code; detect it via dry run / effects. The budget decrement is rolled back atomically, and `Spent` is emitted only after the redeem succeeds.
+</Callout>
+</APIItem>
+
+<APIItem
+  functionSignature="revoke<T>(v: &mut Vault, cap: &OwnerCap, cap_id: ID, ctx: &mut TxContext) -> bool"
+  id="spend_vault-revoke"
+  kind="public"
+>
+Owner kill-switch for one coin: removes the `(cap_id, T)` ledger entry. Idempotent and ledger-state-independent: a present entry is removed (recovering its storage rebate), an absent one is a no-op. Also time-blind: it removes suspended, expired, and unlimited entries alike. Returns `was_present`; `false` is the typo'd-`cap_id` / wrong-coin signal, never an abort. Not retroactive: a spend sequenced first still stands. The cap object survives as inert non-authority for this coin, and `granted_coin_types` is untouched (grows-only).
+
+Aborts with `EWrongOwnerCap` if `cap.vault_id` does not match the vault.
+
+Emits `Revoked` on every non-aborting call, no-op included, with the `was_present` flag.
+</APIItem>
+
+<APIItem
+  functionSignature="revoke_all(v: &mut Vault, cap: &OwnerCap, cap_id: ID, ctx: &mut TxContext)"
+  id="spend_vault-revoke_all"
+  kind="public"
+>
+Whole-cap kill: iterates a snapshot of `granted_coin_types` and removes every existing `(cap_id, T)` entry. Cost is O(k) in the distinct coin types ever granted on the vault: owner-bounded and un-griefable, since permissionless deposits and squashes cannot grow the set. Never touches another cap's entries.
+
+Emergency-stop idiom: run `revoke_all` first, in its own transaction, then `withdraw_all<T>` per coin in a later transaction; never bundled, since a pool-short `withdraw_all` would revert the `revoke_all` with it.
+
+Aborts with `EWrongOwnerCap` if `cap.vault_id` does not match the vault.
+
+Emits one `Revoked { was_present: true }` per removed coin; nothing on a whole-cap miss.
+
+<Callout type="warn">
+`cap_id` is unvalidated: a wrong id is a silent whole-cap no-op that emits no event and leaves the intended cap live. Confirm the kill via the emitted `Revoked` events or a `contains<T>` recheck.
+</Callout>
+</APIItem>
+
+<APIItem
+  functionSignature="renounce(v: &mut Vault, cap: SpenderCap, ctx: &mut TxContext)"
+  id="spend_vault-renounce"
+  kind="public"
+>
+Spender self-revoke against a live vault: consumes the cap by value, removes every `(cap_id, T)` entry (iterating a snapshot of `granted_coin_types`; coins the cap never held are harmless probes), and deletes the cap UID. Total on ledger state; storage rebates route to this transaction's gas payer. Uncallable after vault destruction (it needs `&mut Vault`); use `delete_orphaned_cap` instead.
+
+Aborts with `EWrongVault` if `cap.vault_id` does not match the vault.
+
+Emits one coin-agnostic `Renounced` event (not per-coin `Revoked` events).
+</APIItem>
+
+<APIItem
+  functionSignature="delete_orphaned_cap(cap: SpenderCap)"
+  id="spend_vault-delete_orphaned_cap"
+  kind="public"
+>
+Disposal path for a `SpenderCap` whose vault was already destroyed. Total: never aborts, touches no vault state, deletes exactly the cap UID. The lone `ctx`-free disposal path.
+
+Emits `CapDeleted` (no actor field; there is no `ctx` to read).
+
+<Callout type="warn">
+On a live vault, prefer `renounce`. Deleting a live cap strands all its `(cap, T)` ledger entries as inert garbage: unspendable and not live authority, but still visible via `contains<T>` and forfeiting their storage rebates. The owner's cleanup is `revoke_all` with the `cap_id` from the `CapDeleted` event.
+</Callout>
+</APIItem>
+
+<APIItem
+  functionSignature="squash<T>(v: &mut Vault, c: Receiving<Coin<T>>, ctx: &mut TxContext)"
+  id="spend_vault-squash"
+  kind="public"
+>
+Recovers a stray `Coin<T>` that was `public_transfer`'d to the vault address (a loose owned object, not part of the spendable address balance) by receiving it against the vault's UID and sending its balance into the pool. Permissionless and strictly funds-in: worst case is a donation. Writes no type set. This is the vault's only object-receive path, and it is `Coin`-typed: non-`Coin` objects sent to the vault address cannot be recovered.
+
+Aborts with no module error; the framework `transfer::public_receive` can abort on an invalid or stale `Receiving` ticket. There is no zero-amount guard.
+
+Emits `Squashed` (possibly with `amount: 0`).
+</APIItem>
+
+<APIItem
+  functionSignature="withdraw<T>(v: &mut Vault, cap: &OwnerCap, amount: u64, ctx: &mut TxContext) -> Balance<T>"
+  id="spend_vault-withdraw"
+  kind="public"
+>
+Withdraws exactly `amount` of `T` from the pool as a `Balance<T>`. Consults only the `OwnerCap` binding and the pool, never the ledger: no spender state can block it, and it may leave live allowances unbacked (intended: budgets are ceilings, not reservations). The returned `Balance<T>` has no `drop` and must be consumed in the same PTB.
+
+Aborts with `EWrongOwnerCap` if `cap.vault_id` does not match the vault.
+
+Aborts with `EZeroAmount` if `amount == 0`.
+
+Emits `Withdrawn`.
+
+<Callout>
+The same two framework failure modes as `spend` apply: `EObjectFundsWithdrawNotEnabled` if the `enable_object_funds_withdraw` protocol feature is off, and the `InsufficientFundsForWithdraw` execution status (not a matchable Move abort) if the live `T` balance is below `amount` at redeem time.
+</Callout>
+</APIItem>
+
+<APIItem
+  functionSignature="withdraw_all<T>(v: &mut Vault, cap: &OwnerCap, root: &AccumulatorRoot, ctx: &mut TxContext) -> Balance<T>"
+  id="spend_vault-withdraw_all"
+  kind="public"
+>
+Drains the settled `T` pool: reads the start-of-checkpoint balance snapshot from the accumulator root (`0xacc`) and withdraws exactly that. Deliberately takes no caller-supplied amount (a fixed amount would be a stale-amount denial of service). An empty settled pool returns `balance::zero<T>()` without touching the accumulator primitive (the feature-flag abort is unreachable on that path) but still emits `Withdrawn { amount: 0 }`. Never aborts on spender or ledger state. The returned, possibly-zero `Balance<T>` has no `drop`; consume it (`destroy_zero`, join, `into_coin`) in the same PTB.
+
+Settled-vs-live skew: a prior same-checkpoint `spend` or `withdraw` (including an earlier command in the same PTB) lowers the live pool below the snapshot, making the drain over-ask and fail with the `InsufficientFundsForWithdraw` execution status (retry-safe next checkpoint); a same-checkpoint deposit is under-drained (missed). A `withdraw_all`-as-freeze is reversible (deposits are permissionless), so the durable kill is `revoke_all` or `destroy`.
+
+Aborts with `EWrongOwnerCap` if `cap.vault_id` does not match the vault.
+
+Emits `Withdrawn` (amount possibly `0`).
+
+<Callout>
+On a non-empty settled pool the framework failure modes apply: `EObjectFundsWithdrawNotEnabled` if the `enable_object_funds_withdraw` protocol feature is off, and the `InsufficientFundsForWithdraw` execution status on the settled-vs-live skew described above.
+</Callout>
+</APIItem>
+
+<APIItem
+  functionSignature="allowance<T>(v: &Vault, cap_id: ID) -> u64"
+  id="spend_vault-allowance"
+  kind="public"
+>
+Returns the raw `remaining` of the `(cap_id, T)` entry. Total (never aborts) and advisory (stale the moment a later transaction mutates state). Returns `0` if the entry is absent (ambiguous with a suspended entry); disambiguate with `contains<T>`. `u64::MAX` is the unlimited sentinel, not a volume.
+</APIItem>
+
+<APIItem
+  functionSignature="spendable_now<T>(v: &Vault, root: &AccumulatorRoot, cap_id: ID, clock: &Clock) -> u64"
+  id="spend_vault-spendable_now"
+  kind="public"
+>
+Returns what a `spend<T>` could draw right now: `0` if the entry is absent, expired, or suspended, otherwise `min(remaining, settled pool)` (unlimited reduces to the settled pool). Uses the same closed expiry boundary as `spend` (`now >= expires_at_ms` is expired). Total; advisory upper bound only: settled-vs-live skew can still make `spend(spendable_now(...))` fail, and a `0` result fed to `spend` aborts `EZeroAmount`, so guard with `> 0`. Returns a non-zero quote even when the `enable_object_funds_withdraw` feature is off.
+</APIItem>
+
+<APIItem
+  functionSignature="expiry<T>(v: &Vault, cap_id: ID) -> u64"
+  id="spend_vault-expiry"
+  kind="public"
+>
+Returns the raw `expires_at_ms` of the `(cap_id, T)` entry; `0` if absent. A present entry's value is always non-zero: a timestamp (possibly past; expired entries are not pruned) or the `u64::MAX` no-expiry sentinel. Total; never aborts.
+</APIItem>
+
+<APIItem
+  functionSignature="contains<T>(v: &Vault, cap_id: ID) -> bool"
+  id="spend_vault-contains"
+  kind="public"
+>
+Returns whether a `(cap_id, T)` ledger entry exists. The absent-vs-suspended disambiguator: `allowance<T> == 0 && contains<T>` means suspended. Total; never aborts.
+</APIItem>
+
+<APIItem
+  functionSignature="balance_value<T>(v: &Vault, root: &AccumulatorRoot) -> u64"
+  id="spend_vault-balance_value"
+  kind="public"
+>
+Returns the settled `T` pool at the vault's address (start-of-checkpoint snapshot). Total and advisory; independent of the `enable_object_funds_withdraw` feature flag.
+</APIItem>
+
+<APIItem
+  functionSignature="granted_coin_types(v: &Vault) -> vector<TypeName>"
+  id="spend_vault-granted_coin_types"
+  kind="public"
+>
+Returns exactly the coin-type set that `revoke_all` and `renounce` iterate. Grows-only, never pruned, and not the drain-before-destroy list (use `suix_getAllBalances` off-chain for that). Total; never aborts.
+</APIItem>
+
+<APIItem
+  functionSignature="owner_cap_vault_id(cap: &OwnerCap) -> ID"
+  id="spend_vault-owner_cap_vault_id"
+  kind="public"
+>
+Returns the vault id the `OwnerCap` is bound to. Total; never aborts.
+</APIItem>
+
+<APIItem
+  functionSignature="spender_cap_vault_id(cap: &SpenderCap) -> ID"
+  id="spend_vault-spender_cap_vault_id"
+  kind="public"
+>
+Returns the vault id the `SpenderCap` is bound to. Protocols accepting a user's cap must check this against the expected vault before taking custody. Total; never aborts. For the assembled validate-then-sender-gate sequence this check belongs to, see the module page's [Integrating into a protocol](/contracts-sui/1.x/spend-vault#integrating-into-a-protocol) section.
+</APIItem>
+
+#### Events [!toc] [#spend_vault-Events]
+
+<APIItem
+  functionSignature="VaultCreated(vault_id: ID, owner_cap_id: ID, creator: address)"
+  id="spend_vault-VaultCreated"
+  kind="event"
+>
+Emitted by `new`.
+
+- `vault_id`: the new vault.
+- `owner_cap_id`: the sole owner cap, the vault-to-cap discovery anchor.
+- `creator`: `ctx.sender()`; may differ from the eventual owner.
+</APIItem>
+
+<APIItem
+  functionSignature="Deposited(vault_id: ID, coin_type: TypeName, amount: u64, depositor: address)"
+  id="spend_vault-Deposited"
+  kind="event"
+>
+Emitted by `deposit` and `deposit_balance`.
+
+- `vault_id`: the funded vault.
+- `coin_type`: `type_name::with_defining_ids<T>()`.
+- `amount`: the deposited value (never `0`; zero deposits abort).
+- `depositor`: `ctx.sender()`; attribution only, depositing confers no rights.
+
+Raw `send_funds` top-ups to the vault address are identically spendable but emit no `Deposited`; event-only indexers miss them.
+</APIItem>
+
+<APIItem
+  functionSignature="Squashed(vault_id: ID, coin_type: TypeName, amount: u64, by: address)"
+  id="spend_vault-Squashed"
+  kind="event"
+>
+Emitted by `squash`. Distinct from `Deposited` so indexers can separate recovered strays from intentional funding.
+
+- `vault_id`: the vault that received the recovered funds.
+- `coin_type`: the recovered coin's type.
+- `amount`: the recovered value; may be `0` (`squash` has no zero-amount guard).
+- `by`: `ctx.sender()`.
+</APIItem>
+
+<APIItem
+  functionSignature="SpenderCapMinted(vault_id: ID, cap_id: ID, by: address)"
+  id="spend_vault-SpenderCapMinted"
+  kind="event"
+>
+Emitted by `mint_cap`. Bare: no recipient, amount, or expiry; budget data arrives on the subsequent `AllowanceSet { was_created: true }`.
+
+- `vault_id`: the vault the cap is bound to.
+- `cap_id`: the new cap's object id.
+- `by`: `ctx.sender()`.
+</APIItem>
+
+<APIItem
+  functionSignature="AllowanceSet(vault_id: ID, cap_id: ID, coin_type: TypeName, new_amount: u64, new_expires_at_ms: u64, cas_was_provided: bool, was_created: bool, by: address)"
+  id="spend_vault-AllowanceSet"
+  kind="event"
+>
+Emitted by `set_allowance`.
+
+- `vault_id`, `cap_id`, `coin_type`: the `(cap, coin)` entry written.
+- `new_amount`: the written budget; `0` signals suspension, `u64::MAX` unlimited.
+- `new_expires_at_ms`: the written expiry; `u64::MAX` means no expiry.
+- `cas_was_provided`: whether the CAS guard was engaged.
+- `was_created`: `true` on the create branch, `false` on overwrite (the defense against silent phantom-budget creation from a typo'd `cap_id`).
+- `by`: `ctx.sender()`.
+</APIItem>
+
+<APIItem
+  functionSignature="Spent(vault_id: ID, cap_id: ID, coin_type: TypeName, amount: u64, remaining: u64, caller: address)"
+  id="spend_vault-Spent"
+  kind="event"
+>
+Emitted on every successful `spend`, strictly after the funds redeem succeeds; a decremented-then-reverted pool-short spend emits nothing.
+
+- `vault_id`, `cap_id`, `coin_type`: the drawn `(cap, coin)` entry.
+- `amount`: the exact amount drawn.
+- `remaining`: the raw post-call budget; stays `u64::MAX` for unlimited grants.
+- `caller`: `ctx.sender()`; attribution only, never a gate. In a custody flow this is the operator who drove the spend, not the budget's beneficiary.
+</APIItem>
+
+<APIItem
+  functionSignature="Revoked(vault_id: ID, cap_id: ID, coin_type: TypeName, was_present: bool, by: address)"
+  id="spend_vault-Revoked"
+  kind="event"
+>
+Emitted by `revoke` on every non-aborting call (no-op included, with `was_present: false` as the typo'd-`cap_id` signal) and by `revoke_all` once per removed coin (a whole-cap miss emits nothing).
+
+- `vault_id`, `cap_id`, `coin_type`: the targeted `(cap, coin)` entry.
+- `was_present`: whether an entry was actually removed. Indexers must gate state changes on `was_present == true`.
+- `by`: `ctx.sender()`.
+</APIItem>
+
+<APIItem
+  functionSignature="Renounced(vault_id: ID, cap_id: ID, by: address)"
+  id="spend_vault-Renounced"
+  kind="event"
+>
+Emitted by `renounce`. Coin-agnostic and terminal: it closes every `(cap, *)` entry but carries no coin list; indexers rely on previously indexed `AllowanceSet` state.
+
+- `vault_id`: the vault.
+- `cap_id`: the consumed cap.
+- `by`: `ctx.sender()`.
+</APIItem>
+
+<APIItem
+  functionSignature="Withdrawn(vault_id: ID, coin_type: TypeName, amount: u64, by: address)"
+  id="spend_vault-Withdrawn"
+  kind="event"
+>
+Emitted by both `withdraw` and `withdraw_all`, with no discriminant between the two sources.
+
+- `vault_id`: the drained vault.
+- `coin_type`: the withdrawn coin's type.
+- `amount`: the withdrawn value; may be `0` from `withdraw_all` on an empty settled pool.
+- `by`: `ctx.sender()`.
+</APIItem>
+
+<APIItem
+  functionSignature="VaultDestroyed(vault_id: ID, by: address)"
+  id="spend_vault-VaultDestroyed"
+  kind="event"
+>
+Emitted by `destroy`. Coin-agnostic terminal event for every `(vault, *)` entry; carries no refunded amount; the owner drains per coin beforehand.
+
+- `vault_id`: the destroyed vault.
+- `by`: `ctx.sender()`.
+</APIItem>
+
+<APIItem
+  functionSignature="CapDeleted(vault_id: ID, cap_id: ID)"
+  id="spend_vault-CapDeleted"
+  kind="event"
+>
+Emitted by `delete_orphaned_cap`. Intentionally has no actor field: it is the lone `ctx`-free disposal path, so there is no `ctx.sender()` to record.
+
+- `vault_id`: the (typically already destroyed) vault the cap was bound to.
+- `cap_id`: the deleted cap, the id an owner needs for `revoke_all` cleanup if a live cap was deleted.
+</APIItem>
+
+#### Errors [!toc] [#spend_vault-Errors]
+
+Pool shortfall has no module error by design: on the fund-egress paths (`spend`, `withdraw`, non-empty `withdraw_all`) a short pool surfaces as the framework `InsufficientFundsForWithdraw` execution status (not a matchable Move abort) after the `EObjectFundsWithdrawNotEnabled` feature-flag check. See the callouts under [`spend`](#spend_vault-spend).
+
+<APIItem functionSignature="EWrongOwnerCap (code 0)" id="spend_vault-EWrongOwnerCap" kind="error">
+Raised as the first check of every owner-gated function (`destroy`, `mint_cap`, `set_allowance`, `revoke`, `revoke_all`, `withdraw`, `withdraw_all`) when the `OwnerCap`'s `vault_id` does not match the vault.
+</APIItem>
+
+<APIItem functionSignature="EWrongVault (code 1)" id="spend_vault-EWrongVault" kind="error">
+Raised as the first check in `spend` and `renounce` when the `SpenderCap`'s `vault_id` does not match the vault.
+</APIItem>
+
+<APIItem functionSignature="ENoAllowance (code 2)" id="spend_vault-ENoAllowance" kind="error">
+Raised only by `spend` when no `(cap, T)` ledger entry exists (never granted, revoked, renounced, or a different coin type). `set_allowance` is an upsert and never raises it. Distinct from suspended-at-zero, which raises `EAllowanceExceeded`; disambiguate with `contains<T>`.
+</APIItem>
+
+<APIItem functionSignature="EAllowanceExpired (code 3)" id="spend_vault-EAllowanceExpired" kind="error">
+Raised by `spend` when the entry has a finite expiry and `clock.timestamp_ms() >= expires_at_ms` (a closed boundary: a spend in the exact expiry millisecond fails). The `u64::MAX` no-expiry sentinel short-circuits by equality before any clock comparison.
+</APIItem>
+
+<APIItem functionSignature="EAllowanceExceeded (code 4)" id="spend_vault-EAllowanceExceeded" kind="error">
+Raised by `spend` when `remaining` is finite and `amount > remaining`, including suspended entries (`remaining == 0`) for any positive amount. Compare-before-decrement; there is no underflow path.
+</APIItem>
+
+<APIItem functionSignature="EZeroAmount (code 5)" id="spend_vault-EZeroAmount" kind="error">
+Raised by `deposit`/`deposit_balance` on a zero-value deposit, by `spend` when `amount == 0` (checked after expiry, before exceeded), and by `withdraw` when `amount == 0`. Deliberately not raised by `set_allowance` (`0` is the suspension idiom), `withdraw_all` (returns a zero `Balance<T>`), or `squash` (no zero guard).
+</APIItem>
+
+<APIItem functionSignature="EExpiryInPast (code 6)" id="spend_vault-EExpiryInPast" kind="error">
+Raised by `set_allowance` when `new_expires_at_ms` is finite and `<= clock.timestamp_ms()`; a finite expiry must be strictly in the future. Corollary: a fresh future expiry revives an expired entry in place.
+</APIItem>
+
+<APIItem functionSignature="EUnexpectedAllowance (code 7)" id="spend_vault-EUnexpectedAllowance" kind="error">
+Raised by `set_allowance` when `expected` is `Some(e)` and the entry is absent or its raw `remaining != e`. `Some(0)` on an absent entry aborts; absent is not zero.
+</APIItem>

--- a/content/contracts-sui/1.x/guides/delegated-spending.mdx
+++ b/content/contracts-sui/1.x/guides/delegated-spending.mdx
@@ -1,0 +1,518 @@
+---
+title: Delegated Spending
+---
+
+<Callout type="warn">
+The example code snippets used in this guide are experimental and have not been audited. They simply help exemplify usage of the OpenZeppelin Sui Package.
+</Callout>
+
+This tutorial builds a delegated-spending system on the `spend_vault` module: a shared `Vault` whose owner grants expiring per-coin budgets to a `SpenderCap`, spent first directly by a delegate, then through a sender-gated keeper service that custodies the cap and spends on the user's behalf.
+
+Three parties participate. The owner funds the vault, mints the cap, and sets budgets with the `OwnerCap`. The delegate holds the `SpenderCap` and draws against its budget. The keeper operator later drives spends through a custodied cap without the delegate signing each transaction.
+
+```mermaid
+flowchart LR
+    Owner["Owner<br/>holds OwnerCap"] -->|"set_allowance&lt;T&gt;"| Vault["Shared Vault<br/>multi-coin pool + budget ledger"]
+    Delegate["Delegate<br/>holds SpenderCap"] -->|"spend&lt;T&gt;"| Vault
+    Delegate -->|"register(cap)"| Service["Keeper Service<br/>custodies SpenderCap"]
+    Operator["Keeper operator"] -->|"execute_topup&lt;T&gt;"| Service
+    Service -->|"spend&lt;T&gt; with custodied cap"| Vault
+```
+
+Four ground rules shape everything below:
+
+- A `SpenderCap` is a bearer instrument. The library never checks who calls [`spend`](/contracts-sui/1.x/api/allowance#spend_vault-spend); whoever presents the cap spends with its full authority, across every coin it is budgeted for.
+- A `Vault` has `key` only, so it must be shared or destroyed in the transaction that creates it, and sharing must come last.
+- Budgets are ceilings, not reservations. Grants may sum over the pool; a pool-short spend fails with the `InsufficientFundsForWithdraw` execution status, not a Move abort code.
+- `destroy` deletes the budget ledger but never drains the pool. Undrained funds strand permanently.
+
+The tutorial is linear: one happy path, with a named failure checkpoint at each step. Run every command in order.
+
+## Prerequisites
+
+Before starting, install the Sui CLI and the MVR CLI, and complete the Quickstart on the [Contracts for Sui overview](/contracts-sui/1.x) so you can publish packages and run PTBs against your target network. You need three funded accounts: an owner, a delegate, and a keeper operator. Familiarity with shared objects and programmable transaction blocks (PTBs) helps; the tutorial names the signing account before every transaction.
+
+## Add the dependency
+
+Add the allowance package to `Move.toml`, pinned to a git revision (it is not yet on the Move Registry):
+
+```toml
+[dependencies]
+openzeppelin_allowance = { git = "https://github.com/OpenZeppelin/contracts-sui.git", subdir = "contracts/allowance", rev = "v1.4.0" }
+```
+
+Then import the module from your Move code:
+
+```move
+use openzeppelin_allowance::spend_vault::{Self, Vault, OwnerCap, SpenderCap};
+```
+
+## Create, Fund, and Share a Vault
+
+The setup module composes the whole vault lifecycle in one function and returns the three objects by value, so the enclosing PTB decides every destination:
+
+```move
+module my_defi::delegation;
+
+use openzeppelin_allowance::spend_vault::{Self, Vault, OwnerCap, SpenderCap};
+use sui::clock::Clock;
+use sui::coin::Coin;
+
+/// Build a funded, budgeted allowance and return its three objects unattached, for
+/// the caller to wire into the surrounding PTB. Creates the vault, deposits the
+/// funding, mints a fresh cap, and grants it `budget` of `T`.
+public fun open_allowance<T>(
+    funding: Coin<T>,
+    budget: u64,
+    expires_at_ms: u64, // pass std::u64::max_value!() for "no expiry"
+    clock: &Clock,
+    ctx: &mut TxContext,
+): (Vault, SpenderCap, OwnerCap) {
+    let (mut vault, owner_cap) = spend_vault::new(ctx);
+
+    // Permissionless top-up. Confers no rights; the funds become the owner's pool.
+    vault.deposit(funding, ctx);
+
+    // Bare cap, no budget yet. Returned by value, so the caller chooses its destination.
+    let cap = vault.mint_cap(&owner_cap, ctx);
+    let cap_id = object::id(&cap);
+
+    // Create the (cap, T) budget. `option::none()` = no CAS guard on a fresh create.
+    vault.set_allowance<T>(&owner_cap, cap_id, budget, expires_at_ms, option::none(), clock, ctx);
+
+    // Hand the objects back; the caller shares the vault and routes the caps.
+    (vault, cap, owner_cap)
+}
+```
+
+This teaches the compose-then-share rule. `Vault` has `key` only and no `drop`: the transaction that calls `new` must either `share` or `destroy` the vault, or execution aborts. Sharing must also come last, because a shared vault is only addressable as a shared input in later transactions: every fund, mint, and grant step in the creating transaction has to precede `share`.
+
+```mermaid
+sequenceDiagram
+    participant Owner
+    participant PTB as Creating PTB
+    participant Vault
+    participant Delegate
+    Owner->>PTB: open_allowance<T>(funding, budget, expiry)
+    PTB->>Vault: new, deposit, mint_cap, set_allowance
+    PTB->>Vault: share (last vault step)
+    PTB-->>Delegate: SpenderCap
+    PTB-->>Owner: OwnerCap
+```
+
+Publish the package:
+
+```bash
+sui client publish
+```
+
+Record the package IDs and account addresses. `$ALLOWANCE` is the published OpenZeppelin allowance package address on your target network:
+
+```bash
+export PACKAGE=0x...
+export ALLOWANCE=0x...
+export OWNER=0x...
+export DELEGATE=0x...
+export OPERATOR=0x...
+export RPC_URL=https://fullnode.testnet.sui.io:443
+export EXPIRES_AT_MS=$((($(date +%s) + 30 * 24 * 60 * 60) * 1000))
+```
+
+Run the creating PTB from the owner account. It funds the vault with 1 SUI, grants the cap a 0.4 SUI budget expiring in 30 days, shares the vault last, and routes the caps:
+
+```bash
+sui client ptb \
+  --split-coins gas "[1000000000]" \
+  --assign funding \
+  --move-call $PACKAGE::delegation::open_allowance \
+    "<0x2::sui::SUI>" \
+    funding \
+    400000000 \
+    $EXPIRES_AT_MS \
+    @0x6 \
+  --assign r \
+  --move-call $ALLOWANCE::spend_vault::share r.0 \
+  --transfer-objects "[r.1]" @$DELEGATE \
+  --transfer-objects "[r.2]" @$OWNER
+```
+
+Record the created object IDs from the output:
+
+```bash
+export VAULT=0x...
+export OWNER_CAP=0x...
+export SPENDER_CAP=0x...
+```
+
+**Checkpoint.** The transaction emits `VaultCreated`, `Deposited`, `SpenderCapMinted`, and `AllowanceSet { was_created: true }`. If you see anything else, stop and re-check the PTB before continuing.
+
+## Grant a Budget
+
+`open_allowance` already performed the first grant, so this step unpacks what [`set_allowance`](/contracts-sui/1.x/api/allowance#spend_vault-set_allowance) actually did and establishes the habit you need for every later grant.
+
+A budget is an entry keyed by `(cap_id, coin type)`. Two sentinel values use `u64::MAX`: a `new_amount` of `u64::MAX` means unlimited (never decremented by spends), and a `new_expires_at_ms` of `u64::MAX` means no expiry. Any finite expiry must be strictly in the future or the call aborts [`EExpiryInPast`](/contracts-sui/1.x/api/allowance#spend_vault-EExpiryInPast). Setting `new_amount` to `0` is legal and means suspension, not deletion.
+
+`set_allowance` takes the spender cap's id as a bare, unvalidated `ID` and upserts. A mistyped `cap_id` does not abort; it silently provisions a fresh phantom budget. The defense is the `was_created` flag on the emitted `AllowanceSet` event: on a grant you intended as an update, confirm `was_created == false`. If it is `true`, you just created a budget under the wrong id.
+
+The owner grants or updates later budgets by calling the library directly. Run this from the owner account to raise the budget to 0.6 SUI (unconditionally; the race-free variant comes later):
+
+```bash
+sui client ptb \
+  --move-call $ALLOWANCE::spend_vault::set_allowance \
+    "<0x2::sui::SUI>" \
+    @$VAULT \
+    @$OWNER_CAP \
+    @$SPENDER_CAP \
+    600000000 \
+    $EXPIRES_AT_MS \
+    none \
+    @0x6
+```
+
+**Checkpoint.** Read the entry back with a dev-inspect call to the view functions:
+
+```bash
+sui client ptb --dev-inspect \
+  --move-call $ALLOWANCE::spend_vault::allowance "<0x2::sui::SUI>" @$VAULT @$SPENDER_CAP \
+  --move-call $ALLOWANCE::spend_vault::expiry "<0x2::sui::SUI>" @$VAULT @$SPENDER_CAP
+```
+
+`allowance` must return `600000000` and `expiry` your `$EXPIRES_AT_MS`, and the transaction's `AllowanceSet` event must show `was_created: false`.
+
+## Spend as the Delegate
+
+`spend` returns a `Balance<T>` with no `drop`: the caller must consume it in the same PTB. The delegate-facing wrapper converts it into a wallet `Coin<T>`. Add this to the same module:
+
+```move
+/// `spend` returns Balance<T>, which has no `drop`: it must be consumed in the
+/// same PTB. Here we turn it into a `Coin` and return it, so the caller (or the
+/// enclosing PTB) decides where the coin goes.
+public fun spend_to_wallet<T>(
+    vault: &mut Vault,
+    cap: &SpenderCap,
+    amount: u64,
+    clock: &Clock,
+    ctx: &mut TxContext,
+): Coin<T> {
+    let bal = vault.spend<T>(cap, amount, clock, ctx);
+    bal.into_coin(ctx)
+}
+```
+
+Run the spend from the delegate account, drawing 0.15 SUI:
+
+```bash
+sui client ptb \
+  --move-call $PACKAGE::delegation::spend_to_wallet \
+    "<0x2::sui::SUI>" \
+    @$VAULT \
+    @$SPENDER_CAP \
+    150000000 \
+    @0x6 \
+  --assign payout \
+  --transfer-objects "[payout]" @$DELEGATE
+```
+
+**Checkpoint.** The transaction emits one `Spent` event: `amount: 150000000`, `remaining: 450000000` (the raw post-call budget), `caller` equal to `$DELEGATE`, and the `coin_type` and `cap_id` you expect. Re-running the dev-inspect from the previous step shows `allowance` decremented to `450000000`.
+
+## Build the Keeper Service
+
+Direct spending proves the primitive. The library's primary use case wraps it: a protocol custodies users' caps and spends on their behalf within the owner-set budgets, without the owner or delegate signing each spend.
+
+<Callout type="warn">
+A `SpenderCap` is a bearer instrument and the library never checks who calls `spend`; any code that gets the library to see `&cap` exercises its full authority. A public function that borrows a custodied cap without a sender gate is world-drainable. The operator assert below is the integration's security boundary, not optional hygiene.
+</Callout>
+
+The service is pinned to exactly one vault id at creation; pinning up front is what makes the register-time binding check meaningful. Put it in a second module:
+
+```move
+module my_defi::keeper;
+
+use openzeppelin_allowance::spend_vault::{Vault, SpenderCap};
+use sui::balance::Balance;
+use sui::clock::Clock;
+use sui::table::{Self, Table};
+
+#[error(code = 0)]
+const ENotOperator: vector<u8> = "Caller is not the service operator";
+#[error(code = 1)]
+const EWrongVaultForService: vector<u8> =
+    "Cap is bound to a different vault than this service serves";
+#[error(code = 2)]
+const ENotRegistered: vector<u8> = "No cap registered under this user address";
+
+/// Shared keeper service. Serves exactly one `Vault` and custodies at most one cap
+/// per user. Untyped, so one service drives every coin a cap is budgeted for.
+public struct Service has key {
+    id: UID,
+    operator: address,
+    vault_id: ID,
+    caps: Table<address, SpenderCap>,
+}
+
+/// Create a service pinned to `vault_id`. The creator becomes the operator, the
+/// only address the cap-borrowing entrypoint accepts. Returned by value for the
+/// caller to `share` (two-step create-then-share, mirroring `spend_vault::share`).
+public fun create(vault_id: ID, ctx: &mut TxContext): Service {
+    Service {
+        id: object::new(ctx),
+        operator: ctx.sender(),
+        vault_id,
+        caps: table::new(ctx),
+    }
+}
+
+/// Share the service so users can register caps against it.
+public fun share(service: Service) {
+    transfer::share_object(service);
+}
+
+/// Validate the cap's vault binding BEFORE taking custody: the rule for ANY
+/// protocol that accepts a SpenderCap.
+public fun register(service: &mut Service, cap: SpenderCap, ctx: &mut TxContext) {
+    assert!(cap.spender_cap_vault_id() == service.vault_id, EWrongVaultForService);
+    service.caps.add(ctx.sender(), cap);
+}
+
+/// SENDER-GATED: the library never checks who calls `spend`, so the custody
+/// layer must. Without this check the function is world-drainable.
+public fun execute_topup<T>(
+    service: &mut Service,
+    vault: &mut Vault,
+    user: address,
+    amount: u64,
+    clock: &Clock,
+    ctx: &mut TxContext,
+): Balance<T> {
+    assert!(ctx.sender() == service.operator, ENotOperator);
+    assert!(service.caps.contains(user), ENotRegistered);
+    let cap = service.caps.borrow(user);
+    vault.spend<T>(cap, amount, clock, ctx)
+}
+
+/// Take a cap back out of custody. The grant is untouched: it stays live in the
+/// vault; only custody of the cap changes hands.
+public fun unregister(service: &mut Service, ctx: &mut TxContext): SpenderCap {
+    assert!(service.caps.contains(ctx.sender()), ENotRegistered);
+    service.caps.remove(ctx.sender())
+}
+```
+
+The `register` check calls [`spender_cap_vault_id`](/contracts-sui/1.x/api/allowance#spend_vault-spender_cap_vault_id) so a cap bound to a different vault is rejected at custody time, not discovered at spend time. `execute_topup` is generic over `T`, so one custodied cap serves every coin the owner budgeted it for; asking for a coin the owner never granted fails safe inside the library with [`ENoAllowance`](/contracts-sui/1.x/api/allowance#spend_vault-ENoAllowance).
+
+```mermaid
+sequenceDiagram
+    participant User as Delegate (user)
+    participant Service
+    participant Operator
+    participant Vault
+    User->>Service: register(cap)
+    Service->>Service: assert spender_cap_vault_id == vault_id
+    Operator->>Service: execute_topup<T>(user, amount)
+    Service->>Service: assert sender == operator
+    Service->>Vault: spend<T>(&cap, amount)
+    Vault-->>Operator: Balance<T>
+```
+
+After republishing (or upgrading) your package, create and share the service from the operator account, pinning it to your vault id:
+
+```bash
+sui client ptb \
+  --move-call $PACKAGE::keeper::create @$VAULT \
+  --assign service \
+  --move-call $PACKAGE::keeper::share service
+```
+
+Record the shared service id:
+
+```bash
+export SERVICE=0x...
+```
+
+The delegate hands the cap into custody. Run this from the delegate account:
+
+```bash
+sui client ptb \
+  --move-call $PACKAGE::keeper::register @$SERVICE @$SPENDER_CAP
+```
+
+Now the operator drives a spend. `execute_topup` returns a `Balance<T>`, so the PTB converts it to a `Coin` and routes it. In a real keeper this would flow into a position; here it goes to the user. Run this from the operator account:
+
+```bash
+sui client ptb \
+  --move-call $PACKAGE::keeper::execute_topup \
+    "<0x2::sui::SUI>" \
+    @$SERVICE \
+    @$VAULT \
+    @$DELEGATE \
+    50000000 \
+    @0x6 \
+  --assign bal \
+  --move-call 0x2::coin::from_balance "<0x2::sui::SUI>" bal \
+  --assign topup \
+  --transfer-objects "[topup]" @$DELEGATE
+```
+
+**Checkpoint.** The `Spent` event shows `remaining: 400000000` and `caller` equal to `$OPERATOR`: attribution follows whoever drove the spend, not the user who owns the budget. Repeating the PTB from the delegate or owner account aborts with the keeper module's `ENotOperator`, proving the gate holds.
+
+## Owner Maintenance Mid-Custody
+
+The owner keeps full control while the cap sits in custody, because every owner verb keys on the `cap_id` alone and never touches the cap object. `cap_id` is stable across create, raise, lower, suspend, and renew; a custodied cap keeps working with no re-registration.
+
+A plain `set_allowance` computed from an earlier read can clobber a spend sequenced in between. The race-free idiom is compare-and-set: read the current budget with `allowance<T>` off-chain (or in a previous transaction), then pass that value as `expected` when you write. If a spend landed after the read, the entry's `remaining` no longer matches and the write aborts [`EUnexpectedAllowance`](/contracts-sui/1.x/api/allowance#spend_vault-EUnexpectedAllowance) instead of silently overwriting; re-read and retry. Add this to `my_defi::delegation`:
+
+```move
+/// Raise / lower / renew with the race-free CAS idiom. `expected` is the budget
+/// the caller read via `allowance<T>` off-chain (or in a previous transaction).
+/// If a spend was sequenced between that read and this transaction, the entry's
+/// `remaining` no longer equals `expected` and the call aborts
+/// `EUnexpectedAllowance` instead of clobbering the concurrent spend.
+public fun change_budget<T>(
+    vault: &mut Vault,
+    owner_cap: &OwnerCap,
+    cap_id: ID,
+    expected: u64,
+    new_budget: u64,
+    new_expires_at_ms: u64,
+    clock: &Clock,
+    ctx: &mut TxContext,
+) {
+    vault.set_allowance<T>(
+        owner_cap,
+        cap_id,
+        new_budget,
+        new_expires_at_ms,
+        option::some(expected),
+        clock,
+        ctx,
+    );
+}
+```
+
+Note that the CAS guard matches `remaining` only, while the upsert always overwrites the expiry too: a budget-only update must re-read the current expiry (via `expiry<T>`) and pass it back, or it silently rewrites the deadline.
+
+Read the current budget first (the last checkpoint's `Spent` event showed `remaining: 400000000`, or re-run the dev-inspect read), then raise it to 1 SUI from the owner account, passing the read value as `expected`:
+
+```bash
+sui client ptb \
+  --move-call $PACKAGE::delegation::change_budget \
+    "<0x2::sui::SUI>" \
+    @$VAULT \
+    @$OWNER_CAP \
+    @$SPENDER_CAP \
+    400000000 \
+    1000000000 \
+    $EXPIRES_AT_MS \
+    @0x6
+```
+
+If a spend lands between your read and this transaction, the PTB aborts `EUnexpectedAllowance`; re-read the budget and retry with the fresh value.
+
+Three conditions stop a spender, and the spender can tell them apart by abort code:
+
+- **Suspend**: `set_allowance` with `new_amount = 0` keeps the entry and cap alive. The next positive spend aborts [`EAllowanceExceeded`](/contracts-sui/1.x/api/allowance#spend_vault-EAllowanceExceeded), the signal to ask for a raise.
+- **Revoke**: [`revoke`](/contracts-sui/1.x/api/allowance#spend_vault-revoke) removes the `(cap, coin)` entry. The next spend aborts [`ENoAllowance`](/contracts-sui/1.x/api/allowance#spend_vault-ENoAllowance), the signal to ask for a new grant. `revoke` is idempotent and returns `was_present`; `false` means a typo'd `cap_id` or wrong coin, never an abort.
+- **Expire**: once the clock reaches a finite `expires_at_ms`, the next spend aborts [`EAllowanceExpired`](/contracts-sui/1.x/api/allowance#spend_vault-EAllowanceExpired) (the boundary is closed: a spend at exactly the expiry millisecond fails). The owner revives the entry in place by re-setting a future expiry via `set_allowance`.
+
+**Checkpoint.** Run the operator's `execute_topup` PTB from the previous section again. It succeeds under the new budget without any re-registration, and the `Spent` event reflects the raised `remaining`.
+
+## Emergency Stop
+
+This section is for *durably* stopping a cap that must not spend again, not for routine exit: to just recover funds the owner withdraws anytime (see Teardown), and with a single funder that is the whole story. When a cap is compromised or a keeper misbehaves and the pool could be re-funded, the order of operations matters. Kill that cap's authority first, then move the funds, in two separate transactions. `revoke_all` acts on the one cap you name; this tutorial has a single delegate, but a vault serving many spenders revokes each compromised cap, or `destroy`s the whole vault to end every cap at once. Add these two functions to `my_defi::delegation`, along with `use sui::accumulator::AccumulatorRoot;` in its imports:
+
+```move
+// Emergency stop, in TWO separate transactions, never one PTB.
+
+/// Tx 1: kill this cap's authority. `revoke_all` acts on one cap and never
+/// touches the pool, so no allowance state can race it into failure. (Withdrawing
+/// first is NOT durable: deposits are permissionless, so anyone can re-arm a live
+/// allowance.)
+public fun kill_authority(
+    vault: &mut Vault,
+    owner_cap: &OwnerCap,
+    cap_id: ID,
+    ctx: &mut TxContext,
+) {
+    vault.revoke_all(owner_cap, cap_id, ctx);
+}
+
+/// Tx 2 (a LATER transaction, once per coin type): drain the coin. `withdraw_all`
+/// reads the settled accumulator (root = 0xacc); a same-checkpoint pool change
+/// makes it over-ask and abort (retry-safe). Returns the possibly-zero drained
+/// pool as a wallet `Coin<T>` for the caller to route.
+public fun drain_coin<T>(
+    vault: &mut Vault,
+    owner_cap: &OwnerCap,
+    root: &AccumulatorRoot,
+    ctx: &mut TxContext,
+): Coin<T> {
+    vault.withdraw_all<T>(owner_cap, root, ctx).into_coin(ctx)
+}
+```
+
+Never bundle the two into one PTB. A pool-short `withdraw_all` fails with the `InsufficientFundsForWithdraw` execution status, and Move's atomic revert would take the `revoke_all` down with it, leaving the compromised cap live exactly when you need it dead. Withdraw-first is not a substitute either: deposits are permissionless, so anyone can re-fund the pool and re-arm a still-live allowance. Only [`revoke_all`](/contracts-sui/1.x/api/allowance#spend_vault-revoke_all) (or `destroy`) is durable.
+
+Transaction 1, from the owner account. Note `revoke_all` takes the bare `cap_id` unvalidated, and a wrong id is a silent whole no-op with no event, leaving the intended cap live:
+
+```bash
+sui client ptb \
+  --move-call $ALLOWANCE::spend_vault::revoke_all @$VAULT @$OWNER_CAP @$SPENDER_CAP
+```
+
+**Checkpoint.** The transaction emits one `Revoked { was_present: true }` event per removed coin: for this vault, exactly one, for `0x2::sui::SUI`. Zero `Revoked` events means the `cap_id` missed; fix it before proceeding.
+
+Transaction 2, later, from the owner account. `withdraw_all` returns a possibly-zero `Balance<T>`, consumed here as a `Coin`:
+
+```bash
+sui client ptb \
+  --move-call $ALLOWANCE::spend_vault::withdraw_all \
+    "<0x2::sui::SUI>" \
+    @$VAULT \
+    @$OWNER_CAP \
+    @0xacc \
+  --assign bal \
+  --move-call 0x2::coin::from_balance "<0x2::sui::SUI>" bal \
+  --assign recovered \
+  --transfer-objects "[recovered]" @$OWNER
+```
+
+If this fails with `InsufficientFundsForWithdraw`, a same-checkpoint pool change skewed the settled read; retry in the next checkpoint.
+
+## Teardown
+
+<Callout type="warn">
+`destroy` drains only the budget ledger and deletes the vault's UID. It does not touch the pool, and no on-chain guard can stop a premature destroy: any coins still at the vault address strand permanently. Drain every coin type first, in a prior transaction, never in the same PTB.
+</Callout>
+
+The drain ritual, in order:
+
+1. Enumerate every coin type at the vault address off-chain; the on-chain `granted_coin_types` view is not the drain list, since anyone can deposit coin types that were never granted:
+
+   ```bash
+   curl -s $RPC_URL -X POST -H 'Content-Type: application/json' \
+     -d "{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"suix_getAllBalances\",\"params\":[\"$VAULT\"]}"
+   ```
+
+2. If any loose `Coin` objects were transferred to the vault address (rather than deposited), recover them into the pool with `squash<T>`, passing the receiving ticket.
+3. Run the `withdraw_all` PTB from the previous section once per coin type reported.
+4. Wait one checkpoint, then re-run `suix_getAllBalances`; a same-checkpoint deposit is missed by the settled read, so the re-check is what catches late arrivals.
+5. Only when every balance reads zero, destroy the vault. Run this from the owner account; it consumes both the vault and the `OwnerCap`:
+
+   ```bash
+   sui client ptb \
+     --move-call $ALLOWANCE::spend_vault::destroy @$VAULT @$OWNER_CAP
+   ```
+
+**Checkpoint.** The transaction emits `VaultDestroyed`. If the delegate's cap was never reclaimed and destroyed, it is now orphaned; its holder can dispose of it with [`delete_orphaned_cap`](/contracts-sui/1.x/api/allowance#spend_vault-delete_orphaned_cap) (ungated, but the cap is consumed by value, so only its owner can call it). In this tutorial the cap is still custodied by the keeper `Service`, so the delegate must first take it back with `keeper::unregister`, then call `delete_orphaned_cap`.
+
+## Operational Checklist
+
+- Validate `spender_cap_vault_id` against the expected vault before taking any `SpenderCap` into custody.
+- Sender-gate every function that borrows a custodied cap; the library never checks the caller, so the custody layer's gate is the security boundary.
+- To recover funds, the owner withdraws anytime, unconditionally. To *durably* stop a compromised cap (so a later deposit cannot re-arm it), `revoke_all` that cap first in its own transaction, then `withdraw_all` per coin in a later one; never bundle them, and repeat per cap (or `destroy` the vault to end all).
+- Drain every coin type (off-chain enumeration via `suix_getAllBalances`, then `squash`, then `withdraw_all`, then wait a checkpoint and re-check) before calling `destroy`.
+- Confirm `AllowanceSet.was_created == false` on every budget update; `true` on an intended update means a mistyped `cap_id` provisioned a phantom budget.
+- On budget-only CAS updates, re-read and re-pass the current expiry; the upsert always overwrites `expires_at_ms`.
+- Treat pool-short failures as execution statuses, not Move aborts: preflight `spend`, `withdraw`, and `withdraw_all` with a dry run instead of matching an abort code.
+
+For function-level signatures, abort codes, and events, see the [Allowance API reference](/contracts-sui/1.x/api/allowance#spend_vault).

--- a/content/contracts-sui/1.x/index.mdx
+++ b/content/contracts-sui/1.x/index.mdx
@@ -2,12 +2,13 @@
 title: Contracts for Sui 1.x
 ---
 
-**OpenZeppelin Contracts for Sui v1.x** ships four core packages:
+**OpenZeppelin Contracts for Sui v1.x** ships these core packages:
 
 - `openzeppelin_math` for deterministic integer arithmetic, configurable rounding, and decimal scaling.
 - `openzeppelin_fp_math` for 9-decimal fixed-point arithmetic (`UD30x9`, `SD29x9`) backed by `u128`.
 - `openzeppelin_access` for role-based authorization and ownership-transfer wrappers around privileged `key + store` objects.
 - `openzeppelin_utils` for embeddable building blocks; its first module, `rate_limiter`, provides multi-strategy rate limiting.
+- `openzeppelin_allowance` for cap-keyed spending allowances; its first module, `spend_vault`, escrows multi-coin funds behind owner-set, expiring budgets.
 
 ## Quickstart
 
@@ -35,9 +36,11 @@ mvr add @openzeppelin-move/utils
 
 You only need the dependencies your app actually uses. Add what you need and drop the others.
 
+Packages not yet on the Move Registry, currently `openzeppelin_allowance`, are added by git revision instead of `mvr add` (see the next step).
+
 ### 3. Verify `Move.toml`
 
-`mvr add` updates `Move.toml` automatically. With all three installed it should include:
+`mvr add` updates `Move.toml` automatically. With all four installed it should include:
 
 ```toml
 [dependencies]
@@ -46,6 +49,14 @@ openzeppelin_math = { r.mvr = "@openzeppelin-move/integer-math" }
 openzeppelin_fp_math = { r.mvr = "@openzeppelin-move/fixed-point-math" }
 openzeppelin_utils = { r.mvr = "@openzeppelin-move/utils" }
 ```
+
+Since `openzeppelin_allowance` isn't on MVR yet, add it manually, pinned to a git revision:
+
+```toml
+openzeppelin_allowance = { git = "https://github.com/OpenZeppelin/contracts-sui.git", subdir = "contracts/allowance", rev = "v1.4.0" }
+```
+
+Alternatively, copy the module sources directly into your package's `sources/` so you fully own the code; see each package guide for the per-package options.
 
 ### 4. Add a Minimal Module
 
@@ -83,13 +94,15 @@ sui move test
 - Need fractional values like prices, fees, rates, or signed deltas? Use [Fixed-Point Math](/contracts-sui/1.x/fixed-point).
 - Need integer arithmetic with safe overflow and explicit rounding? Use [Integer Math](/contracts-sui/1.x/math).
 - Need to throttle withdrawals, meter per-user budgets, gate action reuse, or delay an action? Use [Rate Limiter](/contracts-sui/1.x/rate-limiter).
+- Need to delegate bounded, expiring spending of escrowed coins to a keeper, service, or teammate, without signing each spend? Use [Spend Vault](/contracts-sui/1.x/spend-vault).
 
 The packages compose. A typical protocol module imports `openzeppelin_math` for share math, `openzeppelin_fp_math` for rate and fee math, and `openzeppelin_access` for the admin capability that governs both.
 
 ## Next steps
 
-- Package guides: [Integer Math](/contracts-sui/1.x/math), [Fixed-Point Math](/contracts-sui/1.x/fixed-point), [Access](/contracts-sui/1.x/access), [Utilities](/contracts-sui/1.x/utils).
+- Package guides: [Integer Math](/contracts-sui/1.x/math), [Fixed-Point Math](/contracts-sui/1.x/fixed-point), [Access](/contracts-sui/1.x/access), [Utilities](/contracts-sui/1.x/utils), [Allowance](/contracts-sui/1.x/allowance).
 - Access modules: [RBAC](/contracts-sui/1.x/access-control), [Two-Step Transfer](/contracts-sui/1.x/two-step-transfer), [Delayed Transfer](/contracts-sui/1.x/delayed-transfer).
 - Utilities modules: [Rate Limiter](/contracts-sui/1.x/rate-limiter).
-- Learn: [Role Based Access Control](/contracts-sui/1.x/guides/access-control).
-- API reference: [Integer Math](/contracts-sui/1.x/api/math), [Fixed-Point Math](/contracts-sui/1.x/api/fixed-point), [Access](/contracts-sui/1.x/api/access), [Utilities](/contracts-sui/1.x/api/utils).
+- Allowance modules: [Spend Vault](/contracts-sui/1.x/spend-vault).
+- Learn: [Role Based Access Control](/contracts-sui/1.x/guides/access-control), [Delegated Spending](/contracts-sui/1.x/guides/delegated-spending).
+- API reference: [Integer Math](/contracts-sui/1.x/api/math), [Fixed-Point Math](/contracts-sui/1.x/api/fixed-point), [Access](/contracts-sui/1.x/api/access), [Utilities](/contracts-sui/1.x/api/utils), [Allowance](/contracts-sui/1.x/api/allowance).

--- a/content/contracts-sui/1.x/spend-vault.mdx
+++ b/content/contracts-sui/1.x/spend-vault.mdx
@@ -1,0 +1,317 @@
+---
+title: Spend Vault
+---
+
+<Callout type="warn">
+The example code snippets used in this guide are experimental and have not been audited. They simply help exemplify usage of the OpenZeppelin Sui Package.
+</Callout>
+
+The `spend_vault` module provides a cap-keyed, multi-coin allowance primitive for Sui Move. A shared, key-only `Vault` escrows any number of coin types untyped: funds are not struct fields but object-owned address balances held at the vault's address, and a `LinkedTable` ledger maps each `(cap, coin type)` pair to a budget. Each `SpenderCap` is a **bearer instrument**: whoever presents it to `spend<T>` exercises the full authority of every budget keyed by that cap, regardless of who signed the transaction. One vault mints as many spender caps as the owner needs, typically one per delegate or user, each with its own per-`(cap, coin)` budgets. A single `OwnerCap` grants, revokes, and withdraws across all of them; funding is permissionless, and transferring the `OwnerCap` is owner rotation.
+
+## Use cases
+
+Use `spend_vault` when your protocol needs:
+
+- Keeper or automation top-ups drawn from an owner-set budget without the owner signing each spend.
+- Delegated treasury spending, where a teammate or contract draws against a ceiling.
+- Subscription-style pull payments a payee collects on their own schedule.
+- Per-partner budgets across multiple coin types from a single escrow.
+
+## Import
+
+```move
+use openzeppelin_allowance::spend_vault::{Self, Vault, OwnerCap, SpenderCap};
+```
+
+## Object model
+
+| Object | Role | Who holds it |
+|---|---|---|
+| `Vault` | Shared, key-only escrow for N coin types plus the `(cap, coin)` allowance ledger. Funds live as address balances at the vault's address, not in a struct field. | Shared object; everyone references it. |
+| `OwnerCap` | Sole owner authority: mint caps, set budgets, revoke, withdraw, destroy. Exactly one per vault for its whole life. | The vault owner. Transferring it rotates ownership. |
+| `SpenderCap` | Bearer spend authority, untyped: the coin dimension is the `T` at the `spend<T>` call site. Carries no budget itself. One of many: a vault mints a separate cap per grantee. | One per grantee: a delegate, a user, or a protocol custodying it. |
+| Allowance entry | Private ledger record per `(cap, coin type)`: `remaining` budget and `expires_at_ms`. The single source of truth for what a cap may draw. | Inside the vault; managed by the owner via `set_allowance`. |
+
+Two `u64::MAX` sentinels apply, tested by equality only: `remaining == u64::MAX` means unlimited (never decremented) and `expires_at_ms == u64::MAX` means no expiry. A `(cap, coin)` pair is in one of three states: **absent** (never granted, or revoked), **suspended** (entry present with `remaining == 0`), or **live**. Reads alone cannot tell absent from suspended (`allowance<T>` returns `0` for both), so use `contains<T>` to disambiguate.
+
+## Quickstart
+
+Compose the whole setup in one function: create the vault, fund it, mint a cap, and grant a budget, returning all three objects by value so the enclosing PTB decides where each goes:
+
+```move
+module my_protocol::delegation;
+
+use openzeppelin_allowance::spend_vault::{Self, Vault, OwnerCap, SpenderCap};
+use sui::clock::Clock;
+use sui::coin::Coin;
+
+public fun open_allowance<T>(
+    funding: Coin<T>,
+    budget: u64,
+    expires_at_ms: u64, // pass std::u64::max_value!() for "no expiry"
+    clock: &Clock,
+    ctx: &mut TxContext,
+): (Vault, SpenderCap, OwnerCap) {
+    let (mut vault, owner_cap) = spend_vault::new(ctx);
+
+    // Permissionless top-up. Confers no rights; the funds become the owner's pool.
+    vault.deposit(funding, ctx);
+
+    // Bare cap, no budget yet. Returned by value, so the caller chooses its destination.
+    let cap = vault.mint_cap(&owner_cap, ctx);
+    let cap_id = object::id(&cap);
+
+    // Create the (cap, T) budget. `option::none()` = no CAS guard on a fresh create.
+    vault.set_allowance<T>(&owner_cap, cap_id, budget, expires_at_ms, option::none(), clock, ctx);
+
+    // Hand the objects back; the caller shares the vault and routes the caps.
+    (vault, cap, owner_cap)
+}
+```
+
+The caller wires the edges in the same transaction:
+
+```move
+let (vault, cap, owner_cap) = delegation::open_allowance<EXAMPLE_COIN>(
+    stake, 400, now_ms + 30 * DAY_MS, &clock, ctx,
+);
+
+// Compose the edges in the SAME tx: share the vault LAST, hand the cap to the delegate.
+vault.share();
+transfer::public_transfer(cap, delegate);
+transfer::public_transfer(owner_cap, ctx.sender());
+```
+
+`Vault` has `key` only and no `drop`, so the creating transaction must consume it with `share` or `destroy`, and `share` must come last, after every fund, mint, and grant step, because a shared vault is only addressable as a shared input in *later* transactions.
+
+## Spending
+
+`spend<T>` draws exactly `amount` of `T` against the presented cap and returns a `Balance<T>`. `Balance<T>` has no `drop`, so it must be consumed in the same PTB. Convert it to a `Coin`, route it into another call, or deposit it somewhere:
+
+```move
+/// `spend` returns Balance<T>, which has no `drop`: it must be consumed in the same PTB.
+public fun spend_to_wallet<T>(
+    vault: &mut Vault,
+    cap: &SpenderCap,
+    amount: u64,
+    clock: &Clock,
+    ctx: &mut TxContext,
+): Coin<T> {
+    let bal = vault.spend<T>(cap, amount, clock, ctx);
+    bal.into_coin(ctx)
+}
+```
+
+Spends are exact-amount-or-abort: there is no partial fill, and on any abort the pool and ledger are bit-identical to their pre-call state. The abort order is deterministic and documented as an integrator ABI: `EWrongVault`, then `ENoAllowance`, `EAllowanceExpired`, `EZeroAmount`, `EAllowanceExceeded`, then the framework failure modes; see the [Allowance API reference](/contracts-sui/1.x/api/allowance#spend_vault) for each condition. A pool shortfall is *not* a Move abort at all (see the [FAQ](#faq)).
+
+## Integrating into a protocol
+
+A protocol custodies a user's `SpenderCap` and spends on their behalf, within the owner's budget, without the user signing each spend. This is the pattern the primitive is primarily built for: a custody layer holds the cap, an operator drives the spends, and the vault owner still holds the only authority over the budget.
+
+Two custody rules are load-bearing:
+
+- **The borrow entrypoint MUST be sender-gated.** A `SpenderCap` is a bearer instrument, and the library is cap-gated, never sender-gated: any code that gets the library to see `&cap` exercises its full authority. An ungated public function that borrows a custodied cap is world-drainable, so the operator check is the integration's security boundary, not optional hygiene.
+- **Validate the cap's vault binding before taking custody.** Check `spender_cap_vault_id` against the vault you intend to spend from at register time, so a cap bound to a different vault is rejected on entry rather than discovered at spend time.
+
+A minimal custody module, condensed from the [keeper service](/contracts-sui/1.x/guides/delegated-spending#build-the-keeper-service) built in the Delegated Spending tutorial:
+
+```move
+module my_protocol::keeper;
+
+use openzeppelin_allowance::spend_vault::{Vault, SpenderCap};
+use sui::balance::Balance;
+use sui::clock::Clock;
+use sui::table::{Self, Table};
+
+#[error(code = 0)]
+const ENotOperator: vector<u8> = "Caller is not the service operator";
+#[error(code = 1)]
+const EWrongVaultForService: vector<u8> =
+    "Cap is bound to a different vault than this service serves";
+#[error(code = 2)]
+const ENotRegistered: vector<u8> = "No cap registered under this user address";
+
+/// Shared keeper service. Serves exactly one `Vault` and custodies at most one cap
+/// per user. Untyped, so one service drives every coin a cap is budgeted for.
+public struct Service has key {
+    id: UID,
+    operator: address,
+    vault_id: ID,
+    caps: Table<address, SpenderCap>,
+}
+
+/// Create the service pinned to one vault id; the creator becomes the operator.
+/// Key-only, so the caller shares it with this module's `share` (as with the vault).
+public fun create(vault_id: ID, ctx: &mut TxContext): Service {
+    Service { id: object::new(ctx), operator: ctx.sender(), vault_id, caps: table::new(ctx) }
+}
+
+/// Share the service so users can register caps against it.
+public fun share(service: Service) {
+    transfer::share_object(service);
+}
+
+/// Validate the cap's vault binding BEFORE taking custody: the rule for ANY
+/// protocol that accepts a `SpenderCap`. Keyed by the registering sender.
+public fun register(s: &mut Service, cap: SpenderCap, ctx: &mut TxContext) {
+    assert!(cap.spender_cap_vault_id() == s.vault_id, EWrongVaultForService);
+    s.caps.add(ctx.sender(), cap);
+}
+
+/// SENDER-GATED: the library never checks who calls `spend`, so the custody layer
+/// must. Generic over `T`, so one custodied cap serves every budgeted coin; an
+/// ungranted coin fails safe inside the library with `ENoAllowance`.
+public fun execute<T>(
+    s: &mut Service,
+    v: &mut Vault,
+    user: address,
+    amount: u64,
+    clock: &Clock,
+    ctx: &mut TxContext,
+): Balance<T> {
+    assert!(ctx.sender() == s.operator, ENotOperator);
+    assert!(s.caps.contains(user), ENotRegistered);
+    let cap = s.caps.borrow(user);
+    v.spend<T>(cap, amount, clock, ctx)
+}
+
+/// Take a cap back out of custody, keyed to the registering sender. The grant stays
+/// live in the vault; only custody of the cap changes hands.
+public fun unregister(s: &mut Service, ctx: &mut TxContext): SpenderCap {
+    assert!(s.caps.contains(ctx.sender()), ENotRegistered);
+    s.caps.remove(ctx.sender())
+}
+```
+
+**Design properties to preserve:**
+
+- Keep exit self-service: `unregister` is keyed to the registering sender, with no operator or admin seize path.
+- The `Service` is key-only, so share it through your own module's `share` rather than at creation.
+- Custody at most one cap per user, keyed by address.
+
+**Design tip.** Keep the `Service` untyped and `execute` generic over `T`, so a single custodied cap serves every coin the owner budgeted it for; a request for an ungranted coin fails safe inside the library with `ENoAllowance`.
+
+The owner keeps full control throughout: raising, lowering, suspending, or revoking the grant never changes the cap object, so a custodied cap keeps working with no re-registration, and custody of the cap confers no control over the budget.
+
+For the full worked walkthrough (register, operator-driven spend, owner maintenance mid-custody, and teardown), see [Build the Keeper Service](/contracts-sui/1.x/guides/delegated-spending#build-the-keeper-service) in the Delegated Spending tutorial.
+
+## Managing budgets
+
+`set_allowance<T>` is an **upsert** keyed on a bare `cap_id: ID` that is never validated against a live cap: a mistyped id silently provisions a fresh phantom budget instead of aborting. When you intend an update, confirm the emitted `AllowanceSet` event has `was_created == false`, or check `contains<T>` first.
+
+Setting `new_amount` to `0` is the **suspension** idiom: the entry and cap stay alive, and the spender's next attempt aborts `EAllowanceExceeded`, a signal to ask for a raise. A revoked or never-granted pair aborts `ENoAllowance` instead, a signal to ask for a grant. Re-setting always overwrites, never adds, and setting a fresh future expiry on an expired entry revives it in place. None of these updates changes the cap object, so a protocol holding a custodied cap keeps working across every owner budget change with no re-registration (see [Integrating into a protocol](#integrating-into-a-protocol)).
+
+Concurrent-safe updates use the compare-and-set guard: read the current budget with `allowance<T>` off-chain (or in a previous transaction), then pass that value as `expected` when you write. If a spend was sequenced after the read, the write aborts `EUnexpectedAllowance` instead of silently overwriting it. A read taken in the same transaction as the write trivially matches the guard and protects nothing: the shared vault is locked for the whole transaction, so an in-transaction read/write pair is already atomic without a guard.
+
+```move
+/// Raise / lower / renew with the CAS guard. `expected` is the budget the caller
+/// read via `allowance<T>` off-chain (or in a previous transaction). If a spend was
+/// sequenced between that read and this transaction, the entry's `remaining` no
+/// longer equals `expected` and the call aborts `EUnexpectedAllowance` instead of
+/// clobbering the concurrent spend.
+public fun change_budget<T>(
+    vault: &mut Vault,
+    owner_cap: &OwnerCap,
+    cap_id: ID,
+    expected: u64,
+    new_budget: u64,
+    new_expires_at_ms: u64,
+    clock: &Clock,
+    ctx: &mut TxContext,
+) {
+    vault.set_allowance<T>(
+        owner_cap, cap_id, new_budget, new_expires_at_ms, option::some(expected), clock, ctx,
+    );
+}
+```
+
+The CAS guard matches `remaining` **only**; the upsert always overwrites `expires_at_ms` too, and any finite `new_expires_at_ms` must be strictly in the future or the call aborts `EExpiryInPast` (the `u64::MAX` sentinel always passes). A budget-only update must re-read the current expiry via `expiry<T>()` and pass it back, but that works only while the entry is unexpired: expired entries are not pruned, so `expiry<T>()` can return a past timestamp that `set_allowance` rejects. Updating an expired entry means choosing a new future expiry (or `u64::MAX`), which necessarily revives it.
+
+## Revoking and renouncing
+
+Four removal verbs with different scopes:
+
+- **`revoke<T>`** (owner): removes one `(cap, coin)` entry. Idempotent and never blocked by ledger state; returns `was_present`, where `false` is the typo'd-`cap_id` or wrong-coin signal. Strictly per-coin: the cap object survives and remains live authority for any other coins still granted to it; only `revoke_all`/`renounce` zero the whole cap.
+- **`revoke_all`** (owner): removes every entry of one cap across all coin types ever granted; the cap object survives in its holder's wallet as inert non-authority. The `cap_id` is unvalidated: a wrong id is a silent whole no-op that emits nothing and leaves the intended cap live; confirm via the emitted `Revoked` events or a `contains<T>` recheck.
+- **`renounce`** (spender): consumes the `SpenderCap` by value and removes all of its entries. Use it against a live vault.
+- **`delete_orphaned_cap`** (cap holder): consumes the cap by value, disposal only for a cap whose vault was already destroyed. It never aborts and touches no vault state.
+
+<Callout type="warn">
+Calling `delete_orphaned_cap` on a cap whose vault is still live strands every one of its ledger entries as inert garbage: unspendable, but still occupying storage and visible via `contains<T>`. On a live vault, spenders should `renounce` instead; if a live cap was already deleted, the owner cleans up with `revoke_all` using the `cap_id` from the `CapDeleted` event.
+</Callout>
+
+## Owner exit and teardown
+
+`withdraw<T>` and `withdraw_all<T>` consult only the `OwnerCap` binding and the pool, never the ledger. No spender state can block owner exit, and withdrawing may leave live allowances unbacked (intended: budgets are ceilings, not reservations).
+
+`withdraw_all<T>` drains the **settled** (start-of-checkpoint) pool via the `AccumulatorRoot` (`0xacc`). A spend or withdraw earlier in the same checkpoint (including an earlier command in the same PTB) lowers the live pool below that snapshot, making the drain over-ask and fail with the `InsufficientFundsForWithdraw` execution status (retry-safe next checkpoint); a same-checkpoint deposit is simply missed.
+
+Getting funds out needs no ceremony: `withdraw` / `withdraw_all` anytime, and you are done. The ordering below matters only when you also need a *durable* kill of a still-live cap. Because deposits are permissionless, a drained pool can be re-funded (by anyone, or by you later) and re-arm still-live budgets, so `withdraw_all` alone is a reversible freeze, not a kill. When a cap is compromised and the pool could be re-funded, revoke it first, then drain, in separate transactions. `revoke_all` ends one cap's authority across all its coins, so repeat it per compromised cap, or `destroy` the vault to end every cap at once:
+
+```move
+// Emergency stop, in TWO separate transactions, never one PTB:
+//
+// Tx 1: kill the compromised cap's authority. revoke_all is per cap (all its
+// coins), so repeat per cap or destroy the vault to end all. It never touches
+// the pool, so no allowance state can race it into failure. (Withdrawing first
+// is NOT durable: deposits are permissionless, so anyone can re-arm a live allowance.)
+vault.revoke_all(&owner_cap, cap_id, ctx);
+
+// Tx 2 (later tx): drain each coin. withdraw_all reads the settled accumulator
+// (root = 0xacc); a prior same-checkpoint spend/withdraw makes it over-ask and
+// abort, while a same-checkpoint deposit is simply missed.
+let bal = vault.withdraw_all<T>(&owner_cap, root, ctx);
+```
+
+Bundling them into one PTB is wrong in both orders: a pool-short `withdraw_all` would revert the `revoke_all` along with it.
+
+To destroy a vault, follow the drain ritual: enumerate the vault address's coin types off-chain with `suix_getAllBalances`, `squash<T>` any stray coins sent as owned objects, `withdraw_all<T>` each type, wait one checkpoint and re-check, then `destroy` in a separate transaction.
+
+<Callout type="warn">
+`destroy` deletes the vault and owner cap and drains the allowance ledger, but it does **not** drain the pool, and no on-chain guard stops a premature destroy. Any funds still sitting in the vault's address balances strand permanently: the UID is gone and there is no recovery path. Drain every coin type first, in a prior transaction.
+</Callout>
+
+## Security considerations
+
+- **Sender-gate any function that borrows a custodied `&SpenderCap`.** The library is cap-gated, never sender-gated: any code path that gets the library to see `&cap` exercises its full authority. A protocol that custodies caps and exposes an ungated public function borrowing one is world-drainable.
+- **Validate `spender_cap_vault_id` before taking custody.** A protocol accepting a user's cap must check the cap's vault binding against the expected vault at register time, not discover a mismatch at spend time.
+- **A leaked cap drains every budgeted coin.** One `SpenderCap` keys the budgets of all coin types granted to it; its exposure is the sum across coins. Treat caps like private keys, and mint one cap per delegate rather than sharing.
+- **`withdraw_all` is not a durable kill.** To exit, just withdraw. But deposits are permissionless, so a drained pool can be re-funded (by anyone, or by you later) and re-arm still-live budgets: withdrawing alone is a reversible freeze. To stop a live cap for good, use `revoke_all` or `destroy`.
+
+## Common mistakes
+
+| Mistake | What happens | How to fix |
+|---|---|---|
+| `destroy` before draining every coin type | Remaining pool funds strand permanently at the dead vault address | Follow the drain ritual: `suix_getAllBalances`, `squash`, `withdraw_all` per type, wait a checkpoint, then destroy. |
+| Relying on `withdraw_all` to *permanently* stop a live cap | Not durable: a permissionless deposit re-arms the still-live budgets (a plain exit is fine, this just is not a kill) | For a durable kill, `revoke_all` (or `destroy`) first, then `withdraw_all` in a later transaction. |
+| Bundling `revoke_all` with `withdraw_all` in one PTB | A pool-short `withdraw_all` reverts the `revoke_all` with it, leaving the cap live | Run `revoke_all` in its own transaction; drain in a later one. |
+| Ungated public function borrowing a custodied cap | World-drainable: anyone can route spends through it | Sender-gate the borrow (assert the operator) before calling `spend`. |
+| `delete_orphaned_cap` on a cap of a live vault | Strands all its ledger entries as inert storage garbage | Spenders `renounce`; the orphan path is only for caps of destroyed vaults. |
+| Treating `u64::MAX` as a finite volume | It is the unlimited sentinel: never decremented, wrong in volume math | Exclude `u64::MAX` from off-chain accounting; it means "unlimited". |
+| Typo'd `cap_id` in `set_allowance` | Silently creates a phantom budget (`was_created: true`) and permanently records the coin type | Confirm `was_created == false` on updates, or preflight with `contains<T>`. |
+
+## FAQ
+
+**How do I tell an absent grant from a suspended one?**
+`allowance<T>` returns `0` for both. `contains<T>` disambiguates: `allowance == 0 && contains == true` is suspended; `contains == false` is absent. The spender-side abort code carries the same signal: `EAllowanceExceeded` means suspended (ask for a raise), `ENoAllowance` means absent (ask for a grant).
+
+**Why doesn't a pool shortfall abort with a module error code?**
+Because the module deliberately does no pool pre-check. `spend` decrements the budget (`withdraw` touches no ledger state), then calls the framework's funds-accumulator withdraw; a shortfall surfaces as the `InsufficientFundsForWithdraw` execution status in effects and dry runs, not as a matchable Move abort code, and Move's atomic revert rolls any budget decrement back. Preflight by dry-running the transaction; don't try to match an abort code that intentionally does not exist.
+
+**Do two caps' budgets on the same coin sum against one pool?**
+Yes. Budgets are ceilings, not reservations: allowances may sum past the pool, and competing spenders are resolved by consensus sequencing (first sequenced, first served). If summing is not intended, size budgets against the pool or fund per-delegate vaults.
+
+## Examples
+
+Complete, runnable integration examples live in the package's [`examples/spend_vault/`](https://github.com/OpenZeppelin/contracts-sui/tree/main/contracts/allowance/examples/spend_vault) directory, one per integration boundary:
+
+- [`direct_delegation`](https://github.com/OpenZeppelin/contracts-sui/blob/main/contracts/allowance/examples/spend_vault/direct_delegation.move): the **direct delegation** pattern. An owner funds a vault and grants a capped, optionally expiring budget straight to a known address, which spends directly; the library API is the whole integration, no wrapper needed.
+- [`defi_keeper`](https://github.com/OpenZeppelin/contracts-sui/blob/main/contracts/allowance/examples/spend_vault/defi_keeper.move): the **protocol custody** pattern. A keeper service holds a user's `SpenderCap` and spends on their behalf within the owner's budget, showing the two custody rules: validate the cap's vault binding before taking custody, and sender-gate the borrowing entrypoint.
+
+<Callout type="warn">
+These are unaudited illustrations of how the primitive can be integrated, not production-ready code.
+</Callout>
+
+## Learn more
+
+For function-level signatures, parameters, events, and errors, see the [Allowance API reference](/contracts-sui/1.x/api/allowance#spend_vault). For an end-to-end walkthrough of custodied caps and keeper flows, see the [Delegated Spending](/contracts-sui/1.x/guides/delegated-spending) tutorial.

--- a/content/contracts-sui/index.mdx
+++ b/content/contracts-sui/index.mdx
@@ -23,6 +23,9 @@ import { latestStable } from "./latest-versions.js";
   <Card href={`/contracts-sui/${latestStable}/access`} title="Access">
     Role-based authorization and ownership-transfer policies for privileged protocol operations.
   </Card>
+  <Card href={`/contracts-sui/${latestStable}/allowance`} title="Allowance">
+    Cap-keyed, multi-coin spending allowances over an escrowed vault of funds.
+  </Card>
   <Card href={`/contracts-sui/${latestStable}/fixed-point`} title="Fixed-Point Math">
     9-decimal fixed-point types (`UD30x9`, `SD29x9`) for prices, fees, rates, and signed balance deltas.
   </Card>
@@ -39,6 +42,9 @@ import { latestStable } from "./latest-versions.js";
 <Cards>
   <Card href={`/contracts-sui/${latestStable}/api/access`} title="Access">
     Explore the complete access API, including its functions, types, events, and errors.
+  </Card>
+  <Card href={`/contracts-sui/${latestStable}/api/allowance`} title="Allowance">
+    Explore the complete allowance API, including the spend vault types, functions, events, and errors.
   </Card>
   <Card href={`/contracts-sui/${latestStable}/api/fixed-point`} title="Fixed-Point Math">
     Explore the complete fixed-point math API, including its types, functions, and errors.

--- a/src/navigation/sui/current.json
+++ b/src/navigation/sui/current.json
@@ -21,6 +21,11 @@
 				"type": "page",
 				"name": "Role Based Access Control",
 				"url": "/contracts-sui/1.x/guides/access-control"
+			},
+			{
+				"type": "page",
+				"name": "Delegated Spending",
+				"url": "/contracts-sui/1.x/guides/delegated-spending"
 			}
 		]
 	},
@@ -81,6 +86,23 @@
 						"url": "/contracts-sui/1.x/rate-limiter"
 					}
 				]
+			},
+			{
+				"type": "folder",
+				"name": "Allowance",
+				"defaultOpen": true,
+				"index": {
+					"type": "page",
+					"name": "Overview",
+					"url": "/contracts-sui/1.x/allowance"
+				},
+				"children": [
+					{
+						"type": "page",
+						"name": "Spend Vault",
+						"url": "/contracts-sui/1.x/spend-vault"
+					}
+				]
 			}
 		]
 	},
@@ -107,6 +129,11 @@
 				"type": "page",
 				"name": "Utils",
 				"url": "/contracts-sui/1.x/api/utils"
+			},
+			{
+				"type": "page",
+				"name": "Allowance",
+				"url": "/contracts-sui/1.x/api/allowance"
 			}
 		]
 	}


### PR DESCRIPTION
## Documentation Pull Request

### Summary
Adds documentation for the `openzeppelin_allowance` package (Sui v1.4): the package hub, the `spend_vault` module page, the API reference, and a Delegated Spending tutorial, plus the nav and version/product index entries. The package is installed by git revision (`rev = "v1.4.0"`) since it is not yet on the Move Registry, mirroring the finance approach in #202.

### Type of Change
<!-- Check all that apply -->
- [x] New documentation
- [ ] Documentation update/revision
- [ ] Fix typos or grammar
- [ ] Restructure/reorganize content
- [x] Add examples or tutorials
- [ ] Update API documentation
- [ ] Other: ___________

### Related Issues
<!-- Link any related issues -->
Relates to #202

### Checklist
- [x] Build succeeds locally with `pnpm run build`
- [x] Lint is successful when running `pnpm run check`
- [x] Docs follow [OpenZeppelin Documentation Standards](https://github.com/OpenZeppelin/docs/blob/main/STANDARDS.md)

### Additional Notes
<!-- Any additional context, concerns, or information for reviewers -->
Targets the shared `release/sui-v1.4` branch (not `main`) so the v1.4 docs deploy as a single release PR alongside #202 (Finance / VestingWallet). Install is pinned to `rev = "v1.4.0"` by git revision until the package lands on MVR; API source links are pinned to the `v1.4.0` tag.
