### PR TITLE
docs: add Sui library maintenance status disclaimer

### DIFF
--- a/content/contracts-sui/1.x/index.mdx
+++ b/content/contracts-sui/1.x/index.mdx
@@ -9,6 +9,13 @@ title: Contracts for Sui 1.x
 - `openzeppelin_access` for role-based authorization and ownership-transfer wrappers around privileged `key + store` objects.
 - `openzeppelin_utils` for embeddable building blocks; its first module, `rate_limiter`, provides multi-strategy rate limiting.
 
+<Callout type="warn">
+This library is open-source and not actively maintained. No new features,
+fixes, or updates should be expected for existing releases. The `UpgradeCap` for packages published to the Move Registry has been made
+immutable, so these packages can no longer be upgraded by OpenZeppelin or
+anyone else.
+</Callout>
+
 ## Quickstart
 
 ### Prerequisites

--- a/content/contracts-sui/index.mdx
+++ b/content/contracts-sui/index.mdx
@@ -9,6 +9,13 @@ import { latestStable } from "./latest-versions.js";
 **Using this library with an AI agent?** Start from [`llms.txt`](https://raw.githubusercontent.com/OpenZeppelin/contracts-sui/main/llms.txt) — a machine-readable entry point to every package, its examples, API reference, and MVR install snippet.
 </Callout>
 
+<Callout type="warn">
+This library is open-source and not actively maintained. No new features,
+fixes, or updates should be expected for existing releases. The `UpgradeCap` for packages published to the Move Registry has been made
+immutable, so these packages can no longer be upgraded by OpenZeppelin or
+anyone else.
+</Callout>
+
 ## Getting Started
 
 <Cards>


### PR DESCRIPTION
## Summary
- Adds a status notice to the two Contracts for Sui landing pages stating the library is open-source but no longer under active maintenance.
- Notes that packages published to the Move Registry have had their `UpgradeCap` made immutable, so they can no longer be upgraded.

## Test plan
- [ ] Preview both pages on the docs site and confirm the callout renders correctly alongside the existing AI-agent callout and package list.